### PR TITLE
Fix Windows recording and process lifecycle

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -2,6 +2,6 @@
 
 ## UI Development Guidelines
 
-- **Always Reuse Existing UI Components**: When building or modifying interfaces, always import and use the pre-existing custom UI components located in [src/components/ui/](file:///c:/Users/binos/Documents/Personal_project/OSS/DemoRecorder/demo-recorder/demo-recorder/src/components/ui/) (e.g., `Button`, `Popover`, `Select`, `Dialog`, `Input`, `Switch`, `Slider`, `Badge`) rather than writing custom ad-hoc controls or styling.
-- **Maintain Consistent Aesthetics**: Follow the design language defined in [style.css](file:///c:/Users/binos/Documents/Personal_project/OSS/DemoRecorder/demo-recorder/demo-recorder/src/style.css) and the existing components to prevent UI inconsistency.
+- **Always Reuse Existing UI Components**: When building or modifying interfaces, always import and use the pre-existing custom UI components located in [`src/components/ui/`](../src/components/ui/) (e.g., `Button`, `Popover`, `Select`, `Dialog`, `Input`, `Switch`, `Slider`, `Badge`) rather than writing custom ad-hoc controls or styling.
+- **Maintain Consistent Aesthetics**: Follow the design language defined in [`src/style.css`](../src/style.css) and the existing components to prevent UI inconsistency.
 - DO NOT USE :deep selectors EVEN IF NEEDED.

--- a/docs/windows-fix/task.md
+++ b/docs/windows-fix/task.md
@@ -1,0 +1,145 @@
+# Beam process lifecycle implementation checklist
+
+Plan: [`windows-fix.md`](windows-fix.md)
+
+## Execution rules
+
+- [ ] Keep production source files below 500 lines and preserve the Electron/Rust security boundary. (Lifecycle files comply; pre-existing oversized UI modules, including `HUD.vue`, still require a separate refactor.)
+- [x] Sol owns architecture, production changes, integration, diff review, and final gate decisions.
+- [x] Delegate bounded research, test authoring/review, and test execution to Luna; Sol reviews all results and runs final validations.
+- [x] Use only focused tests for the modules changed. Do not run repository-wide Vitest, Node, coverage, or Rust workspace suites unless the change is genuinely cross-cutting and the reason is recorded first.
+- [x] Do not mark platform-specific checks complete unless they were actually run on that platform.
+- [x] Do not kill processes by executable name in production or tests; retain and verify exact PIDs/ownership.
+
+## Phase 1 — Reproduce and lock the behavior
+
+- [x] **1. Add deterministic reproduction tests for the current leak**
+  - Plan ref: `Problem statement`, `Verification strategy > Deterministic Node/Electron unit tests`.
+  - Build: a lifecycle fixture with a main HUD, preloaded hidden countdown window, auxiliary windows, tray, and mocked capture engine.
+  - Acceptance: closing the HUD demonstrates why `window-all-closed` cannot be the primary trigger; the test asserts every owned resource that must be destroyed.
+  - Verify: `node --test <focused-electron-lifecycle-test>`.
+
+- [x] **2. Define lifecycle states, shutdown reasons, and deadlines**
+  - Plan ref: `Central shutdown coordinator`, `Capture-engine termination state machine`.
+  - Build: dedicated small modules/types for application state, capture-engine state, shutdown reason, and the contractual `2 s` graceful, `1 s` terminate-exit, `2 s` hard-kill-confirmation, `5 s` total-shutdown, and `3 s` parent-death deadlines.
+  - Acceptance: invalid transitions and new work after shutdown are rejected; deadline values are centralized; no modified production file exceeds 500 lines.
+  - Verify: focused unit tests for state transitions plus `npm run typecheck`.
+
+## Phase 2 — Fix normal application shutdown
+
+- [x] **3. Enforce a single Beam instance**
+  - Depends on: item 2.
+  - Plan ref: `Single application instance`.
+  - Build: acquire the lock before initialization; exit a losing instance; restore/focus the canonical HUD on `second-instance`.
+  - Acceptance: a second launch creates no window, tray, timer, IPC registration, or capture child and focuses the original instance.
+  - Verify: focused Electron lifecycle test and manual double-launch check.
+
+- [x] **4. Separate HUD Quit from auxiliary window Close**
+  - Depends on: item 2.
+  - Plan ref: `Explicit quit semantics`.
+  - Build: expose a narrow quit intent for the HUD and route tray Quit to the same coordinator while preserving ordinary editor close → HUD behavior.
+  - Acceptance: HUD Close requests application shutdown; closing or returning from the editor destroys only the editor and restores a valid HUD; renderer APIs remain narrow.
+  - Verify: focused preload/window IPC tests.
+
+- [x] **5. Add the central idempotent shutdown coordinator**
+  - Depends on: items 2 and 4.
+  - Plan ref: `Central shutdown coordinator`.
+  - Build: gate new work, run bounded native shutdown, destroy resources, and resume quit/update exactly once.
+  - Acceptance: concurrent HUD/tray/signal quit requests share one shutdown; a blocked cleanup reaches forced shutdown within the deadline.
+  - Verify: focused coordinator tests using fake timers and child fixtures.
+
+- [x] **6. Register and destroy every window/tray resource**
+  - Depends on: item 5.
+  - Plan ref: `Window ownership registry`.
+  - Build: idempotent cleanup for countdown, camera, screen region, teleprompter, editor, HUD, tray, timers, shortcuts, and pending overlay promises.
+  - Acceptance: the eagerly preloaded countdown is destroyed; repeated cleanup is safe; no hidden `BrowserWindow` retains Electron.
+  - Verify: `node --test test/countdown-window.test.cjs <focused-window-lifecycle-tests>`.
+
+## Phase 3 — Make capture-engine termination provable
+
+- [x] **7. Implement observable child termination and escalation**
+  - Depends on: items 2 and 5.
+  - Plan ref: `Capture-engine termination state machine`.
+  - Build: retain the terminating child handle, reject pending requests, close streams/listeners, await exit, and escalate to exact-child hard kill after deadline.
+  - Acceptance: shutdown resolves only after exit is observed or returns a structured unconfirmed-exit failure; repeated calls are idempotent; an old PID and replacement PID are never alive simultaneously.
+  - Verify: `node --test test/capture-engine.test.cjs` with focused graceful, timeout, malformed-output, stdin-write-error, child-error, unexpected-exit, kill-error, missing-exit, request-while-terminating, and repeated-shutdown cases.
+
+- [x] **8. Repair poison recovery and IPC session invalidation**
+  - Depends on: item 7.
+  - Plan ref: `Capture-engine termination state machine`.
+  - Build: invalidate uncertain sessions while allowing a later recoverable request to spawn a fresh engine; prohibit respawn during application shutdown.
+  - Acceptance: no command reaches a poisoned child; the next allowed request spawns exactly one child; deferred sidecar/native state is cleared.
+  - Verify: focused `capture-engine` and `capture-ipc` tests.
+
+## Phase 4 — Cover crashes and hard parent death
+
+- [x] **9. Implement renderer, Electron-child, signal, and fatal-main policies**
+  - Depends on: item 5.
+  - Plan ref: `Crash policy`.
+  - Build: classify HUD renderer loss, editor renderer loss, overlay renderer loss, Electron/GPU child crash, `uncaughtException`, `unhandledRejection`, SIGINT/SIGTERM, and OS session shutdown.
+  - Acceptance: no named renderer/child/main fatal path leaves a headless but live Beam owner; the conservative policy shuts down when ownership is uncertain; fatal handlers are reentrant and bounded.
+  - Verify: focused lifecycle tests that inject every named event and assert the documented recovery or one terminal shutdown.
+
+- [x] **10. Add independent parent-death protection to capture-engine**
+  - Depends on: items 7 and 8.
+  - Plan ref: `Parent-death protection`.
+  - Build: pass parent identity to Rust; run a watchdog independent of the command loop; add Windows parent-handle/Job protection, Linux `PR_SET_PDEATHSIG` plus race check, and macOS `kqueue` `EVFILT_PROC`/`NOTE_EXIT` plus `getppid()` race check.
+  - Acceptance: killing the Electron-owner fixture terminates an idle or command-blocked engine within the crash deadline; PID reuse cannot bind the watchdog to an unrelated process.
+  - Verify: affected Rust package formatting/tests/Clippy plus platform-specific parent-death integration tests.
+
+- [x] **11. Contain native descendants**
+  - Depends on: item 10.
+  - Plan ref: `Process-tree invariants`, `Parent-death protection`.
+  - Build: retain exact child handles; place FFmpeg and direct helpers under engine-owned process groups and parent-death setup; attach future Windows descendants to the Job Object; treat `pkexec`/privilege-boundary helpers explicitly.
+  - Acceptance: killing Electron or the engine leaves no owned descendant alive, including across privilege boundaries, and never targets unrelated processes.
+  - Verify: Linux descendant fixture test and equivalent platform checks where descendants exist.
+
+## Phase 5 — Update path and final proof
+
+- [x] **12. Route update installation through confirmed shutdown**
+  - Depends on: items 5, 7, and 8.
+  - Plan ref: `Update/install path`.
+  - Build: record updater intent, complete bounded shutdown, confirm/escalate native exit, then invoke `quitAndInstall()` once.
+  - Acceptance: update during blocked native startup cannot leave the old engine or launch the installer twice.
+  - Verify: focused updater lifecycle test.
+
+- [ ] **13. Run the Windows process matrix**
+  - Depends on: items 3–12.
+  - Plan ref: `Platform integration checks`, `Gate D`.
+  - Acceptance: PID/parent evidence shows zero old Beam, capture-engine, or helper processes after HUD Close, tray Quit, each recording phase, updater, renderer crash, forced main death, and repeated launches.
+  - Verify: targeted PowerShell/CIM integration script using exact paths and PIDs. Record results without committing machine-specific process data.
+
+- [ ] **14. Run Linux and macOS parity checks**
+  - Depends on: items 3–12.
+  - Plan ref: `Platform integration checks`, `Gate D`.
+  - Acceptance: Linux passes equivalent lifecycle and descendant checks; macOS passes explicit Quit and second-instance checks, with normal window-close activation semantics documented separately.
+  - Verify: platform-specific focused scripts/tests. Leave unavailable platforms unchecked and report them.
+
+- [ ] **15. Final review and handoff**
+  - Depends on: all applicable items above.
+  - Plan ref: `Delivery gates`, `Rollback and safety`.
+  - Build: Sol reviews the complete diff, file sizes, process targeting, error paths, tests, and platform evidence.
+  - Acceptance: Gates A–D are satisfied; no broad process-name kill exists; no required test is missing; unavailable hardware/platform validation is explicit.
+  - Verify: `git diff --check`, focused format/type/build checks, focused Node/Vitest/Rust tests, and the recorded platform matrix.
+
+## Gate summary
+
+- [x] **Gate A — Normal lifecycle:** single instance, explicit Quit, central cleanup, no hidden windows.
+- [x] **Gate B — Native lifecycle:** confirmed child exit, bounded escalation, safe respawn, shutdown blocks respawn.
+- [ ] **Gate C — Crash containment:** renderer/fatal policies and independent parent-death containment.
+- [ ] **Gate D — Platform proof:** Windows evidence complete; Linux/macOS evidence complete or explicitly unavailable.
+
+## Latest validation evidence (2026-08-14)
+
+- [x] TypeScript boundary: `npm run typecheck`.
+- [x] Production bundle and native release binary: `npm run build`.
+- [x] Recording/UI focused Vitest: 63 passed.
+- [x] Electron lifecycle/capture focused Node tests: 34 passed.
+- [x] Rust format and strict Clippy for the affected package/binaries.
+- [x] Linux FFmpeg/process-group tests: 9 passed, 1 hardware test intentionally ignored.
+- [x] Linux input-helper tests: 5 passed.
+- [x] Linux real parent-death harness: exact engine PID exited while stdin remained open.
+- [x] Windows Rust cross-check: `x86_64-pc-windows-gnu` capture library and engine compile; existing unrelated Windows-cfg warnings remain.
+- [ ] Windows runtime recording/process matrix: unavailable from this Linux host; run `scripts/windows/verify-process-lifecycle.ps1` on the target machine.
+- [ ] macOS runtime/cross-build: unavailable from this Linux host because the ScreenCaptureKit dependency requires Apple's Swift toolchain.
+- [ ] Repository-wide `vue-tsc`: currently blocked by pre-existing errors in HUD/editor/UI modules outside this lifecycle change; the regular changed boundary typecheck and production build pass.

--- a/docs/windows-fix/windows-fix.md
+++ b/docs/windows-fix/windows-fix.md
@@ -1,0 +1,328 @@
+# Beam process lifecycle and orphan prevention plan
+
+## Status
+
+- Scope: Windows first, with equivalent guarantees on Linux and macOS.
+- Purpose: prevent Beam, `capture-engine`, and native helper processes from surviving after Beam is closed or its owning process dies.
+- This document is a design and verification contract. Implementation progress is tracked in [`task.md`](task.md).
+- Deterministic implementation gates are complete in the current working tree; Windows hardware/process-matrix proof remains mandatory before release sign-off.
+
+## Problem statement
+
+Closing Beam can leave an Electron process running in the background. Reopening Beam then creates another independent process, so Task Manager shows an increasing number of Beam processes. If native capture has been used, the old Electron instance can also retain a `capture-engine.exe` child.
+
+The original normal-close failure was deterministic:
+
+1. `createCountdownWindow()` eagerly creates a hidden `BrowserWindow` at startup.
+2. The HUD close action closes only the HUD `BrowserWindow`.
+3. The HUD cleanup destroys the editor, tray, teleprompter, camera overlay, and region overlay, but not the countdown window.
+4. Because one hidden window remains, Electron does not emit `window-all-closed`.
+5. `app.quit()` is not called, so `before-quit` never reaches `captureEngine.shutdown()`.
+6. There is no single-instance lock, so another launch starts another complete Beam instance.
+
+The current shutdown code also does not prove that a child has exited: it sends `child.kill()`, clears `this.process`, and resolves without waiting for the child's `exit` or `close` event. Electron lifecycle hooks are also insufficient for hard crashes because `before-quit` and `will-quit` are not guaranteed after abrupt process termination.
+
+## Goals
+
+1. The HUD close action must mean "quit Beam" and complete through one idempotent application shutdown coordinator.
+2. Only one Beam application instance may run for a user session. A second launch must focus or restore the existing HUD and then exit.
+3. Every Beam-owned window, tray, timer, listener, IPC operation, and capture child must be released on normal exit.
+4. `capture-engine` must exit after graceful quit, command timeout, renderer failure requiring application termination, updater installation, OS shutdown, signal termination, or death of the Electron main process.
+5. No uncertain or timed-out native engine may be reused.
+6. Shutdown must have bounded deadlines. A blocked native command must not block Beam exit indefinitely.
+7. Session cleanup should be graceful when possible, but orphan prevention wins after the graceful deadline expires.
+8. The guarantees and tests must cover Windows, Linux, and macOS, with platform-specific checks documented when they cannot run locally.
+
+## Non-goals
+
+- Do not change the `windows-capture` recording implementation to solve Electron orchestration bugs.
+- Do not make renderer components own native process lifecycle.
+- Do not expose generic process, filesystem, or IPC access through preload.
+- Do not kill processes by broad executable-name matching. Termination must target only the exact child PID or OS-owned process group created by this Beam instance.
+- Do not treat normal auxiliary Electron renderer/GPU processes as leaks while their owning main process is still intentionally running.
+
+## Required invariants
+
+### Contractual deadlines
+
+Use named constants rather than scattered timeout literals. Initial contract:
+
+- graceful native stop: `2_000 ms`;
+- exit after the first termination request: `1_000 ms`;
+- hard-kill confirmation: `2_000 ms`;
+- total normal application shutdown: `5_000 ms`;
+- parent-death detection through forced native exit: `3_000 ms`.
+
+Platform tests may justify tighter values later, but must not silently extend them. Timing tests should use fake clocks where possible and a bounded tolerance only for real process integration tests.
+
+### Application invariants
+
+- At most one Electron main process owns a given Beam user-data directory.
+- The custom HUD Close action always requests application quit; it never only hides or closes the HUD.
+- Once shutdown begins, it is monotonic and idempotent: no new windows, capture commands, recordings, or update actions may start.
+- Normal quit reaches a terminal state within a documented maximum duration.
+- After terminal shutdown, no Beam-owned native window or tray remains.
+
+### Capture-engine invariants
+
+- One `CaptureEngine` instance owns at most one live child and, while terminating, retains the child handle until exit is observed.
+- A timed-out, malformed, crashed, or otherwise uncertain engine is poisoned and terminated.
+- All pending requests are rejected exactly once with the originating command and termination reason.
+- A fresh request after recoverable engine termination may spawn one fresh engine; it must never talk to the poisoned child.
+- The old child PID must have a confirmed exit before a replacement is spawned; old and replacement PIDs must never overlap.
+- Application shutdown disables respawn permanently for that application instance.
+- After the Electron owner dies, `capture-engine` must terminate without relying solely on Electron lifecycle events.
+
+### Process-tree invariants
+
+- Beam never terminates an unrelated process, including another user's process with the same executable name.
+- Any process spawned by `capture-engine` is placed under an equivalent parent-death/process-group policy.
+- PID reuse must not allow a watchdog to attach itself to an unrelated process. Parent identity should use an OS handle where possible, or PID plus a startup identity check where it is not.
+
+## Architecture
+
+### 1. Single application instance
+
+Acquire `app.requestSingleInstanceLock()` before `app.whenReady()` initialization.
+
+- If the lock is unavailable, the second process must request attention from the existing instance and exit before creating windows, tray objects, timers, IPC handlers, or a capture engine.
+- The `second-instance` handler must restore the existing HUD through the canonical window controller path, including minimized/hidden/editor states.
+- The handler must not create a second main window.
+- Add a focused lifecycle test proving that losing the lock prevents initialization.
+
+This prevents process accumulation but is not a substitute for correct shutdown.
+
+### 2. Explicit quit semantics
+
+Replace the renderer's ambiguous window-close request with a narrow application-quit intent for the HUD. Keep ordinary window close behavior only where closing a child window is valid.
+
+The main process must decide whether a request means:
+
+- close an auxiliary/editor window and return to the HUD; or
+- quit the entire application.
+
+The HUD Close action and tray Quit action must converge on the same shutdown coordinator. Closing the editor window is different: it destroys the editor and returns to the valid HUD unless the user selected an explicit application Quit action. The updater must enter the coordinator before `quitAndInstall()` is allowed to finish.
+
+### 3. Central shutdown coordinator
+
+Introduce a focused Electron lifecycle module rather than expanding `electron/main.cjs`. It should own a state machine such as:
+
+```text
+running -> graceful-shutdown -> forced-shutdown -> exited
+```
+
+The coordinator receives bounded cleanup functions for:
+
+- capture engine;
+- countdown, camera, screen-region, teleprompter, editor, and HUD windows;
+- tray and global shortcuts;
+- storage owners and pending sidecar writes;
+- update installation handoff.
+
+Required behavior:
+
+1. Atomically mark the application as shutting down.
+2. Reject new capture and window-creation requests.
+3. Hide nonessential overlays immediately so no invisible window can retain the app accidentally.
+4. Ask the capture engine to stop/cancel gracefully, using the actual known native state.
+5. Wait for native exit up to the graceful deadline.
+6. Force-terminate the exact child/process group if the deadline expires.
+7. Destroy every window and tray idempotently.
+8. Remove timers, shortcuts, and listeners.
+9. Resume the original quit or updater action exactly once.
+
+`before-quit`, tray Quit, HUD Quit, signal handlers, OS session shutdown, and updater installation must all call this coordinator. A normal editor-window close returns to the HUD and does not terminate Beam. `will-quit` remains a final synchronous/best-effort safety net, not the primary cleanup path.
+
+### 4. Window ownership registry
+
+Every auxiliary window manager must expose an idempotent `destroy()` that:
+
+- destroys its live `BrowserWindow` if present;
+- clears internal references, readiness flags, pending promises, and timers;
+- is safe before creation, after failure to load, after natural close, and after repeated calls.
+
+Register the countdown window alongside the camera, region, teleprompter, and editor windows. Do not depend on `window-all-closed` to initiate cleanup: hidden windows are precisely what can prevent that event.
+
+`window-all-closed` should remain defense in depth. On Windows and Linux it may request application shutdown if shutdown has not already started. macOS behavior must be an explicit product decision, but the HUD's explicit Quit action still quits on every platform.
+
+### 5. Capture-engine termination state machine
+
+Refactor `CaptureEngine` so process termination has observable completion.
+
+Suggested internal states:
+
+```text
+stopped | running | poisoned | terminating | shutdown
+```
+
+`terminateProcess(reason, options)` must:
+
+1. Capture the exact child reference and mark it unavailable for requests.
+2. Reject and clear every pending request exactly once.
+3. Close stdin and readline interfaces/listeners without allowing old child events to affect a replacement child.
+4. Request normal termination when appropriate.
+5. Wait for `exit`/`close` with a short deadline.
+6. Escalate to a platform-appropriate hard kill of that exact child or owned process group.
+7. Resolve only after exit is observed, or return a structured failure saying that exit could not be confirmed.
+8. Permit respawn only for recoverable runtime termination, never after application shutdown begins.
+
+Do not set the only child reference to `null` before retaining a separate terminating handle. Do not silently ignore a false `child.kill()` result or a kill error. Child `error`, unexpected `exit`, invalid protocol output, write failure, and request timeout must converge on the same termination path.
+
+The IPC adapter must invalidate the active/deferred session when an engine becomes uncertain. It must allow a subsequent safe command to create a fresh engine instead of permanently rejecting all requests because a previous child was poisoned.
+
+### 6. Parent-death protection
+
+Electron hooks cannot cover `TerminateProcess`, `kill -9`, native crashes, power loss, or a main thread stuck before its hooks run. The native child therefore needs an independent parent-death mechanism.
+
+Pass the Electron main PID and a per-launch identity token to `capture-engine`. Establish the watchdog before accepting capture commands.
+
+- **Windows:** prefer an OS parent process handle or Job Object with kill-on-owner-close semantics. If the child owns the watchdog, wait on the exact parent handle rather than polling only a reusable PID.
+- **Linux:** use `PR_SET_PDEATHSIG` with the required post-registration parent check. Native descendants such as FFmpeg/input helpers must receive equivalent process-group or parent-death ownership.
+- **macOS:** use a dedicated `kqueue` watcher registered with `EVFILT_PROC`/`NOTE_EXIT` for the startup parent PID, then immediately validate `getppid()` to close the registration race. The kernel event registration identifies the watched process instance; stdin EOF remains defense in depth. If the watcher cannot be established, native startup must fail closed rather than run without parent ownership.
+
+On parent death, first request cooperative session shutdown. If capture code does not respond within a short crash deadline, force the native process to exit. A blocked capture command must not prevent the watchdog from running, so the watchdog cannot live only on the command-processing thread.
+
+The existing stdin-EOF behavior remains useful and should be tested, but it is not the only protection.
+
+Direct native descendants must be owned explicitly:
+
+- place Linux encoder/helper children in an engine-owned process group and set parent-death behavior in each direct child's pre-exec path;
+- keep exact `Child` handles for graceful cleanup and use the owned group only for forced escalation;
+- attach any future Windows descendants to the same kill-on-close Job Object;
+- use an engine-owned process group plus exact child handles for macOS descendants;
+- treat privilege-boundary helpers such as `pkexec` as separate ownership cases and prove their exit rather than assuming they remain in the group.
+
+### 7. Crash policy
+
+Distinguish failures by owner:
+
+- **Primary HUD renderer gone:** enter controlled application shutdown unless a tested renderer-recovery path is intentionally implemented.
+- **Editor renderer gone:** close the editor safely and either return to a valid HUD or terminate if application state is uncertain.
+- **Overlay renderer gone:** destroy that overlay, reject its pending operation, and continue only if capture state remains valid.
+- **Electron child/GPU fatal failure:** classify the Electron-provided reason; shut down when UI or capture correctness is uncertain.
+- **Uncaught main-process exception/unhandled rejection:** log minimal diagnostics, trigger bounded best-effort termination, then exit nonzero. Do not keep a partially initialized background app alive.
+- **SIGINT/SIGTERM and OS session shutdown:** use the same coordinator with a bounded deadline.
+- **Hard main-process death:** rely on the independent parent-death mechanism.
+
+Fatal handlers must be reentrancy-safe and must not attempt complex recovery after the runtime is already corrupted.
+
+### 8. Update/install path
+
+`quitAndInstall()` must not bypass process cleanup.
+
+1. Mark the updater intent.
+2. Run the central shutdown coordinator.
+3. Confirm native child exit or perform the forced termination path.
+4. Invoke the updater exactly once.
+
+Tests must cover a blocked native startup during update installation.
+
+## Failure reporting and observability
+
+Add development diagnostics and structured test hooks for:
+
+- Electron PID, capture-engine PID, and parent identity;
+- shutdown source (`hud`, `tray`, `window-all-closed`, `updater`, `signal`, `renderer-crash`, `fatal`);
+- lifecycle state transitions;
+- graceful and forced termination deadlines;
+- child exit code/signal and whether exit was confirmed;
+- cleanup errors collected by resource.
+
+Do not log user media, command payloads containing private paths, or secrets. Packaged builds should retain only bounded actionable diagnostics suitable for a copyable error report.
+
+## Verification strategy
+
+### Deterministic Node/Electron unit tests
+
+- Losing the single-instance lock exits before initialization.
+- A second instance restores the existing HUD.
+- HUD Quit, tray Quit, window close, updater, and signals call the coordinator once.
+- Every registered window manager is destroyed, including a preloaded hidden countdown.
+- Repeated shutdown calls share one result.
+- Renderer crash paths follow the documented policy.
+- A blocked cleanup reaches forced shutdown within the deadline.
+
+### Capture-engine process tests
+
+Use a purpose-built fixture process rather than real hardware capture where possible.
+
+- Graceful shutdown observes child exit.
+- Request timeout rejects all pending requests and kills the child.
+- A recoverable next request spawns exactly one new child.
+- Application shutdown disables respawn.
+- Closing the parent pipe makes the Rust engine exit and finalize/drop its session.
+- Killing the Electron-owner fixture kills the engine within the crash deadline.
+- A child blocked in a command is still terminated by the parent-death watchdog.
+- Nested native helpers/processes do not survive their owning engine.
+- Invalid JSON output, stdin write failure, child `error`, and unexpected exit all poison and terminate the engine.
+- A failed kill, missing exit event, shutdown timeout, and request during `terminating` produce deterministic structured outcomes.
+
+### Platform integration checks
+
+On Windows, identify processes by executable path, PID, and parent PID using PowerShell/CIM rather than name-only matching. Validate:
+
+- HUD close before capture;
+- HUD close during countdown, native prepare, native start, recording, and finalization;
+- tray Quit;
+- update install;
+- renderer crash;
+- forced termination of the Electron main PID;
+- repeated launch attempts.
+
+Equivalent Linux checks should inspect exact executable paths and `/proc` parentage. macOS checks should use exact PIDs/process ancestry and distinguish normal app activation semantics from explicit Quit.
+
+For every scenario, the acceptance condition is:
+
+```text
+within the documented deadline:
+  zero old Beam main processes
+  zero old capture-engine processes
+  zero old Beam-owned helper/encoder processes
+  a second launch does not create a concurrent owner
+```
+
+Hardware-dependent capture checks must be reported separately from deterministic lifecycle tests.
+
+### Process-proof harnesses
+
+- Windows normal close: `powershell -ExecutionPolicy Bypass -File scripts/windows/verify-process-lifecycle.ps1 -BeamExecutable 'C:\exact\path\Beam.exe' -ExitMode Close`
+- Windows abrupt main death: use the same command with `-ExitMode Crash` while recording or while a deliberately blocked native start is active.
+- Linux parent-death proof after building the engine: `scripts/linux/verify-parent-death.sh "$PWD/target/debug/capture-engine"`.
+
+The Windows harness records the exact root/descendant PID and executable path before termination and only evaluates those identities afterward. It never uses broad name-based termination. Run it once per recording-matrix configuration; its `ObservationSeconds` interval is the time available to put Beam into the desired phase.
+
+## Delivery gates
+
+### Gate A: normal lifecycle
+
+- Single-instance behavior is enforced.
+- HUD Close and tray Quit converge on one coordinator.
+- Hidden countdown and every auxiliary window are destroyed.
+- Focused Node tests pass.
+
+### Gate B: native lifecycle
+
+- Termination waits for actual child exit and escalates on timeout.
+- Poisoned-engine recovery spawns a fresh child safely.
+- Shutdown prohibits respawn.
+- Focused engine and IPC tests pass.
+
+### Gate C: crash containment
+
+- Renderer and main-process fatal policies are implemented.
+- Independent parent-death behavior is implemented and tested on supported platforms.
+- Nested native children cannot become orphaned.
+
+### Gate D: platform proof
+
+- Windows manual/integration matrix passes with recorded PID evidence.
+- Linux equivalent tests pass where available.
+- macOS explicit-Quit behavior passes where available.
+- Any unavailable platform validation is clearly reported and remains unchecked in `task.md`.
+
+## Rollback and safety
+
+- Keep the single-instance change separable from native watchdog work so it can be validated independently.
+- Never use broad `taskkill /IM`, `pkill`, or executable-name cleanup in production.
+- Preserve session recovery data when forced termination interrupts finalization.
+- Do not mark the work complete based only on an empty Task Manager view; tests must prove that the expected PID exited and was not replaced or detached.

--- a/electron/camera/overlay-window.cjs
+++ b/electron/camera/overlay-window.cjs
@@ -4,7 +4,7 @@ const path = require('path');
 const DEFAULT_SIZE = { width: 320, height: 180 };
 const MIN_SIZE = { width: 120, height: 90 };
 
-function createCameraOverlayWindow({ applicationRoot, isPackaged }) {
+function createCameraOverlayWindow({ applicationRoot, isPackaged, canAcceptWork = () => true }) {
   let window = null;
   let currentState = null;
   let hoverTimer = null;
@@ -43,6 +43,7 @@ function createCameraOverlayWindow({ applicationRoot, isPackaged }) {
   };
 
   const create = () => {
+    if (!canAcceptWork()) return null;
     if (window && !window.isDestroyed()) return window;
     const area = screen.getPrimaryDisplay().workArea;
     window = new BrowserWindow({
@@ -80,19 +81,22 @@ function createCameraOverlayWindow({ applicationRoot, isPackaged }) {
   };
 
   const configure = (state) => {
+    if (!canAcceptWork()) return false;
     currentState = { cameraId: state?.cameraId || 'off' };
     if (!active || currentState.cameraId === 'off') {
       if (window && !window.isDestroyed()) {
         window.webContents.send('camera-overlay:state', { ...currentState, cameraId: 'off' });
         window.hide();
       }
-      return;
+      return true;
     }
     const overlay = create();
+    if (!overlay) return false;
     overlay.webContents.send('camera-overlay:state', currentState);
     overlay.showInactive();
     overlay.moveTop();
     startHoverTracking();
+    return true;
   };
 
   const setActive = (next) => {

--- a/electron/capture/capture-engine.cjs
+++ b/electron/capture/capture-engine.cjs
@@ -11,6 +11,8 @@ const {
 
 const REQUEST_TIMEOUT_MS = 30_000;
 const INTERACTIVE_REQUEST_TIMEOUT_MS = 120_000;
+const TERMINATE_DEADLINE_MS = 1_000;
+const HARD_KILL_CONFIRMATION_MS = 2_000;
 
 class CaptureEngine {
   constructor(app, applicationRoot, options = {}) {
@@ -20,14 +22,17 @@ class CaptureEngine {
     this.pending = new Map();
     this.stderr = [];
     this.inputHelperPath = options.inputHelperPath || (() => null);
-    this.poisoned = false;
+    this.state = 'stopped'; // stopped | running | poisoned | terminating | shutdown
+    this.shuttingDown = false;
+    this.terminating = null;
+    this.unconfirmedExit = null;
     this.stdoutReader = null;
     this.stderrReader = null;
     this.shutdownPromise = null;
   }
 
   get isPoisoned() {
-    return this.poisoned;
+    return this.state === 'poisoned' || this.state === 'terminating' || this.unconfirmedExit !== null;
   }
 
   resolveExecutable() {
@@ -42,9 +47,7 @@ class CaptureEngine {
       path.join(this.applicationRoot, 'target', 'release', buildFilename),
       prebuilt,
     ];
-    const candidates = [process.env.DEMO_RECORDER_CAPTURE_ENGINE, ...(bundled ? [bundled] : development)].filter(
-      Boolean,
-    );
+    const candidates = [process.env.BEAM_CAPTURE_ENGINE, ...(bundled ? [bundled] : development)].filter(Boolean);
     const executable = candidates.find((candidate) => fs.existsSync(candidate));
     if (!executable)
       throw new Error(
@@ -54,18 +57,25 @@ class CaptureEngine {
   }
 
   ensureStarted() {
+    if (this.terminating) throw new Error('capture-engine: the previous process is still terminating');
+    if (this.unconfirmedExit)
+      throw new Error(`capture-engine: previous process exit was not confirmed (${this.unconfirmedExit.reason})`);
     if (this.process && !this.process.killed) return;
+    if (this.shuttingDown) throw new Error('capture-engine: respawn is disabled during application shutdown');
     const child = spawn(this.resolveExecutable(), [], {
       cwd: this.app.getPath('userData'),
       stdio: ['pipe', 'pipe', 'pipe'],
       windowsHide: true,
       env: {
         ...process.env,
+        BEAM_PARENT_PID: String(process.pid),
+        BEAM_INSTANCE_TOKEN: process.env.BEAM_INSTANCE_TOKEN || '',
         ...(this.inputHelperPath() ? { BEAM_INPUT_HELPER_PATH: this.inputHelperPath() } : {}),
       },
     });
     this.process = child;
-    this.poisoned = false;
+    this.state = 'running';
+    this.unconfirmedExit = null;
     this.stderr = [];
     this.stdoutReader = readline
       .createInterface({ input: child.stdout })
@@ -76,11 +86,11 @@ class CaptureEngine {
     });
     child.once('error', (error) => {
       if (this.process !== child) return;
-      this.terminateProcess(error);
+      void this.terminateProcess(error);
     });
     child.once('exit', (code, signal) => {
       if (this.process !== child) return;
-      this.terminateProcess(
+      void this.terminateProcess(
         new Error(
           `capture-engine arrêté (code=${code}, signal=${signal}).${this.stderr.length ? `\n${this.stderr.join('\n')}` : ''}`,
         ),
@@ -93,7 +103,9 @@ class CaptureEngine {
     try {
       response = JSON.parse(line);
     } catch (error) {
-      this.failAll(new Error(`Réponse invalide de capture-engine: ${error.message}`));
+      // Malformed protocol output is an uncertain engine: poison and terminate
+      // it rather than continuing to talk to a possibly corrupted child.
+      void this.terminateProcess(new Error(`Réponse invalide de capture-engine: ${error.message}`));
       return;
     }
     const pending = this.pending.get(response.requestId);
@@ -109,20 +121,28 @@ class CaptureEngine {
   }
 
   request(command, payload = {}, options = {}) {
+    if (this.terminating) {
+      const termination = this.terminating.promise;
+      return termination.then((result) => {
+        if (!result.confirmed)
+          throw new Error(`capture-engine: previous process exit was not confirmed (${result.reason})`);
+        return this.request(command, payload, options);
+      });
+    }
+    if (this.shuttingDown && options.allowDuringShutdown !== true)
+      return Promise.reject(new Error('capture-engine: requests are disabled during application shutdown'));
     this.ensureStarted();
     const id = randomUUID();
     return new Promise((resolve, reject) => {
       const interactive = ['prepare', 'start', 'request-input-access'].includes(command);
       const timeoutMs = options.timeoutMs ?? (interactive ? INTERACTIVE_REQUEST_TIMEOUT_MS : REQUEST_TIMEOUT_MS);
       const timeout = setTimeout(() => {
-        this.terminateProcess(new Error(`Délai dépassé pour la commande de capture "${command}"`));
+        void this.terminateProcess(new Error(`Délai dépassé pour la commande de capture "${command}"`));
       }, timeoutMs);
       this.pending.set(id, { resolve, reject, timeout });
       this.process.stdin.write(`${JSON.stringify({ id, command, ...payload })}\n`, (error) => {
         if (!error) return;
-        clearTimeout(timeout);
-        this.pending.delete(id);
-        reject(error);
+        void this.terminateProcess(error);
       });
     });
   }
@@ -146,21 +166,78 @@ class CaptureEngine {
     }
   }
 
-  terminateProcess(reason) {
+  // Terminate the exact child and resolve only after its exit is observed or
+  // the escalation deadline expires. The child handle is retained locally so
+  // old child events can never affect a replacement child.
+  terminateProcess(reason, { force = false } = {}) {
     const error = reason instanceof Error ? reason : new Error(String(reason));
-    this.poisoned = true;
     this.failAll(error);
+    if (this.terminating) {
+      if (force) this.terminating.force();
+      return this.terminating.promise;
+    }
     const child = this.process;
-    this.process = null;
     this.closeReaders();
-    if (child) {
+    if (this.state !== 'shutdown') this.state = 'terminating';
+    if (!child) return Promise.resolve({ confirmed: false, reason: error.message });
+    const exit = this.awaitExit(child, error);
+    const promise = exit.promise.then((result) => {
+      if (this.terminating?.child === child) this.terminating = null;
+      if (this.process === child) this.process = null;
+      if (!result.confirmed) this.unconfirmedExit = result;
+      if (this.state !== 'shutdown') this.state = 'poisoned';
+      return result;
+    });
+    this.terminating = { child, force: exit.force, promise };
+    if (force) exit.force();
+    return promise;
+  }
+
+  awaitExit(child, reason) {
+    if (child.exitCode !== null || child.signalCode) {
+      return { force: () => {}, promise: Promise.resolve({ confirmed: true, reason: reason.message }) };
+    }
+    let force = () => {};
+    const promise = new Promise((resolve) => {
+      let settled = false;
+      let escalation = null;
+      let confirmation = null;
+      let forceStarted = false;
+      const finish = (result) => {
+        if (settled) return;
+        settled = true;
+        if (escalation) clearTimeout(escalation);
+        if (confirmation) clearTimeout(confirmation);
+        resolve(result);
+      };
+      const hardKill = () => {
+        if (settled || forceStarted) return;
+        forceStarted = true;
+        try {
+          const sent = child.kill('SIGKILL');
+          if (!sent) {
+            finish({ confirmed: false, reason: reason.message, killError: 'hard kill returned false' });
+            return;
+          }
+          // Give the exit event a short confirmation window after SIGKILL.
+          confirmation = setTimeout(
+            () => finish({ confirmed: false, reason: reason.message, hardKilled: true }),
+            HARD_KILL_CONFIRMATION_MS,
+          );
+        } catch (killError) {
+          finish({ confirmed: false, reason: reason.message, killError: String(killError) });
+        }
+      };
+      force = hardKill;
+      escalation = setTimeout(hardKill, TERMINATE_DEADLINE_MS);
+      child.once('exit', () => finish({ confirmed: true, reason: reason.message }));
       try {
         child.stdin.end();
-      } catch {}
-      try {
-        child.kill();
-      } catch {}
-    }
+      } catch {
+        // stdin already closed; the child is still terminated below.
+      }
+    });
+    return { force: () => force(), promise };
   }
 
   async shutdown() {
@@ -170,15 +247,37 @@ class CaptureEngine {
   }
 
   async performShutdown() {
+    // Disable respawn before the graceful stop so a concurrent request can
+    // never spawn a fresh engine once application shutdown has begun.
+    this.shuttingDown = true;
     const child = this.process;
-    if (!child) return;
+    if (!child) {
+      this.state = 'shutdown';
+      return;
+    }
     try {
-      await this.request('stop', {}, { timeoutMs: 2_000 });
+      await this.request('stop', {}, { timeoutMs: 2_000, allowDuringShutdown: true });
     } catch {
       // Graceful stop failed or timed out; the process is force-killed below.
     }
-    this.terminateProcess(new Error('capture-engine shutdown'));
+    await this.terminateProcess(new Error('capture-engine shutdown'));
+    this.state = 'shutdown';
+  }
+
+  forceShutdown() {
+    this.shuttingDown = true;
+    if (this.terminating) {
+      this.state = 'shutdown';
+      return this.terminateProcess(new Error('capture-engine force shutdown'), { force: true });
+    }
+    const child = this.process;
+    if (!child) {
+      this.state = 'shutdown';
+      return Promise.resolve({ confirmed: false, reason: 'no capture-engine process' });
+    }
+    this.state = 'shutdown';
+    return this.terminateProcess(new Error('capture-engine force shutdown'), { force: true });
   }
 }
 
-module.exports = { CaptureEngine };
+module.exports = { CaptureEngine, TERMINATE_DEADLINE_MS };

--- a/electron/capture/capture-engine.cjs
+++ b/electron/capture/capture-engine.cjs
@@ -20,6 +20,14 @@ class CaptureEngine {
     this.pending = new Map();
     this.stderr = [];
     this.inputHelperPath = options.inputHelperPath || (() => null);
+    this.poisoned = false;
+    this.stdoutReader = null;
+    this.stderrReader = null;
+    this.shutdownPromise = null;
+  }
+
+  get isPoisoned() {
+    return this.poisoned;
   }
 
   resolveExecutable() {
@@ -57,20 +65,26 @@ class CaptureEngine {
       },
     });
     this.process = child;
+    this.poisoned = false;
     this.stderr = [];
-    readline.createInterface({ input: child.stdout }).on('line', (line) => this.handleResponse(line));
-    readline.createInterface({ input: child.stderr }).on('line', (line) => {
+    this.stdoutReader = readline
+      .createInterface({ input: child.stdout })
+      .on('line', (line) => this.handleResponse(line));
+    this.stderrReader = readline.createInterface({ input: child.stderr }).on('line', (line) => {
       this.stderr.push(line);
       if (this.stderr.length > 20) this.stderr.shift();
     });
-    child.once('error', (error) => this.failAll(error));
+    child.once('error', (error) => {
+      if (this.process !== child) return;
+      this.terminateProcess(error);
+    });
     child.once('exit', (code, signal) => {
-      this.failAll(
+      if (this.process !== child) return;
+      this.terminateProcess(
         new Error(
           `capture-engine arrêté (code=${code}, signal=${signal}).${this.stderr.length ? `\n${this.stderr.join('\n')}` : ''}`,
         ),
       );
-      if (this.process === child) this.process = null;
     });
   }
 
@@ -94,17 +108,14 @@ class CaptureEngine {
     }
   }
 
-  request(command, payload = {}) {
+  request(command, payload = {}, options = {}) {
     this.ensureStarted();
     const id = randomUUID();
     return new Promise((resolve, reject) => {
-      const timeoutMs = ['prepare', 'start', 'request-input-access'].includes(command)
-        ? INTERACTIVE_REQUEST_TIMEOUT_MS
-        : REQUEST_TIMEOUT_MS;
+      const interactive = ['prepare', 'start', 'request-input-access'].includes(command);
+      const timeoutMs = options.timeoutMs ?? (interactive ? INTERACTIVE_REQUEST_TIMEOUT_MS : REQUEST_TIMEOUT_MS);
       const timeout = setTimeout(() => {
-        this.pending.delete(id);
-        if (['prepare', 'start'].includes(command) && this.process && !this.process.killed) this.process.kill();
-        reject(new Error(`Délai dépassé pour la commande de capture "${command}"`));
+        this.terminateProcess(new Error(`Délai dépassé pour la commande de capture "${command}"`));
       }, timeoutMs);
       this.pending.set(id, { resolve, reject, timeout });
       this.process.stdin.write(`${JSON.stringify({ id, command, ...payload })}\n`, (error) => {
@@ -124,25 +135,49 @@ class CaptureEngine {
     this.pending.clear();
   }
 
+  closeReaders() {
+    if (this.stdoutReader) {
+      this.stdoutReader.close();
+      this.stdoutReader = null;
+    }
+    if (this.stderrReader) {
+      this.stderrReader.close();
+      this.stderrReader = null;
+    }
+  }
+
+  terminateProcess(reason) {
+    const error = reason instanceof Error ? reason : new Error(String(reason));
+    this.poisoned = true;
+    this.failAll(error);
+    const child = this.process;
+    this.process = null;
+    this.closeReaders();
+    if (child) {
+      try {
+        child.stdin.end();
+      } catch {}
+      try {
+        child.kill();
+      } catch {}
+    }
+  }
+
   async shutdown() {
+    if (this.shutdownPromise) return this.shutdownPromise;
+    this.shutdownPromise = this.performShutdown();
+    return this.shutdownPromise;
+  }
+
+  async performShutdown() {
     const child = this.process;
     if (!child) return;
     try {
-      await this.request('status');
-      await this.request('stop');
-    } catch {}
-    child.stdin.end();
-    await new Promise((resolve) => {
-      if (child.exitCode !== null) return resolve();
-      const timeout = setTimeout(() => {
-        if (this.process === child && !child.killed) child.kill();
-        resolve();
-      }, 2_000);
-      child.once('exit', () => {
-        clearTimeout(timeout);
-        resolve();
-      });
-    });
+      await this.request('stop', {}, { timeoutMs: 2_000 });
+    } catch {
+      // Graceful stop failed or timed out; the process is force-killed below.
+    }
+    this.terminateProcess(new Error('capture-engine shutdown'));
   }
 }
 

--- a/electron/capture/capture-ipc.cjs
+++ b/electron/capture/capture-ipc.cjs
@@ -62,6 +62,7 @@ function registerCaptureIpc({
   userPaths,
   trackStorages,
   platform = process.platform,
+  canAcceptWork = () => true,
 }) {
   const registerSession = (session) => {
     for (const storage of trackStorages) storage.registerSession(session);
@@ -83,6 +84,11 @@ function registerCaptureIpc({
     }
   };
   ipcMain.handle('capture:request', async (_event, command, payload = {}) => {
+    if (!canAcceptWork()) {
+      const error = new Error(`capture command "${command}" rejected during application shutdown`);
+      error.code = 'application-shutting-down';
+      throw error;
+    }
     if (command === 'start-default-recording') {
       const catalog = await requestEngine('discover');
       const config = buildDefaultCaptureConfig(catalog, payload.options || {}, {

--- a/electron/capture/capture-ipc.cjs
+++ b/electron/capture/capture-ipc.cjs
@@ -69,47 +69,60 @@ function registerCaptureIpc({
   };
   const completeSession = (session) => trackStorages.reduce((value, storage) => storage.complete(value), session);
   let deferredStoppedSession = null;
+  const requestEngine = async (command, payload = {}) => {
+    try {
+      // A poisoned engine respawns a fresh process on its next request; the
+      // previous (timed out) session is gone and must not be completed.
+      return await captureEngine.request(command, payload);
+    } catch (error) {
+      if (captureEngine.isPoisoned) deferredStoppedSession = null;
+      const message = error instanceof Error ? error.message : String(error);
+      const wrapped = new Error(`capture-engine a échoué pour "${command}": ${message}`);
+      wrapped.code = error?.code || 'capture-engine-error';
+      throw wrapped;
+    }
+  };
   ipcMain.handle('capture:request', async (_event, command, payload = {}) => {
     if (command === 'start-default-recording') {
-      const catalog = await captureEngine.request('discover');
+      const catalog = await requestEngine('discover');
       const config = buildDefaultCaptureConfig(catalog, payload.options || {}, {
         platform,
         defaultOutputRoot: userPaths.projects,
         excludedProcessId: process.pid,
       });
-      await captureEngine.request('prepare', { config });
-      const session = await captureEngine.request('start');
+      await requestEngine('prepare', { config });
+      const session = await requestEngine('start');
       return registerSession(session);
     }
     if (command === 'prepare-default-recording') {
-      const catalog = await captureEngine.request('discover');
+      const catalog = await requestEngine('discover');
       const config = buildDefaultCaptureConfig(catalog, payload.options || {}, {
         platform,
         defaultOutputRoot: userPaths.projects,
         excludedProcessId: process.pid,
       });
-      return withProjectId(await captureEngine.request('prepare', { config }));
+      return withProjectId(await requestEngine('prepare', { config }));
     }
-    if (command === 'start-prepared-recording') return registerSession(await captureEngine.request('start'));
+    if (command === 'start-prepared-recording') return registerSession(await requestEngine('start'));
     if (command === 'cancel-prepared-recording') {
-      await captureEngine.request('cancel');
+      await requestEngine('cancel');
       return undefined;
     }
     if (command === 'discard-recording') {
       for (const storage of trackStorages) storage.forgetSession(payload.sessionId);
-      const session = await captureEngine.request('discard');
+      const session = await requestEngine('discard');
       for (const storage of trackStorages) storage.forgetSession(session?.sessionId);
       return undefined;
     }
     if (command === 'start-recording') {
-      await captureEngine.request('prepare', { config: payload.config });
-      const session = await captureEngine.request('start');
+      await requestEngine('prepare', { config: payload.config });
+      const session = await requestEngine('start');
       return registerSession(session);
     }
     if (command === 'stop-native-recording') {
       if (deferredStoppedSession)
         throw new Error('A native recording is already waiting for its sidecar tracks to finish.');
-      deferredStoppedSession = await captureEngine.request('stop');
+      deferredStoppedSession = await requestEngine('stop');
       return withProjectId(deferredStoppedSession);
     }
     if (command === 'complete-native-recording') {
@@ -118,10 +131,9 @@ function registerCaptureIpc({
       deferredStoppedSession = null;
       return withProjectId(completedVideoSource(session));
     }
-    if (command === 'stop')
-      return withProjectId(completedVideoSource(completeSession(await captureEngine.request('stop'))));
+    if (command === 'stop') return withProjectId(completedVideoSource(completeSession(await requestEngine('stop'))));
     if (!ALLOWED_COMMANDS.has(command)) throw new Error(`Commande de capture interdite: ${command}`);
-    return withProjectId(await captureEngine.request(command, payload));
+    return withProjectId(await requestEngine(command, payload));
   });
   ipcMain.handle('window:getSources', async (_event, types) => {
     // Chromium's desktopCapturer opens the system Portal picker for every

--- a/electron/countdown-window.cjs
+++ b/electron/countdown-window.cjs
@@ -1,7 +1,7 @@
 const { BrowserWindow, screen } = require('electron');
 const path = require('path');
 
-function createCountdownWindow({ applicationRoot, isPackaged }) {
+function createCountdownWindow({ applicationRoot, isPackaged, canAcceptWork = () => true }) {
   let window = null;
   let seconds = null;
   let ready = false;
@@ -14,6 +14,7 @@ function createCountdownWindow({ applicationRoot, isPackaged }) {
     );
   };
   const create = () => {
+    if (!canAcceptWork()) return;
     if (window && !window.isDestroyed()) return;
     if (!window || window.isDestroyed()) {
       ready = false;
@@ -54,11 +55,12 @@ function createCountdownWindow({ applicationRoot, isPackaged }) {
     }
   };
   const show = (value) => {
+    if (!canAcceptWork()) return false;
     seconds = value;
     create();
     if (value === null) {
       window?.hide();
-      return;
+      return true;
     }
     position();
     if (ready) {
@@ -66,12 +68,20 @@ function createCountdownWindow({ applicationRoot, isPackaged }) {
       window.showInactive();
       window.moveTop();
     }
+    return true;
   };
   // Load the renderer while the application is idle. The first countdown
   // value can then be displayed immediately instead of waiting for a cold
   // BrowserWindow and renderer navigation.
   create();
-  return { show, destroy: () => window?.destroy() };
+  return {
+    show,
+    destroy: () => {
+      if (window && !window.isDestroyed()) window.destroy();
+      window = null;
+      ready = false;
+    },
+  };
 }
 
 module.exports = { createCountdownWindow };

--- a/electron/lifecycle/fatal-events.cjs
+++ b/electron/lifecycle/fatal-events.cjs
@@ -1,0 +1,34 @@
+function registerFatalLifecycle({ app, powerMonitor, coordinator, log = () => {}, processTarget = process }) {
+  const exitAfterShutdown = (source, details) => {
+    if (!coordinator.canAcceptWork()) return false;
+    log(`${source}: ${details}`);
+    coordinator.requestShutdown(source).finally(() => app.exit(1));
+    return true;
+  };
+  const requestQuit = () => {
+    if (coordinator.canAcceptWork()) app.quit();
+  };
+
+  processTarget.on('SIGINT', requestQuit);
+  processTarget.on('SIGTERM', requestQuit);
+  processTarget.on('uncaughtException', (error) =>
+    exitAfterShutdown('fatal', `Uncaught exception: ${error?.stack || error}`),
+  );
+  processTarget.on('unhandledRejection', (reason) => exitAfterShutdown('fatal', `Unhandled rejection: ${reason}`));
+  powerMonitor.on('shutdown', requestQuit);
+  app.on('render-process-gone', (_event, contents, details) =>
+    exitAfterShutdown(
+      'renderer-crash',
+      `renderer ${contents?.id ?? 'unknown'} exited (${details.reason}, code=${details.exitCode})`,
+    ),
+  );
+  app.on('child-process-gone', (_event, details) => {
+    if (details.reason === 'clean-exit') return false;
+    return exitAfterShutdown(
+      'fatal',
+      `Electron ${details.type} process exited (${details.reason}, code=${details.exitCode})`,
+    );
+  });
+}
+
+module.exports = { registerFatalLifecycle };

--- a/electron/lifecycle/shutdown-coordinator.cjs
+++ b/electron/lifecycle/shutdown-coordinator.cjs
@@ -1,0 +1,128 @@
+const GRACEFUL_DEADLINE_MS = 2_000;
+const CLEANUP_DEADLINE_MS = 2_000;
+const TOTAL_SHUTDOWN_DEADLINE_MS = 5_000;
+
+const SHUTDOWN_REASONS = Object.freeze([
+  'hud',
+  'tray',
+  'before-quit',
+  'window-all-closed',
+  'updater',
+  'signal',
+  'renderer-crash',
+  'fatal',
+]);
+
+function withDeadline(operation, ms, label) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`${label} exceeded ${ms}ms`)), ms);
+    Promise.resolve()
+      .then(operation)
+      .then(
+        (value) => {
+          clearTimeout(timer);
+          resolve(value);
+        },
+        (error) => {
+          clearTimeout(timer);
+          reject(error);
+        },
+      );
+  });
+}
+
+function createShutdownCoordinator({
+  captureEngine,
+  log = () => {},
+  gracefulDeadlineMs = GRACEFUL_DEADLINE_MS,
+  cleanupDeadlineMs = CLEANUP_DEADLINE_MS,
+  shutdownDeadlineMs = TOTAL_SHUTDOWN_DEADLINE_MS,
+}) {
+  let state = 'running'; // running | shutting-down | shutdown-complete
+  let shutdownPromise = null;
+  const cleanups = [];
+  const errors = [];
+
+  const registerCleanup = ({ id, cleanup, deadlineMs = cleanupDeadlineMs }) => {
+    cleanups.push({ id, cleanup, deadlineMs });
+    return () => {
+      const index = cleanups.findIndex((entry) => entry.id === id);
+      if (index >= 0) cleanups.splice(index, 1);
+    };
+  };
+
+  const requestShutdown = (source) => {
+    if (shutdownPromise) return shutdownPromise;
+    if (state === 'shutdown-complete') return Promise.resolve({ source, errors });
+    state = 'shutting-down';
+    log(`shutdown requested (source=${source})`);
+    shutdownPromise = performShutdown(source);
+    return shutdownPromise;
+  };
+
+  const performShutdown = async (source) => {
+    const message = (error) => (error instanceof Error ? error.message : String(error));
+    let forcePromise = null;
+    const forceNative = () => {
+      forcePromise ??= Promise.resolve().then(() => captureEngine.forceShutdown());
+      return forcePromise;
+    };
+    const nativeShutdown = async () => {
+      try {
+        await withDeadline(() => captureEngine.shutdown(), gracefulDeadlineMs, 'capture-engine graceful shutdown');
+      } catch (error) {
+        errors.push(message(error));
+      }
+      const forced = await forceNative();
+      if (forced && forced.confirmed === false && forced.reason !== 'no capture-engine process') {
+        errors.push(`capture-engine exit unconfirmed: ${forced.reason}`);
+      }
+    };
+    const resourceShutdown = () =>
+      Promise.allSettled(
+        cleanups.map(({ id, cleanup, deadlineMs }) =>
+          withDeadline(cleanup, deadlineMs, `cleanup ${id}`).catch((error) => {
+            errors.push(`${id}: ${message(error)}`);
+          }),
+        ),
+      );
+    try {
+      // Resource cleanup runs alongside native shutdown so the contractual
+      // total deadline is not the sum of every independent deadline.
+      await withDeadline(
+        () => Promise.all([nativeShutdown(), resourceShutdown()]),
+        shutdownDeadlineMs,
+        'application shutdown',
+      );
+    } catch (error) {
+      errors.push(message(error));
+      // The global deadline is also the deadline for returning control to
+      // Electron. Dispatch the hard kill once; the engine-level parent guard
+      // remains the independent fallback if the child never reports exit.
+      void forceNative().catch((forceError) => {
+        errors.push(`capture-engine force shutdown: ${message(forceError)}`);
+      });
+    }
+    state = 'shutdown-complete';
+    log(`shutdown complete (source=${source})`);
+    return { source, errors };
+  };
+
+  return {
+    registerCleanup,
+    requestShutdown,
+    isShuttingDown: () => state === 'shutting-down',
+    isComplete: () => state === 'shutdown-complete',
+    canAcceptWork: () => state === 'running',
+    getState: () => state,
+  };
+}
+
+module.exports = {
+  CLEANUP_DEADLINE_MS,
+  GRACEFUL_DEADLINE_MS,
+  SHUTDOWN_REASONS,
+  TOTAL_SHUTDOWN_DEADLINE_MS,
+  createShutdownCoordinator,
+  withDeadline,
+};

--- a/electron/lifecycle/shutdown-ipc.cjs
+++ b/electron/lifecycle/shutdown-ipc.cjs
@@ -1,0 +1,24 @@
+function shutdownError() {
+  const error = new Error('Beam is shutting down; new IPC work is disabled');
+  error.code = 'application-shutting-down';
+  return error;
+}
+
+function createShutdownAwareIpc(ipcMain, canAcceptWork) {
+  return {
+    handle(channel, listener) {
+      ipcMain.handle(channel, (...args) => {
+        if (!canAcceptWork()) throw shutdownError();
+        return listener(...args);
+      });
+    },
+    on(channel, listener) {
+      ipcMain.on(channel, (...args) => {
+        if (!canAcceptWork()) return false;
+        return listener(...args);
+      });
+    },
+  };
+}
+
+module.exports = { createShutdownAwareIpc, shutdownError };

--- a/electron/lifecycle/single-instance.cjs
+++ b/electron/lifecycle/single-instance.cjs
@@ -1,0 +1,11 @@
+function initializeSingleInstance({ app, initialize, restoreHud }) {
+  if (!app.requestSingleInstanceLock()) {
+    app.quit();
+    return false;
+  }
+  app.on('second-instance', () => restoreHud());
+  initialize();
+  return true;
+}
+
+module.exports = { initializeSingleInstance };

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -10,6 +10,7 @@ const {
   net,
   shell,
   nativeTheme,
+  powerMonitor,
 } = require('electron');
 const { autoUpdater } = require('electron-updater');
 const fs = require('fs');
@@ -43,6 +44,10 @@ const { createBackgroundLibrary } = require('./backgrounds/background-library.cj
 const { createAutoUpdater, registerUpdateIpc } = require('./updates/auto-updater.cjs');
 const { createTrayManager } = require('./tray/tray-manager.cjs');
 const { InputAccess, registerInputAccessIpc } = require('./input/input-access.cjs');
+const { createShutdownCoordinator } = require('./lifecycle/shutdown-coordinator.cjs');
+const { createShutdownAwareIpc } = require('./lifecycle/shutdown-ipc.cjs');
+const { registerFatalLifecycle } = require('./lifecycle/fatal-events.cjs');
+const { initializeSingleInstance } = require('./lifecycle/single-instance.cjs');
 
 const DISCORD_INVITE_URL = 'https://discord.gg/6Q6v2xUCB';
 const GITHUB_REPOSITORY_URL = 'https://github.com/ExtraBinoss/Beam';
@@ -63,19 +68,17 @@ const logStartup = (step) => {
 };
 
 const applicationRoot = path.join(__dirname, '..');
-let captureEngine;
-const inputAccess = new InputAccess({
-  app,
-  applicationRoot,
-  nativeRequest: (command) => captureEngine.request(command),
-});
-captureEngine = new CaptureEngine(app, applicationRoot, {
-  inputHelperPath: () => inputAccess.helperForCapture(),
-});
-const cameraStorage = createCameraStorage({});
-const microphoneStorage = createMicrophoneStorage({});
-const systemAudioStorage = createSystemAudioStorage({});
 const controllers = new WeakMap();
+let captureEngine = null;
+let coordinator = null;
+let quitting = false;
+let showExistingHud = () => false;
+let pendingHudRestore = false;
+
+function restoreCanonicalHud() {
+  if (showExistingHud()) pendingHudRestore = false;
+  else pendingHudRestore = true;
+}
 
 function profileRendererRequests(webContents) {
   if (app.isPackaged) return;
@@ -184,9 +187,6 @@ function createWindow(preferencesStore) {
   win.webContents.once('did-start-loading', () => logStartup('Renderer navigation started.'));
   win.webContents.once('dom-ready', () => logStartup('Renderer DOM is ready.'));
   win.webContents.once('did-finish-load', () => logStartup('Renderer loading finished.'));
-  win.webContents.on('render-process-gone', (_event, details) =>
-    logStartup(`Renderer process exited (${details.reason}).`),
-  );
   if (shouldAutoOpenDevTools({ isPackaged: app.isPackaged })) {
     win.webContents.once('did-finish-load', () => win.webContents.openDevTools({ mode: 'detach' }));
   }
@@ -200,210 +200,240 @@ function createWindow(preferencesStore) {
   return win;
 }
 
-app.whenReady().then(() => {
-  logStartup('Electron app.whenReady resolved.');
-  configureMediaPermission();
-  logStartup('Media permission policy registered.');
-  configureDesktopLoopback();
-  registerInputAccessIpc(ipcMain, inputAccess);
-  const userPaths = createUserPaths(app.getPath('videos'));
-  const preferencesStore = createPreferencesStore(userPaths.preferences, { platform: process.platform });
-  const teleprompterWindow = createTeleprompterWindow({
+function initializeApplication() {
+  const inputAccess = new InputAccess({
+    app,
     applicationRoot,
-    isPackaged: app.isPackaged,
-    preferencesStore,
+    nativeRequest: (command) => captureEngine.request(command),
   });
-  setTimeout(() => teleprompterWindow.prepare(), 0);
-  const preferencesCleanup = registerPreferencesIpc({
-    ipcMain,
-    BrowserWindow,
-    globalShortcut,
-    store: preferencesStore,
-    shortcutHandler: (id) => teleprompterWindow.handleShortcut(id),
-    onPreferencesChanged: (preferences) => {
-      for (const win of BrowserWindow.getAllWindows()) {
-        const controller = controllers.get(win);
-        if (controller) {
-          controller.applyModePolicy();
+  captureEngine = new CaptureEngine(app, applicationRoot, {
+    inputHelperPath: () => inputAccess.helperForCapture(),
+  });
+  coordinator = createShutdownCoordinator({ captureEngine, log: logStartup });
+  const applicationIpc = createShutdownAwareIpc(ipcMain, () => coordinator.canAcceptWork());
+  registerFatalLifecycle({ app, powerMonitor, coordinator, log: logStartup });
+  const cameraStorage = createCameraStorage({});
+  const microphoneStorage = createMicrophoneStorage({});
+  const systemAudioStorage = createSystemAudioStorage({});
+
+  app.whenReady().then(() => {
+    logStartup('Electron app.whenReady resolved.');
+    configureMediaPermission();
+    logStartup('Media permission policy registered.');
+    configureDesktopLoopback();
+    registerInputAccessIpc(applicationIpc, inputAccess);
+    const userPaths = createUserPaths(app.getPath('videos'));
+    const preferencesStore = createPreferencesStore(userPaths.preferences, { platform: process.platform });
+    const teleprompterWindow = createTeleprompterWindow({
+      applicationRoot,
+      isPackaged: app.isPackaged,
+      preferencesStore,
+    });
+    setTimeout(() => teleprompterWindow.prepare(), 0);
+    const preferencesCleanup = registerPreferencesIpc({
+      ipcMain: applicationIpc,
+      BrowserWindow,
+      globalShortcut,
+      store: preferencesStore,
+      shortcutHandler: (id) => teleprompterWindow.handleShortcut(id),
+      onPreferencesChanged: (preferences) => {
+        for (const win of BrowserWindow.getAllWindows()) {
+          const controller = controllers.get(win);
+          if (controller) {
+            controller.applyModePolicy();
+          }
         }
+      },
+    });
+    logStartup('Desktop loopback policy registered.');
+    registerCaptureIpc({
+      ipcMain,
+      desktopCapturer,
+      screen,
+      captureEngine,
+      app,
+      userPaths,
+      trackStorages: [cameraStorage, microphoneStorage, systemAudioStorage],
+      canAcceptWork: () => coordinator.canAcceptWork(),
+    });
+    logStartup('Capture IPC registered.');
+    registerCameraIpc({ ipcMain: applicationIpc, storage: cameraStorage });
+    registerMicrophoneIpc({ ipcMain: applicationIpc, storage: microphoneStorage });
+    registerSystemAudioIpc({ ipcMain: applicationIpc, storage: systemAudioStorage });
+    logStartup('Capture track IPC registered.');
+    const projectStore = createProjectStore(userPaths.projects);
+    const teleprompterStorage = createTeleprompterStorage({ projectStore });
+    registerTeleprompterIpc({ ipcMain: applicationIpc, teleprompterWindow, storage: teleprompterStorage });
+    registerProjectIpc(
+      applicationIpc,
+      projectStore,
+      createBackgroundLibrary(userPaths),
+      require('electron').dialog,
+      BrowserWindow,
+    );
+    protocol.handle('project-media', async (request) => {
+      try {
+        const file = projectStore.mediaFileForUrl(request.url);
+        if (!file || !fs.existsSync(file)) return new Response('Not found', { status: 404 });
+        const response = await net.fetch(pathToFileURL(file).href);
+        const ext = path.extname(file).toLowerCase();
+        const mimeTypes = {
+          '.mp4': 'video/mp4',
+          '.webm': 'video/webm',
+          '.mov': 'video/quicktime',
+          '.mkv': 'video/x-matroska',
+          '.png': 'image/png',
+          '.jpg': 'image/jpeg',
+          '.jpeg': 'image/jpeg',
+          '.webp': 'image/webp',
+        };
+        const contentType = mimeTypes[ext] || 'application/octet-stream';
+        const headers = new Headers(response.headers);
+        headers.set('content-type', contentType);
+        headers.set('access-control-allow-origin', '*');
+        return new Response(response.body, {
+          status: response.status,
+          statusText: response.statusText,
+          headers,
+        });
+      } catch (e) {
+        console.error('[project-media] Error serving media:', e);
+        return new Response('Internal error', { status: 500 });
       }
-    },
-  });
-  app.once('will-quit', preferencesCleanup);
-  logStartup('Desktop loopback policy registered.');
-  registerCaptureIpc({
-    ipcMain,
-    desktopCapturer,
-    screen,
-    captureEngine,
-    app,
-    userPaths,
-    trackStorages: [cameraStorage, microphoneStorage, systemAudioStorage],
-  });
-  logStartup('Capture IPC registered.');
-  registerCameraIpc({ ipcMain, storage: cameraStorage });
-  logStartup('Camera IPC registered.');
-  registerMicrophoneIpc({ ipcMain, storage: microphoneStorage });
-  logStartup('Microphone IPC registered.');
-  registerSystemAudioIpc({ ipcMain, storage: systemAudioStorage });
-  logStartup('System audio IPC registered.');
-  const projectStore = createProjectStore(userPaths.projects);
-  const teleprompterStorage = createTeleprompterStorage({ projectStore });
-  registerTeleprompterIpc({ ipcMain, teleprompterWindow, storage: teleprompterStorage });
-  registerProjectIpc(
-    ipcMain,
-    projectStore,
-    createBackgroundLibrary(userPaths),
-    require('electron').dialog,
-    BrowserWindow,
-  );
-  protocol.handle('project-media', async (request) => {
-    try {
-      const file = projectStore.mediaFileForUrl(request.url);
-      if (!file || !fs.existsSync(file)) return new Response('Not found', { status: 404 });
-      const response = await net.fetch(pathToFileURL(file).href);
-      const ext = path.extname(file).toLowerCase();
-      const mimeTypes = {
-        '.mp4': 'video/mp4',
-        '.webm': 'video/webm',
-        '.mov': 'video/quicktime',
-        '.mkv': 'video/x-matroska',
-        '.png': 'image/png',
-        '.jpg': 'image/jpeg',
-        '.jpeg': 'image/jpeg',
-        '.webp': 'image/webp',
-      };
-      const contentType = mimeTypes[ext] || 'application/octet-stream';
-      const headers = new Headers(response.headers);
-      headers.set('content-type', contentType);
-      headers.set('access-control-allow-origin', '*');
-      return new Response(response.body, {
-        status: response.status,
-        statusText: response.statusText,
-        headers,
-      });
-    } catch (e) {
-      console.error('[project-media] Error serving media:', e);
-      return new Response('Internal error', { status: 500 });
-    }
-  });
-  logStartup('Project IPC registered.');
-  const whisperStore = createWhisperModelStore(userPaths.whisperModels);
-  protocol.handle('whisper-model', (request) => {
-    const file = whisperStore.fileForUrl(request.url);
-    return file
-      ? new Response(Readable.toWeb(fs.createReadStream(file)), {
-          headers: { 'Content-Length': String(fs.statSync(file).size) },
-        })
-      : new Response('Not found', { status: 404 });
-  });
-  registerWhisperIpc({ ipcMain, store: whisperStore });
-  logStartup('Whisper model IPC registered.');
-  registerWindowIpc(ipcMain, (win) => win && controllers.get(win), { debug: !app.isPackaged });
-  const cameraOverlay = createCameraOverlayWindow({ applicationRoot, isPackaged: app.isPackaged });
-  const countdownOverlay = createCountdownWindow({ applicationRoot, isPackaged: app.isPackaged });
-  const screenRegionOverlay = createScreenRegionOverlayWindow({ applicationRoot, isPackaged: app.isPackaged });
-  ipcMain.on('camera-overlay:configure', (_event, state) => cameraOverlay.configure(state));
-  ipcMain.on('camera-overlay:set-active', (_event, active) => cameraOverlay.setActive(active));
-  ipcMain.on('camera-overlay:reset-placement', () => cameraOverlay.resetPlacement());
-  ipcMain.handle('countdown:set', (_event, seconds) => {
-    countdownOverlay.show(Number.isInteger(seconds) && seconds >= 0 ? seconds : null);
-  });
-  ipcMain.handle('recording-surface:prepare', async () => {
-    countdownOverlay.show(null);
-    screenRegionOverlay.hide();
-    // Wait for the compositor to commit both hidden overlay surfaces before
-    // the native start gate admits the first recorded frame.
-    await new Promise((resolve) => setTimeout(resolve, 100));
-  });
-  ipcMain.handle('screen-region:select', (_event, options) => screenRegionOverlay.select(options));
-  ipcMain.on('screen-region:show', (_event, options) => screenRegionOverlay.show(options));
-  ipcMain.on('screen-region:hide', () => screenRegionOverlay.hide());
-  ipcMain.on('screen-region:confirm', (_event, region) => screenRegionOverlay.confirm(region));
-  ipcMain.on('screen-region:cancel', () => screenRegionOverlay.cancel());
-  ipcMain.handle('camera-overlay:state', () => cameraOverlay.state());
-  logStartup('Window IPC registered.');
-  const exportIpc = registerExportIpc({ ipcMain, dialog: require('electron').dialog, BrowserWindow });
-  logStartup('Export IPC registered.');
-  const updater = createAutoUpdater({
-    app,
-    BrowserWindow,
-    autoUpdater,
-    openExternal: require('electron').shell.openExternal,
-  });
-  registerUpdateIpc(ipcMain, updater);
-  ipcMain.handle('community:open-discord', () => shell.openExternal(DISCORD_INVITE_URL));
-  ipcMain.handle('community:open-github', () => shell.openExternal(GITHUB_REPOSITORY_URL));
-  const win = createWindow(preferencesStore);
-  const selectedTheme = preferencesStore.read().theme;
-  const editorWindow = createEditorWindowManager({
-    applicationRoot,
-    isPackaged: app.isPackaged,
-    ipcMain,
-    hudWindow: win,
-    hudController: controllers.get(win),
-    registerController: (target, controller) => controllers.set(target, controller),
-    initialDark: selectedTheme === 'dark' || (selectedTheme === 'system' && nativeTheme.shouldUseDarkColors),
-    cleanupWindow: (contents) => {
-      exportIpc.cleanupWindow(contents);
-      cameraStorage.cleanupOwner(contents.id);
-      microphoneStorage.cleanupOwner(contents.id);
-      systemAudioStorage.cleanupOwner(contents.id);
-    },
-  });
-  const trayManager = createTrayManager({
-    applicationRoot,
-    getWindow: () => win,
-    getController: () => win && controllers.get(win),
-    onShowHud: () => editorWindow.showHud(),
-  });
-  trayManager.init();
-  win.on('closed', () => {
-    editorWindow.destroy();
-    trayManager.destroy();
-    teleprompterWindow.destroy();
-  });
-  app.once('will-quit', () => {
-    editorWindow.destroy();
-    trayManager.destroy();
-    teleprompterWindow.destroy();
-  });
-  void updater.checkForUpdates();
-  win.webContents.once('destroyed', () => {
-    cameraOverlay.destroy();
-    screenRegionOverlay.destroy();
-    exportIpc.cleanupWindow(win.webContents);
-    cameraStorage.cleanupOwner(win.webContents.id);
-    microphoneStorage.cleanupOwner(win.webContents.id);
-    systemAudioStorage.cleanupOwner(win.webContents.id);
-  });
-  app.on('activate', () => {
-    if (BrowserWindow.getAllWindows().length === 0) createWindow(preferencesStore);
-  });
-});
+    });
+    logStartup('Project IPC registered.');
+    const whisperStore = createWhisperModelStore(userPaths.whisperModels);
+    protocol.handle('whisper-model', (request) => {
+      const file = whisperStore.fileForUrl(request.url);
+      return file
+        ? new Response(Readable.toWeb(fs.createReadStream(file)), {
+            headers: { 'Content-Length': String(fs.statSync(file).size) },
+          })
+        : new Response('Not found', { status: 404 });
+    });
+    registerWhisperIpc({ ipcMain: applicationIpc, store: whisperStore });
+    logStartup('Whisper model IPC registered.');
+    registerWindowIpc(applicationIpc, (win) => win && controllers.get(win), { debug: !app.isPackaged });
+    const lifecycleOptions = {
+      applicationRoot,
+      isPackaged: app.isPackaged,
+      canAcceptWork: () => coordinator.canAcceptWork(),
+    };
+    const cameraOverlay = createCameraOverlayWindow(lifecycleOptions);
+    const countdownOverlay = createCountdownWindow(lifecycleOptions);
+    const screenRegionOverlay = createScreenRegionOverlayWindow(lifecycleOptions);
+    applicationIpc.on('camera-overlay:configure', (_event, state) => cameraOverlay.configure(state));
+    applicationIpc.on('camera-overlay:set-active', (_event, active) => cameraOverlay.setActive(active));
+    applicationIpc.on('camera-overlay:reset-placement', () => cameraOverlay.resetPlacement());
+    applicationIpc.handle('countdown:set', (_event, seconds) => {
+      countdownOverlay.show(Number.isInteger(seconds) && seconds >= 0 ? seconds : null);
+    });
+    applicationIpc.handle('recording-surface:prepare', async () => {
+      countdownOverlay.show(null);
+      screenRegionOverlay.hide();
+      // Wait for the compositor to commit both hidden overlay surfaces before
+      // the native start gate admits the first recorded frame.
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    });
+    applicationIpc.handle('screen-region:select', (_event, options) => screenRegionOverlay.select(options));
+    applicationIpc.on('screen-region:show', (_event, options) => screenRegionOverlay.show(options));
+    applicationIpc.on('screen-region:hide', () => screenRegionOverlay.hide());
+    applicationIpc.on('screen-region:confirm', (_event, region) => screenRegionOverlay.confirm(region));
+    applicationIpc.on('screen-region:cancel', () => screenRegionOverlay.cancel());
+    applicationIpc.handle('camera-overlay:state', () => cameraOverlay.state());
+    logStartup('Window IPC registered.');
+    const exportIpc = registerExportIpc({ ipcMain: applicationIpc, dialog: require('electron').dialog, BrowserWindow });
+    logStartup('Export IPC registered.');
+    const updater = createAutoUpdater({
+      app,
+      BrowserWindow,
+      autoUpdater,
+      openExternal: require('electron').shell.openExternal,
+      beforeQuitAndInstall: () => coordinator.requestShutdown('updater'),
+    });
+    registerUpdateIpc(applicationIpc, updater);
+    applicationIpc.handle('community:open-discord', () => shell.openExternal(DISCORD_INVITE_URL));
+    applicationIpc.handle('community:open-github', () => shell.openExternal(GITHUB_REPOSITORY_URL));
+    ipcMain.on('app:quit', () => {
+      if (coordinator.canAcceptWork()) app.quit();
+    });
+    const win = createWindow(preferencesStore);
+    const selectedTheme = preferencesStore.read().theme;
+    const editorWindow = createEditorWindowManager({
+      applicationRoot,
+      isPackaged: app.isPackaged,
+      ipcMain: applicationIpc,
+      hudWindow: win,
+      hudController: controllers.get(win),
+      registerController: (target, controller) => controllers.set(target, controller),
+      initialDark: selectedTheme === 'dark' || (selectedTheme === 'system' && nativeTheme.shouldUseDarkColors),
+      cleanupWindow: (contents) => {
+        exportIpc.cleanupWindow(contents);
+        cameraStorage.cleanupOwner(contents.id);
+        microphoneStorage.cleanupOwner(contents.id);
+        systemAudioStorage.cleanupOwner(contents.id);
+      },
+      canAcceptWork: () => coordinator.canAcceptWork(),
+    });
+    showExistingHud = () => {
+      if (!coordinator.canAcceptWork()) return false;
+      editorWindow.showHud();
+      return true;
+    };
+    if (pendingHudRestore) restoreCanonicalHud();
+    const trayManager = createTrayManager({
+      applicationRoot,
+      getWindow: () => win,
+      getController: () => win && controllers.get(win),
+      onShowHud: () => editorWindow.showHud(),
+    });
+    trayManager.init();
 
-let quitting = false;
-let captureShutdown = null;
-app.on('before-quit', (event) => {
-  if (quitting) return;
-  event.preventDefault();
-  captureShutdown ??= captureEngine.shutdown().finally(() => {
+    // Every owned resource must be released on shutdown. The eagerly preloaded
+    // countdown window is the hidden window that previously prevented
+    // `window-all-closed`, so it is registered alongside every other resource.
+    coordinator.registerCleanup({ id: 'hud-window', cleanup: () => win.destroy() });
+    coordinator.registerCleanup({ id: 'editor', cleanup: () => editorWindow.destroy() });
+    coordinator.registerCleanup({ id: 'tray', cleanup: () => trayManager.destroy() });
+    coordinator.registerCleanup({ id: 'teleprompter', cleanup: () => teleprompterWindow.destroy() });
+    coordinator.registerCleanup({ id: 'countdown', cleanup: () => countdownOverlay.destroy() });
+    coordinator.registerCleanup({ id: 'camera-overlay', cleanup: () => cameraOverlay.destroy() });
+    coordinator.registerCleanup({ id: 'screen-region', cleanup: () => screenRegionOverlay.destroy() });
+    coordinator.registerCleanup({ id: 'preferences', cleanup: preferencesCleanup });
+
+    win.on('closed', () => {
+      if (coordinator.canAcceptWork()) app.quit();
+    });
+
+    win.webContents.once('destroyed', () => {
+      exportIpc.cleanupWindow(win.webContents);
+      cameraStorage.cleanupOwner(win.webContents.id);
+      microphoneStorage.cleanupOwner(win.webContents.id);
+      systemAudioStorage.cleanupOwner(win.webContents.id);
+    });
+    void updater.checkForUpdates();
+    app.on('activate', () => {
+      showExistingHud();
+    });
+  });
+
+  app.on('before-quit', (event) => {
+    if (coordinator.isComplete() || quitting) return;
+    event.preventDefault();
     quitting = true;
-    app.quit();
+    coordinator.requestShutdown('before-quit').finally(() => app.quit());
   });
-});
-app.on('will-quit', () => {
-  // Final guarantee: no capture-engine.exe may survive Electron exit, even if
-  // the graceful path above was bypassed (update install, window close, etc.).
-  captureEngine.terminateProcess(new Error('capture-engine will-quit'));
-});
-app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') app.quit();
-});
+  app.on('will-quit', () => {
+    // Final synchronous/best-effort safety net, not the primary cleanup path.
+    captureEngine.forceShutdown();
+  });
+  app.on('window-all-closed', () => {
+    if (process.platform !== 'darwin') app.quit();
+  });
+}
 
-process.on('SIGINT', () => {
-  if (!quitting) app.quit();
-});
-process.on('SIGTERM', () => {
-  if (!quitting) app.quit();
+initializeSingleInstance({
+  app,
+  initialize: initializeApplication,
+  restoreHud: restoreCanonicalHud,
 });

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -392,6 +392,11 @@ app.on('before-quit', (event) => {
     app.quit();
   });
 });
+app.on('will-quit', () => {
+  // Final guarantee: no capture-engine.exe may survive Electron exit, even if
+  // the graceful path above was bypassed (update install, window close, etc.).
+  captureEngine.terminateProcess(new Error('capture-engine will-quit'));
+});
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') app.quit();
 });

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -38,6 +38,7 @@ contextBridge.exposeInMainWorld(
     finalizeSystemAudioSegment: (payload) => ipcRenderer.invoke('system-audio:finalize-segment', payload),
     failSystemAudio: (payload) => ipcRenderer.invoke('system-audio:fail', payload),
     close: () => ipcRenderer.send('window:close'),
+    quit: () => ipcRenderer.send('app:quit'),
     minimize: () => ipcRenderer.send('window:minimize'),
     toggleDevTools: () => ipcRenderer.send('window:toggle-devtools'),
     updateTrayMenu: (labels) => ipcRenderer.send('tray:update-menu', labels),

--- a/electron/screen-region-overlay.cjs
+++ b/electron/screen-region-overlay.cjs
@@ -13,7 +13,7 @@ function finiteBounds(value) {
   };
 }
 
-function createScreenRegionOverlayWindow({ applicationRoot, isPackaged }) {
+function createScreenRegionOverlayWindow({ applicationRoot, isPackaged, canAcceptWork = () => true }) {
   let window = null;
   let ready = false;
   let pending = null;
@@ -25,6 +25,7 @@ function createScreenRegionOverlayWindow({ applicationRoot, isPackaged }) {
   };
 
   const ensureWindow = () => {
+    if (!canAcceptWork()) throw new Error('Cannot create a screen overlay while Beam is shutting down');
     if (window && !window.isDestroyed()) return window;
     window = new BrowserWindow({
       frame: false,

--- a/electron/updates/auto-updater.cjs
+++ b/electron/updates/auto-updater.cjs
@@ -10,7 +10,14 @@ const idleState = (version, status = 'idle') => ({
 const versionOf = (info) => (typeof info?.version === 'string' ? info.version : null);
 const errorMessage = (error) => (error instanceof Error ? error.message : 'Unable to check for updates.');
 
-function createAutoUpdater({ app, BrowserWindow, autoUpdater, openExternal, isPackaged = app.isPackaged }) {
+function createAutoUpdater({
+  app,
+  BrowserWindow,
+  autoUpdater,
+  openExternal,
+  isPackaged = app.isPackaged,
+  beforeQuitAndInstall = null,
+}) {
   let state = idleState(app.getVersion(), isPackaged ? 'idle' : 'unsupported');
   const publish = () =>
     BrowserWindow.getAllWindows().forEach((window) => {
@@ -66,8 +73,11 @@ function createAutoUpdater({ app, BrowserWindow, autoUpdater, openExternal, isPa
         return false;
       }
     },
-    quitAndInstall: () => {
+    quitAndInstall: async () => {
       if (state.status !== 'downloaded') return false;
+      // Run the central shutdown coordinator first so the native engine and
+      // every owned window are released before the installer takes over.
+      if (beforeQuitAndInstall) await beforeQuitAndInstall();
       autoUpdater.quitAndInstall();
       return true;
     },

--- a/electron/window/devtools-policy.cjs
+++ b/electron/window/devtools-policy.cjs
@@ -1,5 +1,5 @@
 function shouldAutoOpenDevTools({ isPackaged, environment = process.env }) {
-  return !isPackaged && environment.DEMO_RECORDER_DEVTOOLS === '1';
+  return !isPackaged && environment.BEAM_DEVTOOLS === '1';
 }
 
 module.exports = { shouldAutoOpenDevTools };

--- a/electron/window/editor-window.cjs
+++ b/electron/window/editor-window.cjs
@@ -46,6 +46,7 @@ function createEditorWindowManager({
   registerController,
   initialDark = false,
   cleanupWindow = null,
+  canAcceptWork = () => true,
 }) {
   let window = null;
   let controller = null;
@@ -86,15 +87,18 @@ function createEditorWindowManager({
   };
 
   const showHud = () => {
+    if (!canAcceptWork()) return false;
     returningToHud = true;
     if (window && !window.isDestroyed()) window.close();
     if (hudWindow.isMinimized()) hudWindow.restore();
     hudController.showHud();
     hudWindow.show();
     hudWindow.focus();
+    return true;
   };
 
   const ensure = () => {
+    if (!canAcceptWork()) throw new Error('Cannot create an editor while Beam is shutting down');
     if (window && !window.isDestroyed()) return window;
     rendererReady = false;
     returningToHud = false;
@@ -144,6 +148,7 @@ function createEditorWindowManager({
   };
 
   const open = (projectId) => {
+    if (!canAcceptWork()) throw new Error('Cannot open an editor while Beam is shutting down');
     if (!PROJECT_ID.test(projectId)) throw new Error('Identifiant de projet invalide');
     lastProgressValue = 0;
     sendProgress('openingWindow');
@@ -178,6 +183,7 @@ function createEditorWindowManager({
   };
 
   const startRecording = (event, configuration) => {
+    if (!canAcceptWork()) return false;
     if (!window || window.isDestroyed() || event.sender !== window.webContents) return false;
     returningToHud = true;
     window.close();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "demo-recorder",
+  "name": "beam",
   "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "demo-recorder",
+      "name": "beam",
       "version": "0.1.2",
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "demo-recorder",
+  "name": "beam",
   "private": true,
   "version": "0.1.2",
   "description": "Beam - Screen recorder to create product demos.",

--- a/packages/capture/Cargo.toml
+++ b/packages/capture/Cargo.toml
@@ -21,13 +21,14 @@ fs2 = "0.4"
 [target.'cfg(windows)'.dependencies]
 windows-capture = "2.0.0"
 parking_lot = "0.12"
-windows = { version = "0.62", features = ["Win32_Foundation", "Win32_Graphics_Direct3D", "Win32_Graphics_Direct3D11", "Win32_Graphics_Dxgi", "Win32_Graphics_Gdi", "Win32_System_Com", "Win32_System_Performance", "Win32_UI_HiDpi", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_WindowsAndMessaging"] }
+windows = { version = "0.62", features = ["Win32_Foundation", "Win32_Graphics_Direct3D", "Win32_Graphics_Direct3D11", "Win32_Graphics_Dxgi", "Win32_Graphics_Gdi", "Win32_Security", "Win32_System_Com", "Win32_System_JobObjects", "Win32_System_Performance", "Win32_System_Threading", "Win32_UI_HiDpi", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_WindowsAndMessaging"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6.4"
 objc2-app-kit = { version = "0.3.2", features = ["NSCursor"] }
 screencapturekit = { version = "8.0.1", features = ["macos_15_0"] }
 core-graphics = "0.25"
+libc = "0.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 ashpd = { version = "=0.13.13", default-features = false, features = ["tokio", "screencast"] }

--- a/packages/capture/src/bin/beam-input-helper.rs
+++ b/packages/capture/src/bin/beam-input-helper.rs
@@ -463,6 +463,14 @@ mod linux {
 
 #[cfg(target_os = "linux")]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // pkexec normally execs this helper. Tie it to that exact direct parent so
+    // an abrupt capture-engine exit cannot leave a privileged input streamer.
+    let parent = unsafe { libc::getppid() };
+    if unsafe { libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGKILL) } != 0
+        || unsafe { libc::getppid() } != parent
+    {
+        return Err(std::io::Error::other("failed to bind input helper to its parent").into());
+    }
     linux::run()
 }
 

--- a/packages/capture/src/bin/capture-engine.rs
+++ b/packages/capture/src/bin/capture-engine.rs
@@ -18,10 +18,14 @@ fn main() {
 }
 
 fn run() -> Result<(), capture::CaptureError> {
+    capture::parent_watch::install_parent_death_guard()?;
     let mut reader = BufReader::new(io::stdin().lock());
     let mut output = io::stdout().lock();
     let mut engine = Engine::default();
     loop {
+        if capture::parent_watch::parent_death_requested() {
+            break;
+        }
         let request = match read_json_line::<RequestEnvelope>(&mut reader) {
             Ok(Some(request)) => request,
             Ok(None) => break,

--- a/packages/capture/src/error.rs
+++ b/packages/capture/src/error.rs
@@ -79,6 +79,8 @@ pub enum CaptureError {
     Serialization(#[from] serde_json::Error),
     #[error("backend error: {0}")]
     Backend(String),
+    #[error("parent-death guard unavailable: {0}")]
+    ParentDeathGuard(String),
     #[error("operation cancelled")]
     Cancelled,
     #[error("{code}: {message}", code = code.as_str())]
@@ -110,6 +112,7 @@ impl CaptureError {
             Self::Serialization(_) => "serialization-error",
             Self::Backend(_) => "capture-error",
             Self::Cancelled => "cancelled",
+            Self::ParentDeathGuard(_) => "parent-death-guard-unavailable",
         }
     }
 
@@ -118,5 +121,9 @@ impl CaptureError {
             code,
             message: message.into(),
         }
+    }
+
+    pub(crate) fn parent_death_unavailable(message: impl Into<String>) -> Self {
+        Self::ParentDeathGuard(message.into())
     }
 }

--- a/packages/capture/src/lib.rs
+++ b/packages/capture/src/lib.rs
@@ -6,6 +6,7 @@ pub mod cursor;
 pub mod error;
 pub mod input;
 pub mod model;
+pub mod parent_watch;
 pub mod protocol;
 pub mod screen;
 pub mod session;

--- a/packages/capture/src/parent_watch/mod.rs
+++ b/packages/capture/src/parent_watch/mod.rs
@@ -1,0 +1,329 @@
+//! Independent parent-death protection for the capture engine.
+//!
+//! Electron lifecycle hooks cannot run after `kill -9`, `TerminateProcess`, a
+//! native crash, or a main thread stuck before its hooks. The engine therefore
+//! arms an OS-level parent-death guard at startup and, on supported platforms,
+//! runs a watchdog thread that is independent of the command loop so a capture
+//! command blocked in a native call cannot prevent termination.
+//!
+//! The guard never trusts a reusable PID alone: Windows opens the exact parent
+//! process object, while Linux and macOS close the arm/check race explicitly.
+
+use crate::CaptureError;
+
+/// Environment variable carrying the owning Electron main process PID.
+pub const PARENT_PID_ENV: &str = "BEAM_PARENT_PID";
+/// Grace period after parent death before the watchdog force-exits the engine,
+/// giving the command loop a chance to shut down cooperatively first.
+pub const FORCED_EXIT_DEADLINE_MS: u64 = 3_000;
+
+/// Install the platform parent-death guard and spawn the watchdog thread.
+///
+/// Returns `Ok` when the guard is active, or when no owner PID was provided
+/// (a direct engine invocation falls back to stdin EOF). Returns an error when
+/// a guard is required but cannot be established, so startup fails closed
+/// rather than running without parent ownership.
+pub fn install_parent_death_guard() -> Result<(), CaptureError> {
+    #[cfg(target_os = "linux")]
+    return linux::install();
+
+    #[cfg(windows)]
+    return windows_guard::install();
+
+    #[cfg(target_os = "macos")]
+    return macos::install();
+
+    #[allow(unreachable_code)]
+    Ok(())
+}
+
+/// Whether the parent-death signal has been observed, so the command loop can
+/// shut down cooperatively between requests.
+#[must_use]
+pub fn parent_death_requested() -> bool {
+    #[cfg(target_os = "linux")]
+    return linux::parent_died();
+
+    #[cfg(windows)]
+    return windows_guard::parent_died();
+
+    #[cfg(target_os = "macos")]
+    return macos::parent_died();
+
+    #[cfg(not(any(target_os = "linux", windows, target_os = "macos")))]
+    return false;
+}
+
+#[cfg(windows)]
+mod windows_guard {
+    use std::{
+        ffi::c_void,
+        mem::size_of,
+        sync::atomic::{AtomicBool, Ordering},
+    };
+
+    use windows::Win32::{
+        Foundation::{CloseHandle, FILETIME, HANDLE, WAIT_FAILED, WAIT_OBJECT_0},
+        System::{
+            JobObjects::{
+                AssignProcessToJobObject, CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+                JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectExtendedLimitInformation,
+                SetInformationJobObject,
+            },
+            Threading::{
+                GetCurrentProcess, GetProcessTimes, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+                PROCESS_SYNCHRONIZE, TerminateProcess, WaitForSingleObject,
+            },
+        },
+    };
+    use windows::core::PCWSTR;
+
+    use super::{FORCED_EXIT_DEADLINE_MS, parent_pid_from_env};
+    use crate::CaptureError;
+
+    static PARENT_DIED: AtomicBool = AtomicBool::new(false);
+
+    #[must_use]
+    pub(super) fn parent_died() -> bool {
+        PARENT_DIED.load(Ordering::SeqCst)
+    }
+
+    pub(super) fn install() -> Result<(), CaptureError> {
+        let Some(parent_pid) = parent_pid_from_env() else {
+            return Ok(());
+        };
+        let job = create_kill_on_close_job()?;
+        let parent = unsafe {
+            OpenProcess(
+                PROCESS_SYNCHRONIZE | PROCESS_QUERY_LIMITED_INFORMATION,
+                false,
+                parent_pid,
+            )
+        }
+        .map_err(|_| {
+            close(job);
+            CaptureError::parent_death_unavailable("failed to open the owning Electron process")
+        })?;
+        let current = unsafe { GetCurrentProcess() };
+        if creation_time(parent)
+            .ok()
+            .zip(creation_time(current).ok())
+            .is_none_or(|(parent_created, engine_created)| parent_created >= engine_created)
+        {
+            close(parent);
+            close(job);
+            return Err(CaptureError::parent_death_unavailable(
+                "the Electron parent identity could not be verified",
+            ));
+        }
+        let parent_raw = parent.0 as usize;
+        std::thread::Builder::new()
+            .name("capture-parent-watchdog".to_owned())
+            .spawn(move || {
+                let parent = HANDLE(parent_raw as *mut c_void);
+                let result = unsafe { WaitForSingleObject(parent, u32::MAX) };
+                let _ = unsafe { CloseHandle(parent) };
+                if result == WAIT_OBJECT_0 {
+                    PARENT_DIED.store(true, Ordering::SeqCst);
+                    std::thread::sleep(std::time::Duration::from_millis(FORCED_EXIT_DEADLINE_MS));
+                    let _ = unsafe { TerminateProcess(GetCurrentProcess(), 1) };
+                } else if result == WAIT_FAILED {
+                    let _ = unsafe { TerminateProcess(GetCurrentProcess(), 1) };
+                }
+            })
+            .map_err(|_| {
+                close(parent);
+                close(job);
+                CaptureError::parent_death_unavailable("failed to spawn the watchdog thread")
+            })?;
+
+        // Intentionally retain this handle for the lifetime of the engine.
+        // Windows closes it on every exit path, killing every process assigned
+        // to the job even when Electron terminates the engine abruptly.
+        // `HANDLE` has no Rust destructor; leaving scope deliberately keeps the
+        // kernel handle open until process teardown.
+        let _job_lifetime = job;
+        Ok(())
+    }
+
+    fn create_kill_on_close_job() -> Result<HANDLE, CaptureError> {
+        let job = unsafe { CreateJobObjectW(None, PCWSTR::null()) }.map_err(|_| {
+            CaptureError::parent_death_unavailable("failed to create the capture Job Object")
+        })?;
+        let mut limits = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+        limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        let configured = unsafe {
+            SetInformationJobObject(
+                job,
+                JobObjectExtendedLimitInformation,
+                &limits as *const _ as *const c_void,
+                u32::try_from(size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>())
+                    .unwrap_or(u32::MAX),
+            )
+        };
+        if configured.is_err()
+            || unsafe { AssignProcessToJobObject(job, GetCurrentProcess()) }.is_err()
+        {
+            close(job);
+            return Err(CaptureError::parent_death_unavailable(
+                "failed to configure the capture Job Object",
+            ));
+        }
+        Ok(job)
+    }
+
+    fn close(handle: HANDLE) {
+        let _ = unsafe { CloseHandle(handle) };
+    }
+
+    fn creation_time(handle: HANDLE) -> windows::core::Result<u64> {
+        let mut created = FILETIME::default();
+        let mut exited = FILETIME::default();
+        let mut kernel = FILETIME::default();
+        let mut user = FILETIME::default();
+        unsafe { GetProcessTimes(handle, &mut created, &mut exited, &mut kernel, &mut user) }?;
+        Ok((u64::from(created.dwHighDateTime) << 32) | u64::from(created.dwLowDateTime))
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use super::{FORCED_EXIT_DEADLINE_MS, parent_pid_from_env};
+    use crate::CaptureError;
+
+    static PARENT_DIED: AtomicBool = AtomicBool::new(false);
+
+    #[must_use]
+    pub(super) fn parent_died() -> bool {
+        PARENT_DIED.load(Ordering::SeqCst)
+    }
+
+    pub(super) fn install() -> Result<(), CaptureError> {
+        let Some(parent_pid) = parent_pid_from_env() else {
+            return Ok(());
+        };
+        let recorded_parent = libc::pid_t::try_from(parent_pid).unwrap_or(-1);
+        if unsafe { libc::getppid() } != recorded_parent {
+            PARENT_DIED.store(true, Ordering::SeqCst);
+        }
+        std::thread::Builder::new()
+            .name("capture-parent-watchdog".to_owned())
+            .spawn(move || watch(recorded_parent))
+            .map_err(|_| {
+                CaptureError::parent_death_unavailable("failed to spawn the watchdog thread")
+            })?;
+        Ok(())
+    }
+
+    fn watch(parent: libc::pid_t) {
+        if !parent_died() {
+            let queue = unsafe { libc::kqueue() };
+            if queue < 0 {
+                unsafe { libc::_exit(1) };
+            }
+            let mut change = libc::kevent {
+                ident: parent as libc::uintptr_t,
+                filter: libc::EVFILT_PROC,
+                flags: libc::EV_ADD | libc::EV_ENABLE | libc::EV_ONESHOT,
+                fflags: libc::NOTE_EXIT,
+                data: 0,
+                udata: std::ptr::null_mut(),
+            };
+            let mut event: libc::kevent = unsafe { std::mem::zeroed() };
+            let observed =
+                unsafe { libc::kevent(queue, &change, 1, &mut event, 1, std::ptr::null()) };
+            unsafe { libc::close(queue) };
+            if observed <= 0 {
+                unsafe { libc::_exit(1) };
+            }
+            PARENT_DIED.store(true, Ordering::SeqCst);
+        }
+        std::thread::sleep(std::time::Duration::from_millis(FORCED_EXIT_DEADLINE_MS));
+        unsafe { libc::_exit(1) };
+    }
+}
+
+#[must_use]
+pub fn parent_pid_from_env() -> Option<u32> {
+    std::env::var(PARENT_PID_ENV)
+        .ok()
+        .and_then(|value| value.parse::<u32>().ok())
+}
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use super::{FORCED_EXIT_DEADLINE_MS, parent_pid_from_env};
+    use crate::CaptureError;
+
+    static PARENT_DIED: AtomicBool = AtomicBool::new(false);
+
+    /// Parent-death signal handler. Only stores an async-signal-safe atomic; all
+    /// work happens on the watchdog thread or in the command loop.
+    extern "C" fn on_parent_death(_signal: libc::c_int) {
+        PARENT_DIED.store(true, Ordering::SeqCst);
+    }
+
+    #[must_use]
+    pub(super) fn parent_died() -> bool {
+        PARENT_DIED.load(Ordering::SeqCst)
+    }
+
+    pub(super) fn install() -> Result<(), CaptureError> {
+        let Some(parent_pid) = parent_pid_from_env() else {
+            return Ok(());
+        };
+
+        let mut action: libc::sigaction = unsafe { std::mem::zeroed() };
+        action.sa_sigaction = on_parent_death as *const () as usize;
+        unsafe { libc::sigemptyset(&mut action.sa_mask) };
+        // No SA_RESTART: the death signal must surface through a blocking
+        // command syscall so the cooperative path can observe it promptly.
+        action.sa_flags = 0;
+        if unsafe { libc::sigaction(libc::SIGTERM, &action, std::ptr::null_mut()) } != 0 {
+            return Err(CaptureError::parent_death_unavailable(
+                "failed to install the SIGTERM handler",
+            ));
+        }
+
+        // Arm the kernel parent-death relationship: the kernel delivers SIGTERM
+        // when the forking parent thread dies.
+        if unsafe { libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGTERM) } != 0 {
+            return Err(CaptureError::parent_death_unavailable(
+                "PR_SET_PDEATHSIG failed",
+            ));
+        }
+
+        // Close the fork/exec race: if the owner died before the signal was
+        // armed, the kernel already reparented us and getppid() differs.
+        let recorded_parent = libc::pid_t::try_from(parent_pid).unwrap_or(-1);
+        if unsafe { libc::getppid() } != recorded_parent {
+            unsafe { libc::raise(libc::SIGTERM) };
+            return Ok(());
+        }
+
+        std::thread::Builder::new()
+            .name("capture-parent-watchdog".to_owned())
+            .spawn(move || {
+                while !parent_died() {
+                    std::thread::sleep(std::time::Duration::from_millis(100));
+                }
+                crate::screen::linux::terminate_owned_descendants();
+                // Cooperative shutdown first: the command loop checks
+                // `parent_death_requested()` between requests. If it is blocked
+                // in a native call it cannot respond, so force-exit after the
+                // crash deadline.
+                std::thread::sleep(std::time::Duration::from_millis(FORCED_EXIT_DEADLINE_MS));
+                crate::screen::linux::terminate_owned_descendants();
+                std::process::exit(1);
+            })
+            .map_err(|_| {
+                CaptureError::parent_death_unavailable("failed to spawn the watchdog thread")
+            })?;
+
+        Ok(())
+    }
+}

--- a/packages/capture/src/screen/linux/ffmpeg.rs
+++ b/packages/capture/src/screen/linux/ffmpeg.rs
@@ -8,7 +8,7 @@ use std::{
 
 use crate::{CaptureError, NativeCaptureErrorCode};
 
-use super::{FfmpegAcceleration, FfmpegEncoder};
+use super::{FfmpegAcceleration, FfmpegEncoder, owned_child};
 
 const FFMPEG_PATH_ENV: &str = "BEAM_FFMPEG_PATH";
 const FFMPEG_PROBE_TIMEOUT: Duration = Duration::from_secs(3);
@@ -163,15 +163,17 @@ fn probe_hardware_encoder(executable: &Path, encoder: &FfmpegEncoder) -> bool {
         "null".into(),
         "-".into(),
     ]);
-    let Ok(mut child) = Command::new(executable)
+    let mut command = Command::new(executable);
+    command
         .args(arguments)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-    else {
+        .stderr(Stdio::null());
+    owned_child::configure(&mut command);
+    let Ok(mut child) = command.spawn() else {
         return false;
     };
+    owned_child::register(&child);
     wait_for_probe(&mut child).is_some_and(|status| status.success())
 }
 
@@ -179,13 +181,15 @@ fn wait_for_probe(child: &mut std::process::Child) -> Option<std::process::ExitS
     let deadline = Instant::now() + FFMPEG_PROBE_TIMEOUT;
     loop {
         match child.try_wait() {
-            Ok(Some(status)) => return Some(status),
+            Ok(Some(status)) => {
+                owned_child::unregister(child);
+                return Some(status);
+            }
             Ok(None) if Instant::now() < deadline => {
                 std::thread::sleep(Duration::from_millis(10));
             }
             _ => {
-                let _ = child.kill();
-                let _ = child.wait();
+                owned_child::kill_and_wait(child);
                 return None;
             }
         }
@@ -193,34 +197,41 @@ fn wait_for_probe(child: &mut std::process::Child) -> Option<std::process::ExitS
 }
 
 fn run(executable: &Path, arguments: &[&str]) -> Result<String, CaptureError> {
-    let mut child = Command::new(executable)
+    let mut command = Command::new(executable);
+    command
         .args(arguments)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .map_err(|error| {
-            ffmpeg_error(
-                NativeCaptureErrorCode::FfmpegUnavailable,
-                format!(
-                    "failed to execute {}: {error}. Install FFmpeg or set {FFMPEG_PATH_ENV}",
-                    executable.display()
-                ),
-            )
-        })?;
+        .stderr(Stdio::piped());
+    owned_child::configure(&mut command);
+    let mut child = command.spawn().map_err(|error| {
+        ffmpeg_error(
+            NativeCaptureErrorCode::FfmpegUnavailable,
+            format!(
+                "failed to execute {}: {error}. Install FFmpeg or set {FFMPEG_PATH_ENV}",
+                executable.display()
+            ),
+        )
+    })?;
+    owned_child::register(&child);
     let deadline = Instant::now() + FFMPEG_PROBE_TIMEOUT;
     let status = loop {
-        if let Some(status) = child.try_wait().map_err(|error| {
-            ffmpeg_error(
-                NativeCaptureErrorCode::FfmpegUnavailable,
-                format!("failed while waiting for {}: {error}", executable.display()),
-            )
-        })? {
-            break status;
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                owned_child::unregister(&child);
+                break status;
+            }
+            Err(error) => {
+                owned_child::kill_and_wait(&mut child);
+                return Err(ffmpeg_error(
+                    NativeCaptureErrorCode::FfmpegUnavailable,
+                    format!("failed while waiting for {}: {error}", executable.display()),
+                ));
+            }
+            Ok(None) => {}
         }
         if Instant::now() >= deadline {
-            let _ = child.kill();
-            let _ = child.wait();
+            owned_child::kill_and_wait(&mut child);
             return Err(ffmpeg_error(
                 NativeCaptureErrorCode::FfmpegUnavailable,
                 format!("{} capability probe timed out", executable.display()),

--- a/packages/capture/src/screen/linux/ffmpeg_process.rs
+++ b/packages/capture/src/screen/linux/ffmpeg_process.rs
@@ -8,7 +8,7 @@ use std::{
 
 use crate::{CaptureError, NativeCaptureErrorCode, screen::OwnedVideoFrame};
 
-use super::FfmpegCapabilities;
+use super::{FfmpegCapabilities, owned_child};
 
 const MAX_STDERR_BYTES: usize = 64 * 1024;
 
@@ -53,37 +53,42 @@ impl FfmpegProcess {
         })?;
         std::fs::create_dir_all(parent).map_err(|error| CaptureError::storage(parent, error))?;
         let arguments = arguments(&config, &partial_path);
-        let mut child = Command::new(&config.capabilities.executable)
+        let mut command = Command::new(&config.capabilities.executable);
+        command
             .args(&arguments)
             .stdin(Stdio::piped())
             .stdout(Stdio::null())
-            .stderr(Stdio::piped())
-            .spawn()
-            .map_err(|error| {
-                ffmpeg_error(
-                    NativeCaptureErrorCode::FfmpegUnavailable,
-                    format!(
-                        "failed to start {}: {error}",
-                        config.capabilities.executable.display()
-                    ),
-                )
-            })?;
-        let stdin = child.stdin.take().ok_or_else(|| {
+            .stderr(Stdio::piped());
+        owned_child::configure(&mut command);
+        let mut child = command.spawn().map_err(|error| {
             ffmpeg_error(
+                NativeCaptureErrorCode::FfmpegUnavailable,
+                format!(
+                    "failed to start {}: {error}",
+                    config.capabilities.executable.display()
+                ),
+            )
+        })?;
+        owned_child::register(&child);
+        let Some(stdin) = child.stdin.take() else {
+            owned_child::kill_and_wait(&mut child);
+            return Err(ffmpeg_error(
                 NativeCaptureErrorCode::FfmpegFailed,
                 "FFmpeg did not expose its input pipe",
-            )
-        })?;
-        let stderr = child.stderr.take().ok_or_else(|| {
-            ffmpeg_error(
+            ));
+        };
+        let Some(stderr) = child.stderr.take() else {
+            owned_child::kill_and_wait(&mut child);
+            return Err(ffmpeg_error(
                 NativeCaptureErrorCode::FfmpegFailed,
                 "FFmpeg did not expose its diagnostic pipe",
-            )
-        })?;
-        let stderr = std::thread::Builder::new()
+            ));
+        };
+        let stderr_reader = std::thread::Builder::new()
             .name("beam-ffmpeg-stderr".into())
             .spawn(move || drain_stderr(stderr))
             .map_err(|error| {
+                owned_child::kill_and_wait(&mut child);
                 ffmpeg_error(
                     NativeCaptureErrorCode::FfmpegFailed,
                     format!("failed to start the FFmpeg diagnostic reader: {error}"),
@@ -92,7 +97,7 @@ impl FfmpegProcess {
         Ok(Self {
             child: Some(child),
             stdin: Some(stdin),
-            stderr: Some(stderr),
+            stderr: Some(stderr_reader),
             final_path,
             partial_path,
             frames: 0,
@@ -149,6 +154,9 @@ impl FfmpegProcess {
             .ok_or_else(|| ffmpeg_failed("FFmpeg process was already finalized"))?
             .wait()
             .map_err(ffmpeg_write_error)?;
+        if let Some(child) = self.child.as_ref() {
+            owned_child::unregister(child);
+        }
         self.child = None;
         let stderr = self
             .stderr
@@ -197,8 +205,7 @@ impl Drop for FfmpegProcess {
     fn drop(&mut self) {
         drop(self.stdin.take());
         if let Some(child) = self.child.as_mut() {
-            let _ = child.kill();
-            let _ = child.wait();
+            owned_child::kill_and_wait(child);
         }
         self.child = None;
         if let Some(stderr) = self.stderr.take() {

--- a/packages/capture/src/screen/linux/ffmpeg_process_tests.rs
+++ b/packages/capture/src/screen/linux/ffmpeg_process_tests.rs
@@ -1,6 +1,15 @@
 #![allow(clippy::expect_used)]
 
-use std::{fs, io::Write, os::unix::fs::PermissionsExt, path::Path, sync::Arc};
+use std::{
+    fs,
+    io::{BufRead, BufReader, Write},
+    os::unix::fs::PermissionsExt,
+    path::Path,
+    process::{Command, Stdio},
+    sync::{Arc, Mutex, OnceLock},
+    thread,
+    time::{Duration, Instant},
+};
 
 use crate::{
     model::RecordingSettings,
@@ -13,7 +22,77 @@ use crate::{
 use super::{
     FfmpegCapabilities, FfmpegEncoder, FfmpegScreenSink,
     ffmpeg_process::{FfmpegProcess, FfmpegProcessConfig, arguments, partial_path},
+    owned_child,
 };
+
+fn child_test_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("child test lock")
+}
+
+#[test]
+fn kill_and_wait_terminates_a_descendant_in_the_owned_process_group() {
+    let _lock = child_test_lock();
+    let mut command = Command::new("sh");
+    command
+        .args(["-c", "sleep 30 & printf '%s\\n' \"$!\"; wait"])
+        .stdout(Stdio::piped());
+    owned_child::configure(&mut command);
+    let mut child = command.spawn().expect("spawn process-group test child");
+    let child_pid = libc::pid_t::try_from(child.id()).expect("child pid fits pid_t");
+    let stdout = child.stdout.take().expect("child stdout");
+    let mut stdout = BufReader::new(stdout);
+    let mut line = String::new();
+    stdout.read_line(&mut line).expect("read descendant pid");
+    let descendant_pid = line.trim().parse::<libc::pid_t>().expect("descendant pid");
+    assert_eq!(unsafe { libc::kill(descendant_pid, 0) }, 0);
+
+    owned_child::kill_and_wait(&mut child);
+
+    assert!(child.try_wait().expect("reap direct child").is_some());
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while unsafe { libc::kill(descendant_pid, 0) } == 0 && Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(20));
+    }
+    assert_ne!(unsafe { libc::kill(descendant_pid, 0) }, 0);
+    assert_ne!(unsafe { libc::kill(-child_pid, 0) }, 0);
+}
+
+#[test]
+fn terminate_all_kills_registered_child_and_descendant_before_test_reaps_child() {
+    let _lock = child_test_lock();
+    let mut command = Command::new("sh");
+    command
+        .args(["-c", "sleep 30 & printf '%s\\n' \"$!\"; wait"])
+        .stdout(Stdio::piped());
+    owned_child::configure(&mut command);
+    let mut child = command
+        .spawn()
+        .expect("spawn registered process-group child");
+    let child_pid = libc::pid_t::try_from(child.id()).expect("child pid fits pid_t");
+    let stdout = child.stdout.take().expect("child stdout");
+    let mut stdout = BufReader::new(stdout);
+    let mut line = String::new();
+    stdout.read_line(&mut line).expect("read descendant pid");
+    drop(stdout);
+    let descendant_pid = line.trim().parse::<libc::pid_t>().expect("descendant pid");
+    assert_eq!(unsafe { libc::kill(descendant_pid, 0) }, 0);
+
+    owned_child::register(&child);
+    owned_child::terminate_all();
+    let status = child.wait().expect("reap registered child");
+    owned_child::unregister(&child);
+
+    assert!(!status.success());
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while unsafe { libc::kill(descendant_pid, 0) } == 0 && Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(20));
+    }
+    assert_ne!(unsafe { libc::kill(descendant_pid, 0) }, 0);
+    assert_ne!(unsafe { libc::kill(-child_pid, 0) }, 0);
+}
 
 fn capabilities() -> FfmpegCapabilities {
     FfmpegCapabilities {
@@ -116,6 +195,7 @@ fn frame(stride: usize, bytes: Vec<u8>) -> OwnedVideoFrame {
 
 #[test]
 fn process_writes_compact_rows_and_atomically_publishes_output() {
+    let _lock = child_test_lock();
     let (_fake, capabilities) = fake_ffmpeg(
         "#!/bin/sh\nfor output do :; done\nbytes=$(wc -c)\n[ \"$bytes\" -eq 16 ] || exit 9\nprintf 'fake-mp4' > \"$output\"\n",
     );
@@ -152,6 +232,7 @@ fn process_writes_compact_rows_and_atomically_publishes_output() {
 
 #[test]
 fn process_propagates_non_zero_exit_and_removes_partial_output() {
+    let _lock = child_test_lock();
     let (_fake, capabilities) = fake_ffmpeg(
         "#!/bin/sh\nfor output do :; done\nwc -c >/dev/null\nprintf 'broken' > \"$output\"\nprintf 'encoder exploded' >&2\nexit 7\n",
     );
@@ -183,6 +264,7 @@ fn process_propagates_non_zero_exit_and_removes_partial_output() {
 
 #[test]
 fn process_rejects_a_segment_without_frames() {
+    let _lock = child_test_lock();
     let (_fake, capabilities) = fake_ffmpeg(
         "#!/bin/sh\nfor output do :; done\nwc -c >/dev/null\nprintf 'header-only' > \"$output\"\n",
     );
@@ -205,6 +287,7 @@ fn process_rejects_a_segment_without_frames() {
 
 #[test]
 fn sink_accepts_the_initial_segment_when_format_arrives_before_frames_and_stop() {
+    let _lock = child_test_lock();
     let (_fake, capabilities) = fake_ffmpeg(
         "#!/bin/sh\nfor output do :; done\nbytes=$(wc -c)\n[ \"$bytes\" -eq 16 ] || exit 9\nprintf 'fake-mp4' > \"$output\"\n",
     );
@@ -258,6 +341,7 @@ fn sink_accepts_the_initial_segment_when_format_arrives_before_frames_and_stop()
 #[test]
 #[ignore = "requires the system FFmpeg runtime"]
 fn system_ffmpeg_encodes_a_playable_mp4_segment() {
+    let _lock = child_test_lock();
     let capabilities = super::probe_ffmpeg().expect("system FFmpeg capabilities");
     let output_directory = tempfile::tempdir().expect("temporary output");
     let output = output_directory.path().join("segment-0001.mp4");
@@ -288,11 +372,11 @@ fn system_ffmpeg_encodes_a_playable_mp4_segment() {
                 pixels: Arc::from(vec![shade; frame_bytes]),
             })
             .expect("write system FFmpeg frame");
-        std::thread::sleep(std::time::Duration::from_millis(20));
+        thread::sleep(Duration::from_millis(20));
     }
     process.finish().expect("finalize system FFmpeg");
     assert!(fs::metadata(&output).expect("MP4 metadata").len() > 0);
-    let validation = std::process::Command::new(&capabilities.executable)
+    let validation = Command::new(&capabilities.executable)
         .args(["-hide_banner", "-loglevel", "error", "-i"])
         .arg(&output)
         .args(["-f", "null", "-"])

--- a/packages/capture/src/screen/linux/input_monitor.rs
+++ b/packages/capture/src/screen/linux/input_monitor.rs
@@ -15,6 +15,8 @@ use crate::{
     input::{InputAccessStatus, NativeInputEvent},
 };
 
+use super::owned_child;
+
 const INSTALLED_HELPER: &str = "/usr/libexec/beam-input-helper";
 
 struct BrokerShared {
@@ -111,34 +113,50 @@ pub fn request_linux_input_access() -> Result<InputAccessStatus, CaptureError> {
     }
     broker.stop();
 
-    let mut child = Command::new("pkexec")
+    let mut command = Command::new("pkexec");
+    command
         .arg(helper)
         .arg("stream")
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
-        .stderr(Stdio::null())
+        .stderr(Stdio::null());
+    owned_child::configure(&mut command);
+    let mut child = command
         .spawn()
         .map_err(|error| CaptureError::Backend(format!("input helper failed to start: {error}")))?;
-    let stdout = child
-        .stdout
-        .take()
-        .ok_or_else(|| CaptureError::Backend("input helper stdout was unavailable".into()))?;
+    owned_child::register(&child);
+    let Some(stdout) = child.stdout.take() else {
+        owned_child::kill_and_wait(&mut child);
+        return Err(CaptureError::Backend(
+            "input helper stdout was unavailable".into(),
+        ));
+    };
     let mut reader = BufReader::new(stdout);
     let mut ready_line = String::new();
-    if reader
-        .read_line(&mut ready_line)
-        .map_err(|error| CaptureError::Backend(format!("input helper readiness failed: {error}")))?
-        == 0
-    {
-        let _ = child.wait();
-        return Err(CaptureError::PermissionDenied(
-            "interaction access was not authorized".into(),
-        ));
+    match reader.read_line(&mut ready_line) {
+        Ok(0) => {
+            owned_child::kill_and_wait(&mut child);
+            return Err(CaptureError::PermissionDenied(
+                "interaction access was not authorized".into(),
+            ));
+        }
+        Err(error) => {
+            owned_child::kill_and_wait(&mut child);
+            return Err(CaptureError::Backend(format!(
+                "input helper readiness failed: {error}"
+            )));
+        }
+        Ok(_) => {}
     }
-    let ready: serde_json::Value = serde_json::from_str(&ready_line)?;
+    let ready: serde_json::Value = match serde_json::from_str(&ready_line) {
+        Ok(ready) => ready,
+        Err(error) => {
+            owned_child::kill_and_wait(&mut child);
+            return Err(error.into());
+        }
+    };
     if ready.get("event").and_then(serde_json::Value::as_str) != Some("ready") {
-        let _ = child.kill();
-        let _ = child.wait();
+        owned_child::kill_and_wait(&mut child);
         return Err(CaptureError::Backend(
             "input helper returned an invalid readiness response".into(),
         ));
@@ -165,27 +183,32 @@ pub fn request_linux_input_access() -> Result<InputAccessStatus, CaptureError> {
     broker.shared.ready.store(true, Ordering::Release);
 
     let shared = broker.shared.clone();
-    broker.reader = Some(
-        std::thread::Builder::new()
-            .name("beam-linux-input-broker".into())
-            .spawn(move || {
-                for line in reader.lines().map_while(Result::ok) {
-                    let Ok(event) = serde_json::from_str::<NativeInputEvent>(&line) else {
-                        continue;
-                    };
-                    if let Ok(mut subscribers) = shared.subscribers.lock() {
-                        subscribers.retain(|subscriber| subscriber.send(event.clone()).is_ok());
-                    }
-                }
-                shared.ready.store(false, Ordering::Release);
+    let reader_thread = std::thread::Builder::new()
+        .name("beam-linux-input-broker".into())
+        .spawn(move || {
+            for line in reader.lines().map_while(Result::ok) {
+                let Ok(event) = serde_json::from_str::<NativeInputEvent>(&line) else {
+                    continue;
+                };
                 if let Ok(mut subscribers) = shared.subscribers.lock() {
-                    subscribers.clear();
+                    subscribers.retain(|subscriber| subscriber.send(event.clone()).is_ok());
                 }
-            })
-            .map_err(|error| {
-                CaptureError::Backend(format!("input broker reader failed to start: {error}"))
-            })?,
-    );
+            }
+            shared.ready.store(false, Ordering::Release);
+            if let Ok(mut subscribers) = shared.subscribers.lock() {
+                subscribers.clear();
+            }
+        });
+    let reader_thread = match reader_thread {
+        Ok(reader_thread) => reader_thread,
+        Err(error) => {
+            owned_child::kill_and_wait(&mut child);
+            return Err(CaptureError::Backend(format!(
+                "input broker reader failed to start: {error}"
+            )));
+        }
+    };
+    broker.reader = Some(reader_thread);
     broker.child = Some(child);
     Ok(linux_input_access_status_from(&broker))
 }
@@ -200,8 +223,7 @@ impl LinuxInputBroker {
     fn stop(&mut self) {
         self.shared.ready.store(false, Ordering::Release);
         if let Some(mut child) = self.child.take() {
-            let _ = child.kill();
-            let _ = child.wait();
+            owned_child::kill_and_wait(&mut child);
         }
         if let Some(reader) = self.reader.take() {
             let _ = reader.join();
@@ -240,18 +262,19 @@ fn ensure_installed_helper() -> Result<PathBuf, CaptureError> {
         && bundled != installed
         && (!executable_file(&installed) || helper_version(&bundled) != helper_version(&installed))
     {
-        let status = Command::new("pkexec")
+        let mut command = Command::new("pkexec");
+        command
             .arg(&bundled)
             .arg("install")
             .stdin(Stdio::null())
             .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .map_err(|error| {
-                CaptureError::Backend(format!(
-                    "input helper installation failed to start: {error}"
-                ))
-            })?;
+            .stderr(Stdio::null());
+        owned_child::configure(&mut command);
+        let status = command.status().map_err(|error| {
+            CaptureError::Backend(format!(
+                "input helper installation failed to start: {error}"
+            ))
+        })?;
         if !status.success() {
             return Err(CaptureError::PermissionDenied(
                 "interaction access installation was not authorized".into(),
@@ -264,11 +287,10 @@ fn ensure_installed_helper() -> Result<PathBuf, CaptureError> {
 }
 
 fn helper_version(path: &Path) -> Option<(String, u64)> {
-    let output = Command::new(path)
-        .arg("version")
-        .stdin(Stdio::null())
-        .output()
-        .ok()?;
+    let mut command = Command::new(path);
+    command.arg("version").stdin(Stdio::null());
+    owned_child::configure(&mut command);
+    let output = command.output().ok()?;
     if !output.status.success() {
         return None;
     }

--- a/packages/capture/src/screen/linux/mod.rs
+++ b/packages/capture/src/screen/linux/mod.rs
@@ -8,6 +8,7 @@ mod ffmpeg_sink;
 mod input_monitor;
 #[cfg(test)]
 mod input_monitor_tests;
+mod owned_child;
 mod pipewire;
 mod portal;
 mod recording;
@@ -21,4 +22,5 @@ pub(crate) use input_monitor::{LinuxInputMonitor, input_helper_supported};
 pub use input_monitor::{
     linux_input_access_status, request_linux_input_access, shutdown_linux_input_access,
 };
+pub(crate) use owned_child::terminate_all as terminate_owned_descendants;
 pub use recording::*;

--- a/packages/capture/src/screen/linux/owned_child.rs
+++ b/packages/capture/src/screen/linux/owned_child.rs
@@ -1,0 +1,72 @@
+use std::{
+    io,
+    os::unix::process::CommandExt,
+    process::{Child, Command},
+    sync::{Mutex, OnceLock},
+};
+
+fn process_groups() -> &'static Mutex<Vec<libc::pid_t>> {
+    static GROUPS: OnceLock<Mutex<Vec<libc::pid_t>>> = OnceLock::new();
+    GROUPS.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+/// Put a native helper in its own process group and bind it to the capture
+/// engine. The parent check closes the fork/exec race after `PR_SET_PDEATHSIG`.
+pub(super) fn configure(command: &mut Command) {
+    let expected_parent = unsafe { libc::getpid() };
+    unsafe {
+        command.pre_exec(move || {
+            if libc::setpgid(0, 0) != 0 {
+                return Err(io::Error::last_os_error());
+            }
+            if libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGKILL) != 0 {
+                return Err(io::Error::last_os_error());
+            }
+            if libc::getppid() != expected_parent {
+                return Err(io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    "capture parent exited",
+                ));
+            }
+            Ok(())
+        });
+    }
+}
+
+pub(super) fn register(child: &Child) {
+    if let Ok(pid) = libc::pid_t::try_from(child.id())
+        && let Ok(mut groups) = process_groups().lock()
+        && !groups.contains(&pid)
+    {
+        groups.push(pid);
+    }
+}
+
+pub(super) fn unregister(child: &Child) {
+    if let Ok(pid) = libc::pid_t::try_from(child.id())
+        && let Ok(mut groups) = process_groups().lock()
+    {
+        groups.retain(|group| *group != pid);
+    }
+}
+
+/// Called by the independent parent watchdog before it force-exits the engine.
+pub(crate) fn terminate_all() {
+    let groups = process_groups()
+        .lock()
+        .map_or_else(|_| Vec::new(), |groups| groups.clone());
+    for group in groups {
+        let _ = unsafe { libc::kill(-group, libc::SIGKILL) };
+    }
+}
+
+/// Kill the complete owned process group, then reap the direct child.
+pub(super) fn kill_and_wait(child: &mut Child) {
+    if child.try_wait().ok().flatten().is_none()
+        && let Ok(pid) = libc::pid_t::try_from(child.id())
+    {
+        let _ = unsafe { libc::kill(-pid, libc::SIGKILL) };
+    }
+    let _ = child.wait();
+    unregister(child);
+}

--- a/scripts/dev/electron.cjs
+++ b/scripts/dev/electron.cjs
@@ -62,7 +62,7 @@ async function startElectron(executable, { root = applicationRoot, spawnImpl = s
   await runCommand(
     process.execPath,
     [electronCli, '.'],
-    { cwd: root, env: { ...env, DEMO_RECORDER_CAPTURE_ENGINE: executable } },
+    { cwd: root, env: { ...env, BEAM_CAPTURE_ENGINE: executable } },
     spawnImpl,
   );
 }

--- a/scripts/linux/verify-parent-death.sh
+++ b/scripts/linux/verify-parent-death.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+engine_path=${1:?usage: verify-parent-death.sh /absolute/path/to/capture-engine}
+case "$engine_path" in
+  /*) ;;
+  *) echo "capture-engine path must be absolute" >&2; exit 2 ;;
+esac
+test -x "$engine_path"
+
+test_root=$(mktemp -d)
+writer_pid=
+owner_pid=
+engine_pid=
+cleanup() {
+  if test -n "$owner_pid"; then
+    kill -KILL "$owner_pid" 2>/dev/null || true
+    wait "$owner_pid" 2>/dev/null || true
+  fi
+  if test -n "$engine_pid"; then
+    kill -KILL "$engine_pid" 2>/dev/null || true
+  fi
+  if test -n "$writer_pid"; then
+    kill "$writer_pid" 2>/dev/null || true
+    wait "$writer_pid" 2>/dev/null || true
+  fi
+  rm -rf -- "$test_root"
+}
+trap cleanup EXIT
+
+mkfifo "$test_root/engine-stdin"
+tail -f /dev/null >"$test_root/engine-stdin" &
+writer_pid=$!
+
+bash -c '
+  BEAM_PARENT_PID=$$ "$1" <"$2/engine-stdin" >"$2/out" 2>"$2/err" &
+  printf "%s\n" "$!" >"$2/pid"
+  wait
+' _ "$engine_path" "$test_root" &
+owner_pid=$!
+
+deadline=$((SECONDS + 3))
+while ! test -s "$test_root/pid" && test "$SECONDS" -lt "$deadline"; do
+  read -r -t 0.1 _ </dev/null || true
+done
+test -s "$test_root/pid"
+
+engine_pid=$(sed -n '1p' "$test_root/pid")
+case "$engine_pid" in
+  ''|*[!0-9]*) echo "invalid engine PID" >&2; exit 1 ;;
+esac
+kill -KILL "$owner_pid"
+wait "$owner_pid" 2>/dev/null || true
+owner_pid=
+
+deadline=$((SECONDS + 6))
+while test -e "/proc/$engine_pid/exe" && test "$SECONDS" -lt "$deadline"; do
+  read -r -t 0.1 _ </dev/null || true
+done
+if test -e "/proc/$engine_pid/exe"; then
+  echo "capture-engine PID $engine_pid survived direct parent death" >&2
+  exit 1
+fi
+echo "PASS: capture-engine PID $engine_pid exited while stdin remained open"

--- a/scripts/windows/verify-process-lifecycle.ps1
+++ b/scripts/windows/verify-process-lifecycle.ps1
@@ -1,0 +1,80 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$BeamExecutable,
+  [ValidateSet('Close', 'Crash')]
+  [string]$ExitMode = 'Close',
+  [ValidateRange(1, 50)]
+  [int]$Iterations = 3,
+  [ValidateRange(1, 600)]
+  [int]$ObservationSeconds = 15,
+  [ValidateRange(1, 60)]
+  [int]$ExitDeadlineSeconds = 12
+)
+
+$ErrorActionPreference = 'Stop'
+$beamPath = [System.IO.Path]::GetFullPath($BeamExecutable)
+if (-not (Test-Path -LiteralPath $beamPath -PathType Leaf)) {
+  throw "Beam executable not found: $beamPath"
+}
+
+function Get-ProcessSnapshot {
+  @(Get-CimInstance Win32_Process | ForEach-Object {
+    [pscustomobject]@{
+      Id = [uint32]$_.ProcessId
+      ParentId = [uint32]$_.ParentProcessId
+      Path = $_.ExecutablePath
+      Name = $_.Name
+    }
+  })
+}
+
+function Get-Descendants([uint32]$RootId, [object[]]$Snapshot) {
+  $known = [System.Collections.Generic.HashSet[uint32]]::new()
+  [void]$known.Add($RootId)
+  $changed = $true
+  while ($changed) {
+    $changed = $false
+    foreach ($entry in $Snapshot) {
+      if ($known.Contains($entry.ParentId) -and $known.Add($entry.Id)) {
+        $changed = $true
+      }
+    }
+  }
+  @($Snapshot | Where-Object { $known.Contains($_.Id) })
+}
+
+for ($iteration = 1; $iteration -le $Iterations; $iteration += 1) {
+  $root = Start-Process -FilePath $beamPath -PassThru
+  Write-Host "[$iteration/$Iterations] Beam root PID $($root.Id) started from $beamPath"
+  Start-Sleep -Seconds $ObservationSeconds
+
+  $owned = Get-Descendants -RootId $root.Id -Snapshot (Get-ProcessSnapshot)
+  if (-not ($owned | Where-Object { $_.Id -eq $root.Id -and $_.Path -eq $beamPath })) {
+    throw "PID $($root.Id) no longer maps to the exact Beam path; refusing to inspect or stop it."
+  }
+  $owned | Sort-Object Id | Format-Table Id, ParentId, Name, Path -AutoSize
+
+  if ($ExitMode -eq 'Crash') {
+    Stop-Process -Id $root.Id -Force
+  } elseif (-not $root.CloseMainWindow()) {
+    throw "Beam PID $($root.Id) has no closable main window. Close it manually, then rerun the check."
+  }
+
+  $deadline = [DateTime]::UtcNow.AddSeconds($ExitDeadlineSeconds)
+  do {
+    $liveById = @{}
+    foreach ($entry in Get-ProcessSnapshot) { $liveById[$entry.Id] = $entry }
+    $survivors = @($owned | Where-Object {
+      $live = $liveById[$_.Id]
+      $null -ne $live -and $live.Path -eq $_.Path
+    })
+    if ($survivors.Count -eq 0) { break }
+    Start-Sleep -Milliseconds 200
+  } while ([DateTime]::UtcNow -lt $deadline)
+
+  if ($survivors.Count -gt 0) {
+    $details = $survivors | Format-Table Id, ParentId, Name, Path -AutoSize | Out-String
+    throw "Owned Beam processes survived $ExitMode beyond the deadline:`n$details"
+  }
+  Write-Host "[$iteration/$Iterations] PASS: every observed exact PID/path exited."
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -11,7 +11,9 @@ import type {
   RecordingBarVisibility,
   RecordingConfiguration,
   RecordingSessionResult,
+  RecordingStartFailure,
 } from './components/hud/recorder/recording-types';
+import { formatRecordingStartFailure } from './components/hud/recorder/recording-types';
 
 import { capture } from './api/capture';
 import { useLocaleStore } from './stores/locale';
@@ -55,7 +57,7 @@ const syncTrayMenu = () => {
     stopRecording: tRecorderBar('stopRecording'),
     quit: tHud('quit'),
     tooltip: 'Beam',
-    recording: ['countdown', 'recording', 'paused'].includes(recording.phase.value),
+    recording: ['countdown', 'starting', 'recording', 'paused'].includes(recording.phase.value),
   });
 };
 
@@ -103,11 +105,40 @@ const editorLoadError = ref('');
 const editorLoadingProgress = ref<EditorLoadingProgress>({ stage: 'openingWindow', value: 10 });
 
 const recordingBarVisibility = ref<RecordingBarVisibility>('always');
-const recording = useRecordingController((session) => {
-  void handleStopRecording(session);
-});
+const recordingStartupError = ref('');
+const recording = useRecordingController(
+  (session) => {
+    void handleStopRecording(session);
+  },
+  (failure) => {
+    handleRecordingStartupFailure(failure);
+  },
+);
 
-watch(recording.phase, () => syncTrayMenu(), { immediate: true });
+const returnToHud = () => {
+  if (currentView.value !== 'recorder') return;
+  capture.hideScreenRegionOverlay();
+  void capture.setCountdown(null);
+  capture.setCameraOverlayActive(true);
+  capture.showHud();
+  currentView.value = 'hud';
+};
+
+const handleRecordingStartupFailure = (failure: RecordingStartFailure) => {
+  recordingStartupError.value = formatRecordingStartFailure(failure);
+  returnToHud();
+};
+
+watch(
+  recording.phase,
+  (phase) => {
+    syncTrayMenu();
+    // Guarantee the recorder view never coexists with the idle phase, even if
+    // the failure callback above is bypassed or throws.
+    if (phase === 'idle') returnToHud();
+  },
+  { immediate: true },
+);
 
 watch(currentView, (view) => {
   if (view !== 'hud') return;
@@ -119,6 +150,7 @@ const isRecordingStartedFromEditor = ref(false);
 const startRecordingFromEditor = async (configuration: RecordingConfiguration) => {
   isRecordingStartedFromEditor.value = true;
   editorLoadError.value = '';
+  recordingStartupError.value = '';
   recordingBarVisibility.value = configuration.recordingBarVisibility;
   currentView.value = 'recorder';
   capture.setWindowMode('recorder');
@@ -126,10 +158,7 @@ const startRecordingFromEditor = async (configuration: RecordingConfiguration) =
   capture.setCameraOverlayActive(true);
   capture.resetCameraOverlayPlacement?.();
   await recording.start(configuration);
-  if (recording.phase.value === 'idle') {
-    currentView.value = 'hud';
-    capture.showHud();
-  }
+  if (recording.phase.value === 'idle') returnToHud();
 };
 
 onMounted(() => {
@@ -139,12 +168,13 @@ onMounted(() => {
   removeEditorLoadingListener = capture.onEditorLoadingProgress((progress) => {
     if (isPreparingEditor.value) editorLoadingProgress.value = progress;
   });
-  removeTrayStopListener = capture.onTrayStopRecording?.(() => {
-    void cancelOrStopRecording();
-  }) ?? null;
+  removeTrayStopListener =
+    capture.onTrayStopRecording?.(() => {
+      void cancelOrStopRecording();
+    }) ?? null;
   removeRecordingShortcutListener = capture.onPreferenceShortcut((actionId) => {
     if (actionId !== 'hud.startStopRecording') return;
-    if (!['countdown', 'recording', 'paused'].includes(recording.phase.value)) return;
+    if (!['countdown', 'starting', 'recording', 'paused'].includes(recording.phase.value)) return;
     void cancelOrStopRecording();
   });
 });
@@ -153,41 +183,28 @@ const startRecording = async (configuration: RecordingConfiguration) => {
   isRecordingStartedFromEditor.value = false;
   editorLoadError.value = '';
   currentProject.value = null;
+  recordingStartupError.value = '';
   recordingBarVisibility.value = configuration.recordingBarVisibility;
   currentView.value = 'recorder';
   capture.setWindowMode('recorder');
   capture.setCameraOverlayActive(true);
   capture.resetCameraOverlayPlacement?.();
   await recording.start(configuration);
-  if (recording.phase.value === 'idle') {
-    currentView.value = 'hud';
-    capture.setCameraOverlayActive(true);
-    capture.showHud();
-  }
+  if (recording.phase.value === 'idle') returnToHud();
 };
 
 const cancelOrStopRecording = async () => {
-  const wasCountdown = recording.phase.value === 'countdown';
-  if (!wasCountdown) capture.setCameraOverlayActive(false);
+  const wasStartup = recording.phase.value === 'countdown' || recording.phase.value === 'starting';
+  if (!wasStartup) capture.setCameraOverlayActive(false);
   await recording.stop();
-  if (!wasCountdown && recording.phase.value !== 'idle') capture.setCameraOverlayActive(true);
-  if (wasCountdown && currentView.value === 'recorder') {
-    capture.setWindowMode('hud');
-    capture.setSize(352, 512);
-    currentView.value = 'hud';
-  }
+  if (!wasStartup && recording.phase.value !== 'idle') capture.setCameraOverlayActive(true);
+  if (wasStartup) returnToHud();
 };
 
 const cancelRecording = async () => {
   await recording.cancel();
   if (recording.phase.value !== 'idle') return;
-  if (currentView.value === 'recorder') {
-    capture.setWindowMode('hud');
-    capture.setSize(352, 512);
-    currentView.value = 'hud';
-    capture.setCameraOverlayActive(true);
-    capture.showHud();
-  }
+  returnToHud();
 };
 
 const revealEditor = () => {
@@ -281,6 +298,7 @@ const dismissEditorLoadError = () => {
       v-if="currentView === 'hud' && !editorLoadError"
       :preparing-editor="isPreparingEditor"
       :editor-loading-progress="editorLoadingProgress"
+      :external-error="recordingStartupError"
       @start-recording="startRecording"
       @open-project="handleOpenProject"
     />

--- a/src/api/types/capture-api.ts
+++ b/src/api/types/capture-api.ts
@@ -46,6 +46,7 @@ export interface CaptureApi {
 
 export interface DesktopCaptureApi extends CaptureApi {
   close(): void;
+  quit(): void;
   minimize(): void;
   toggleDevTools?(): void;
   updateTrayMenu?(labels: {

--- a/src/components/hud/HUD.vue
+++ b/src/components/hud/HUD.vue
@@ -901,7 +901,7 @@ onBeforeUnmount(() => {
 });
 
 const closeApp = () => {
-  capture.close();
+  capture.quit();
 };
 
 const minimizeApp = () => {

--- a/src/components/hud/HUD.vue
+++ b/src/components/hud/HUD.vue
@@ -71,6 +71,7 @@ const props = withDefaults(
     embedded?: boolean;
     preparingEditor?: boolean;
     editorLoadingProgress?: EditorLoadingProgress;
+    externalError?: string;
   }>(),
   {
     embedded: false,
@@ -88,6 +89,7 @@ const activeTab = ref<'screen' | 'window'>('screen');
 const isRecording = ref(false);
 const isBusy = ref(false);
 const errorMessage = ref('');
+const shownError = computed(() => props.externalError || errorMessage.value);
 const copiedError = ref(false);
 let copiedErrorTimeout: ReturnType<typeof setTimeout> | null = null;
 const sources = ref<CaptureSource[]>([]);
@@ -364,7 +366,7 @@ const updateWindowSize = () => {
   if (props.embedded) return;
   const isDropdownOpen = activeDropdowns.value > 0;
   let targetHeight = 480;
-  const errorHeight = !showSettings.value && !showProjectPicker.value && errorMessage.value ? 116 : 0;
+  const errorHeight = !showSettings.value && !showProjectPicker.value && shownError.value ? 116 : 0;
   if (props.preparingEditor) {
     targetHeight = 480;
   } else if (showSettings.value) {
@@ -395,7 +397,7 @@ const updateWindowSize = () => {
     setTimeout(() => {
       const currentDropdownOpen = activeDropdowns.value > 0;
       let currentTargetHeight = 480;
-      const errorHeight = !showSettings.value && !showProjectPicker.value && errorMessage.value ? 116 : 0;
+      const errorHeight = !showSettings.value && !showProjectPicker.value && shownError.value ? 116 : 0;
       if (props.preparingEditor) {
         currentTargetHeight = 480;
       } else if (showSettings.value) {
@@ -428,7 +430,7 @@ const updateWindowSize = () => {
 
 const hudHeight = computed(() => {
   if (props.preparingEditor) return 480;
-  const errorHeight = !showSettings.value && !showProjectPicker.value && errorMessage.value ? 116 : 0;
+  const errorHeight = !showSettings.value && !showProjectPicker.value && shownError.value ? 116 : 0;
   if (showSettings.value || showProjectPicker.value) {
     return 520 + errorHeight;
   }
@@ -481,18 +483,18 @@ watch(showProjectPicker, () => {
   updateWindowSize();
 });
 
-watch(errorMessage, () => {
+watch(shownError, () => {
   copiedError.value = false;
   updateWindowSize();
 });
 
 const copyError = async () => {
-  if (!errorMessage.value) return;
+  if (!shownError.value) return;
   try {
-    await navigator.clipboard.writeText(errorMessage.value);
+    await navigator.clipboard.writeText(shownError.value);
   } catch {
     const text = document.createElement('textarea');
-    text.value = errorMessage.value;
+    text.value = shownError.value;
     text.setAttribute('readonly', '');
     text.style.position = 'fixed';
     text.style.opacity = '0';
@@ -1145,8 +1147,8 @@ const openProject = (project: CaptureProject) => {
           </Transition>
         </div>
 
-        <div v-if="errorMessage" class="capture-error" role="alert">
-          <p class="capture-error-message">{{ errorMessage }}</p>
+        <div v-if="shownError" class="capture-error" role="alert">
+          <p class="capture-error-message">{{ shownError }}</p>
           <Button
             variant="ghost"
             size="sm"

--- a/src/components/hud/recorder/RecorderBar.test.ts
+++ b/src/components/hud/recorder/RecorderBar.test.ts
@@ -100,6 +100,24 @@ describe('RecorderBar', () => {
     expect(wrapper.get('.recorder-bar').classes()).not.toContain('hover-only');
   });
 
+  it('shows the Preparing throbber and never the timer while starting', async () => {
+    const wrapper = mount(RecorderBar, {
+      props: { ...props, phase: 'starting' as const },
+    });
+    expect(wrapper.get('.recording-time').text()).toContain('Preparing');
+    expect(wrapper.get('.recording-time').text()).not.toContain('00:');
+    // Pause and the three device toggles are disabled during startup.
+    const controls = wrapper.findAll('.control');
+    expect(controls[0].attributes('disabled')).toBeDefined();
+    expect(controls[2].attributes('disabled')).toBeDefined();
+    expect(controls[3].attributes('disabled')).toBeDefined();
+    expect(controls[4].attributes('disabled')).toBeDefined();
+    // Stop and cancel stay available so startup can be aborted.
+    expect(controls[1].attributes('disabled')).toBeUndefined();
+    expect(controls[5].attributes('disabled')).toBeUndefined();
+    wrapper.unmount();
+  });
+
   it('keeps pause and stop clickable on their first pointer interaction', async () => {
     const wrapper = mount(RecorderBar, { props });
     const controls = wrapper.findAll('.control');

--- a/src/components/hud/recorder/RecorderBar.vue
+++ b/src/components/hud/recorder/RecorderBar.vue
@@ -5,6 +5,7 @@ import type { RecordingBarVisibility, RecordingPhase } from './recording-types';
 import { useTranslate } from '~/i18n/useTranslate';
 import { useAudioLevelMeter } from '../audio/useAudioLevelMeter';
 import AudioIconMeter from '../audio/AudioIconMeter.vue';
+import Throbber from '~/ui/throbber/Throbber.vue';
 
 const { t } = useTranslate('RecorderBar');
 
@@ -48,14 +49,16 @@ const emit = defineEmits<{
     </button>
 
     <p class="recording-time" :class="{ countdown: phase === 'countdown' }" aria-live="polite">
-      {{ phase === 'countdown' ? t('ready') : recordingTime }}
+      <template v-if="phase === 'countdown'">{{ t('ready') }}</template>
+      <Throbber v-else-if="phase === 'starting'" :text="t('preparing')" variant="breathe" color="muted" size="xs" />
+      <template v-else>{{ recordingTime }}</template>
     </p>
 
     <button
       class="control"
       :aria-label="phase === 'paused' ? t('resumeRecording') : t('pauseRecording')"
       :title="phase === 'paused' ? t('resumeRecording') : t('pauseRecording')"
-      :disabled="phase === 'countdown' || phase === 'finalizing'"
+      :disabled="phase === 'countdown' || phase === 'starting' || phase === 'finalizing'"
       @pointerdown.stop
       @click="emit('pause')"
     >
@@ -78,7 +81,7 @@ const emit = defineEmits<{
       :class="{ inactive: !microphoneEnabled }"
       :aria-label="microphoneEnabled ? t('turnMicOff') : t('turnMicOn')"
       :title="microphoneEnabled ? t('turnMicOff') : t('turnMicOn')"
-      :disabled="phase === 'countdown' || phase === 'finalizing'"
+      :disabled="phase === 'countdown' || phase === 'starting' || phase === 'finalizing'"
       @pointerdown.stop
       @click="emit('microphone')"
     >
@@ -90,7 +93,7 @@ const emit = defineEmits<{
       :class="{ inactive: !cameraEnabled }"
       :aria-label="cameraEnabled ? t('turnCameraOff') : t('turnCameraOn')"
       :title="cameraEnabled ? t('turnCameraOff') : t('turnCameraOn')"
-      :disabled="phase === 'countdown' || phase === 'finalizing'"
+      :disabled="phase === 'countdown' || phase === 'starting' || phase === 'finalizing'"
       @pointerdown.stop
       @click="emit('camera')"
     >
@@ -102,7 +105,7 @@ const emit = defineEmits<{
       :class="{ inactive: !systemAudioEnabled }"
       :aria-label="systemAudioEnabled ? t('turnSystemAudioOff') : t('turnSystemAudioOn')"
       :title="systemAudioEnabled ? t('turnSystemAudioOff') : t('turnSystemAudioOn')"
-      :disabled="phase === 'countdown' || phase === 'finalizing'"
+      :disabled="phase === 'countdown' || phase === 'starting' || phase === 'finalizing'"
       @pointerdown.stop
       @click="emit('systemAudio')"
     >

--- a/src/components/hud/recorder/recording-camera-metadata.ts
+++ b/src/components/hud/recorder/recording-camera-metadata.ts
@@ -1,0 +1,21 @@
+import { capture } from '../../../api/capture';
+import type { CameraAppearance, CameraPlacement } from '../../../api/camera-recorder';
+
+const DEFAULT_CAMERA_PLACEMENT: CameraPlacement = { x: 0.72, y: 0.72, width: 0.24, height: 0.24 };
+
+export async function recordingCameraMetadata(): Promise<{
+  appearance?: CameraAppearance;
+  placement: CameraPlacement;
+}> {
+  const overlay = await capture.getCameraOverlayState();
+  const appearance: CameraAppearance | undefined =
+    overlay &&
+    ['none', 'sm', 'md', 'lg'].includes(overlay.shadowSize) &&
+    ['none', 'sm', 'md', 'lg', 'full'].includes(overlay.cornerRadius)
+      ? {
+          shadowSize: overlay.shadowSize as CameraAppearance['shadowSize'],
+          cornerRadius: overlay.cornerRadius as CameraAppearance['cornerRadius'],
+        }
+      : undefined;
+  return { appearance, placement: { ...DEFAULT_CAMERA_PLACEMENT } };
+}

--- a/src/components/hud/recorder/recording-types.test.ts
+++ b/src/components/hud/recorder/recording-types.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { formatRecordingStartFailure } from './recording-types';
+
+describe('formatRecordingStartFailure', () => {
+  it('produces a copyable summary with startup context', () => {
+    const text = formatRecordingStartFailure({
+      stage: 'start-native',
+      message: 'native start failed',
+      nativePrepared: true,
+      nativeStarted: false,
+      camera: 'prepared',
+      microphone: 'started',
+      systemAudio: 'disabled',
+    });
+    expect(text).toContain('Recording failed during native startup.');
+    expect(text).toContain('Stage: start-native');
+    expect(text).toContain('Native prepared: yes');
+    expect(text).toContain('Native started: no');
+    expect(text).toContain('Camera: prepared');
+    expect(text).toContain('Microphone: started');
+    expect(text).toContain('System audio: disabled');
+    expect(text).toContain('Error: native start failed');
+  });
+
+  it('appends cleanup errors when present', () => {
+    const text = formatRecordingStartFailure({
+      stage: 'start-sidecars',
+      message: 'system audio failed',
+      nativePrepared: false,
+      nativeStarted: true,
+      camera: 'started',
+      microphone: 'started',
+      systemAudio: 'failed',
+      cleanupErrors: ['discard failed'],
+    });
+    expect(text).toContain('Cleanup: discard failed');
+  });
+});

--- a/src/components/hud/recorder/recording-types.ts
+++ b/src/components/hud/recorder/recording-types.ts
@@ -1,7 +1,37 @@
 import type { ScreenRegion, ScreenRegionOverlayOptions } from '../../../api/types/screen-region';
 
-export type RecordingPhase = 'idle' | 'countdown' | 'recording' | 'paused' | 'finalizing';
+export type RecordingPhase = 'idle' | 'countdown' | 'starting' | 'recording' | 'paused' | 'finalizing';
 export type RecordingBarVisibility = 'always' | 'auto-fade' | 'hover-only';
+export type StartupSidecarState = 'disabled' | 'prepared' | 'started' | 'failed';
+export type RecordingStartStage = 'prepare-sources' | 'prepare-native' | 'start-native' | 'start-sidecars' | 'cleanup';
+
+export interface RecordingStartFailure {
+  stage: RecordingStartStage;
+  message: string;
+  nativePrepared: boolean;
+  nativeStarted: boolean;
+  camera: StartupSidecarState;
+  microphone: StartupSidecarState;
+  systemAudio: StartupSidecarState;
+  cleanupErrors?: string[];
+}
+
+export const formatRecordingStartFailure = (failure: RecordingStartFailure): string => {
+  const lines = [
+    'Recording failed during native startup.',
+    `Stage: ${failure.stage}`,
+    `Native prepared: ${failure.nativePrepared ? 'yes' : 'no'}`,
+    `Native started: ${failure.nativeStarted ? 'yes' : 'no'}`,
+    `Camera: ${failure.camera}`,
+    `Microphone: ${failure.microphone}`,
+    `System audio: ${failure.systemAudio}`,
+    `Error: ${failure.message}`,
+  ];
+  if (failure.cleanupErrors && failure.cleanupErrors.length > 0) {
+    lines.push(`Cleanup: ${failure.cleanupErrors.join(' | ')}`);
+  }
+  return lines.join('\n');
+};
 
 export interface RecordingConfiguration {
   screenKind: 'display' | 'window';

--- a/src/components/hud/recorder/useDeviceToggles.ts
+++ b/src/components/hud/recorder/useDeviceToggles.ts
@@ -1,0 +1,154 @@
+import {
+  BrowserCameraRecorder,
+  isCameraUnavailableError,
+  listBrowserCameras,
+  type CameraAppearance,
+  type CameraPlacement,
+} from '../../../api/camera-recorder';
+import { BrowserMicrophoneRecorder, listBrowserMicrophones } from '../../../api/microphone-recorder';
+import { BrowserSystemAudioRecorder } from '../../../api/system-audio-recorder';
+import type { RecordingConfiguration } from './recording-types';
+
+const inactiveCamera = 'off';
+const inactiveMicrophone = 'no-audio';
+
+type Recorder = BrowserCameraRecorder | BrowserMicrophoneRecorder | BrowserSystemAudioRecorder;
+
+export interface DeviceToggleContext {
+  getConfiguration(): RecordingConfiguration | null;
+  setConfigurationCameraId(id: string): void;
+  setConfigurationMicrophoneId(id: string): void;
+  getSessionId(): string | null;
+  getSessionTimelineStartedAt(): number;
+  getCamera(): BrowserCameraRecorder | null;
+  setCamera(recorder: BrowserCameraRecorder | null): void;
+  getMicrophone(): BrowserMicrophoneRecorder | null;
+  setMicrophone(recorder: BrowserMicrophoneRecorder | null): void;
+  getSystemAudio(): BrowserSystemAudioRecorder | null;
+  setSystemAudio(recorder: BrowserSystemAudioRecorder | null): void;
+  setCameraEnabled(enabled: boolean): void;
+  setMicrophoneEnabled(enabled: boolean): void;
+  setSystemAudioEnabled(enabled: boolean): void;
+  setError(message: string): void;
+  cameraMetadata(): Promise<{ appearance?: CameraAppearance; placement?: CameraPlacement }>;
+}
+
+export function useDeviceToggles(ctx: DeviceToggleContext) {
+  const stopRecorder = async (recorder: Recorder | null) => {
+    await recorder?.stop().catch(() => undefined);
+  };
+
+  const resolveCameraSourceId = async () => {
+    const configuration = ctx.getConfiguration();
+    if (!configuration) return null;
+    if (configuration.cameraId !== inactiveCamera) return configuration.cameraId;
+    const sources = await listBrowserCameras();
+    return (
+      sources.find((source) => source.isDefault && source.id !== 'camera:chromium:')?.id ??
+      sources.find((source) => source.id !== 'camera:chromium:')?.id ??
+      null
+    );
+  };
+
+  const resolveMicrophoneSourceId = async () => {
+    const configuration = ctx.getConfiguration();
+    if (!configuration) return null;
+    if (configuration.microphoneId !== inactiveMicrophone) return configuration.microphoneId;
+    const sources = await listBrowserMicrophones();
+    return (
+      sources.find((source) => source.isDefault && source.id !== 'microphone:chromium:')?.id ??
+      sources.find((source) => source.id !== 'microphone:chromium:')?.id ??
+      null
+    );
+  };
+
+  const setToggleError = (reason: unknown) => {
+    ctx.setError(reason instanceof Error ? reason.message : String(reason));
+  };
+
+  const toggleCamera = async () => {
+    const configuration = ctx.getConfiguration();
+    const sessionId = ctx.getSessionId();
+    if (!configuration || !sessionId) return;
+    if (ctx.getCamera()) {
+      await stopRecorder(ctx.getCamera());
+      ctx.setCamera(null);
+      ctx.setCameraEnabled(false);
+      return;
+    }
+    try {
+      const sourceId = await resolveCameraSourceId();
+      if (!sourceId) throw new Error('No camera is available.');
+      const { appearance, placement } = await ctx.cameraMetadata();
+      const nextCamera = await BrowserCameraRecorder.request(sourceId);
+      try {
+        await nextCamera.start(sessionId, appearance, placement, ctx.getSessionTimelineStartedAt());
+      } catch (reason) {
+        await stopRecorder(nextCamera);
+        throw reason;
+      }
+      ctx.setCamera(nextCamera);
+      ctx.setConfigurationCameraId(sourceId);
+      ctx.setCameraEnabled(true);
+    } catch (reason) {
+      if (isCameraUnavailableError(reason)) {
+        ctx.setConfigurationCameraId(inactiveCamera);
+        ctx.setError('Camera is unavailable.');
+      } else setToggleError(reason);
+    }
+  };
+
+  const toggleMicrophone = async () => {
+    const configuration = ctx.getConfiguration();
+    const sessionId = ctx.getSessionId();
+    if (!configuration || !sessionId) return;
+    if (ctx.getMicrophone()) {
+      await stopRecorder(ctx.getMicrophone());
+      ctx.setMicrophone(null);
+      ctx.setMicrophoneEnabled(false);
+      return;
+    }
+    try {
+      const sourceId = await resolveMicrophoneSourceId();
+      if (!sourceId) throw new Error('No microphone is available.');
+      const nextMicrophone = await BrowserMicrophoneRecorder.request(sourceId);
+      try {
+        await nextMicrophone.start(sessionId);
+      } catch (reason) {
+        await stopRecorder(nextMicrophone);
+        throw reason;
+      }
+      ctx.setMicrophone(nextMicrophone);
+      ctx.setConfigurationMicrophoneId(sourceId);
+      ctx.setMicrophoneEnabled(true);
+    } catch (reason) {
+      setToggleError(reason);
+    }
+  };
+
+  const toggleSystemAudio = async () => {
+    const sessionId = ctx.getSessionId();
+    if (!sessionId) return;
+    if (ctx.getSystemAudio()) {
+      await stopRecorder(ctx.getSystemAudio());
+      ctx.setSystemAudio(null);
+      ctx.setSystemAudioEnabled(false);
+      return;
+    }
+    try {
+      const nextSystemAudio = await BrowserSystemAudioRecorder.request();
+      try {
+        await nextSystemAudio.start(sessionId);
+      } catch (reason) {
+        await stopRecorder(nextSystemAudio);
+        throw reason;
+      }
+      ctx.setSystemAudio(nextSystemAudio);
+      ctx.setSystemAudioEnabled(true);
+    } catch (reason) {
+      setToggleError(reason);
+    }
+  };
+
+  return { toggleCamera, toggleMicrophone, toggleSystemAudio };
+}

--- a/src/components/hud/recorder/useRecordingController.test.ts
+++ b/src/components/hud/recorder/useRecordingController.test.ts
@@ -201,6 +201,48 @@ describe('useRecordingController startup', () => {
     expect(controller.phase.value).toBe('idle');
   });
 
+  it('cancels the prepared session when a stale native start rejects', async () => {
+    let rejectStart: (reason: Error) => void = () => undefined;
+    mocks.capture.startPreparedRecording.mockReturnValue(
+      new Promise((_resolve, reject) => {
+        rejectStart = reject;
+      }),
+    );
+    const controller = useRecordingController(vi.fn(), vi.fn());
+    await controller.start({ ...baseConfig, countdownSeconds: 0 });
+    expect(controller.phase.value).toBe('starting');
+
+    await controller.cancel();
+    expect(controller.phase.value).toBe('idle');
+
+    // resetState deferred prepared-session cleanup to the stale-generation path;
+    // a rejecting start must still release the prepared native session.
+    rejectStart(new Error('native start failed'));
+    await vi.waitFor(() => expect(mocks.capture.cancelPreparedRecording).toHaveBeenCalled());
+    expect(mocks.capture.discardRecording).not.toHaveBeenCalled();
+    expect(controller.phase.value).toBe('idle');
+  });
+
+  it('cancels the prepared session when a stale surface preparation rejects', async () => {
+    let rejectSurface: (reason: Error) => void = () => undefined;
+    mocks.capture.prepareRecordingSurface.mockReturnValue(
+      new Promise((_resolve, reject) => {
+        rejectSurface = reject;
+      }),
+    );
+    const controller = useRecordingController(vi.fn(), vi.fn());
+    await controller.start({ ...baseConfig, countdownSeconds: 0 });
+    expect(controller.phase.value).toBe('starting');
+
+    await controller.cancel();
+    expect(controller.phase.value).toBe('idle');
+
+    rejectSurface(new Error('surface preparation failed'));
+    await vi.waitFor(() => expect(mocks.capture.cancelPreparedRecording).toHaveBeenCalled());
+    expect(mocks.capture.startPreparedRecording).not.toHaveBeenCalled();
+    expect(controller.phase.value).toBe('idle');
+  });
+
   it('keeps a new start blocked until deferred stale-session cleanup completes', async () => {
     let resolveStart: (value: { sessionId: string }) => void = () => undefined;
     let resolveDiscard: () => void = () => undefined;

--- a/src/components/hud/recorder/useRecordingController.test.ts
+++ b/src/components/hud/recorder/useRecordingController.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { RecordingConfiguration } from './recording-types';
+
+const mocks = vi.hoisted(() => {
+  const makeRecorder = () => ({
+    start: vi.fn(async () => undefined),
+    stop: vi.fn(async () => undefined),
+    pause: vi.fn(async () => undefined),
+    resume: vi.fn(async () => undefined),
+  });
+  return {
+    cameraRecorder: makeRecorder(),
+    micRecorder: makeRecorder(),
+    systemAudioRecorder: makeRecorder(),
+    capture: {
+      getCameraOverlayState: vi.fn(async () => null),
+      prepareRecording: vi.fn(async () => ({ sessionId: 'prepared' })),
+      cancelPreparedRecording: vi.fn(async () => undefined),
+      setCountdown: vi.fn(async () => undefined),
+      prepareRecordingSurface: vi.fn(async () => undefined),
+      startPreparedRecording: vi.fn(async () => ({ sessionId: 'session-1' })),
+      discardRecording: vi.fn(async () => undefined),
+      stop: vi.fn(async () => ({ sessionId: 'session-1' })),
+      stopNativeRecording: vi.fn(async () => ({ sessionId: 'session-1' })),
+      completeNativeRecording: vi.fn(async () => ({ sessionId: 'session-1', videoSrc: 'file:///v.mp4' })),
+      pause: vi.fn(async () => ({ sessionId: 'session-1' })),
+      resume: vi.fn(async () => ({ sessionId: 'session-1' })),
+      setTeleprompterSession: vi.fn(),
+      showScreenRegionOverlay: vi.fn(),
+      hideScreenRegionOverlay: vi.fn(),
+    },
+  };
+});
+
+vi.mock('../../../api/capture', () => ({ capture: mocks.capture }));
+vi.mock('../../../api/camera-recorder', () => ({
+  BrowserCameraRecorder: { request: vi.fn(async () => mocks.cameraRecorder) },
+  isCameraUnavailableError: (error: unknown) => (error as Error)?.name === 'NotFoundError',
+  listBrowserCameras: vi.fn(async () => []),
+}));
+vi.mock('../../../api/microphone-recorder', () => ({
+  BrowserMicrophoneRecorder: { request: vi.fn(async () => mocks.micRecorder) },
+  listBrowserMicrophones: vi.fn(async () => []),
+}));
+vi.mock('../../../api/system-audio-recorder', () => ({
+  BrowserSystemAudioRecorder: { request: vi.fn(async () => mocks.systemAudioRecorder) },
+}));
+
+import { useRecordingController } from './useRecordingController';
+
+const baseConfig: RecordingConfiguration = {
+  screenKind: 'display',
+  screenId: 'screen-1',
+  cameraId: 'off',
+  microphoneId: 'no-audio',
+  systemAudio: false,
+  targetFps: 60,
+  countdownSeconds: 0,
+  recordingBarVisibility: 'always',
+};
+
+const fullConfig: RecordingConfiguration = {
+  ...baseConfig,
+  cameraId: 'camera:chromium:1',
+  microphoneId: 'microphone:chromium:1',
+  systemAudio: true,
+};
+
+const resetCapture = () => {
+  mocks.capture.getCameraOverlayState.mockResolvedValue(null);
+  mocks.capture.prepareRecording.mockResolvedValue({ sessionId: 'prepared' });
+  mocks.capture.cancelPreparedRecording.mockResolvedValue(undefined);
+  mocks.capture.setCountdown.mockResolvedValue(undefined);
+  mocks.capture.prepareRecordingSurface.mockResolvedValue(undefined);
+  mocks.capture.startPreparedRecording.mockResolvedValue({ sessionId: 'session-1' });
+  mocks.capture.discardRecording.mockResolvedValue(undefined);
+  mocks.capture.stop.mockResolvedValue({ sessionId: 'session-1' });
+  mocks.capture.stopNativeRecording.mockResolvedValue({ sessionId: 'session-1' });
+  mocks.capture.completeNativeRecording.mockResolvedValue({ sessionId: 'session-1', videoSrc: 'file:///v.mp4' });
+  mocks.capture.pause.mockResolvedValue({ sessionId: 'session-1' });
+  mocks.capture.resume.mockResolvedValue({ sessionId: 'session-1' });
+  for (const recorder of [mocks.cameraRecorder, mocks.micRecorder, mocks.systemAudioRecorder]) {
+    recorder.start.mockResolvedValue(undefined);
+    recorder.stop.mockResolvedValue(undefined);
+    recorder.pause.mockResolvedValue(undefined);
+    recorder.resume.mockResolvedValue(undefined);
+  }
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetCapture();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('useRecordingController countdown', () => {
+  it('starts the native recorder exactly once when the countdown reaches zero', async () => {
+    vi.useFakeTimers();
+    const controller = useRecordingController(vi.fn(), vi.fn());
+    await controller.start({ ...baseConfig, countdownSeconds: 1 });
+    expect(controller.phase.value).toBe('countdown');
+    expect(mocks.capture.startPreparedRecording).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(controller.secondsRemaining.value).toBe(0);
+    expect(controller.phase.value).toBe('recording');
+    expect(mocks.capture.startPreparedRecording).toHaveBeenCalledTimes(1);
+  });
+
+  it('clamps the countdown and never triggers more than once when timers skip past zero', async () => {
+    vi.useFakeTimers();
+    const controller = useRecordingController(vi.fn(), vi.fn());
+    await controller.start({ ...baseConfig, countdownSeconds: 1 });
+
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(controller.secondsRemaining.value).toBe(0);
+    expect(controller.secondsRemaining.value).not.toBeLessThan(0);
+    expect(mocks.capture.startPreparedRecording).toHaveBeenCalledTimes(1);
+    expect(controller.phase.value).toBe('recording');
+  });
+
+  it('reports a start-native failure with correct metadata after the countdown', async () => {
+    vi.useFakeTimers();
+    mocks.capture.startPreparedRecording.mockRejectedValue(new Error('native start failed'));
+    const onStartupFailure = vi.fn();
+    const controller = useRecordingController(vi.fn(), onStartupFailure);
+    await controller.start({ ...baseConfig, countdownSeconds: 1 });
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(controller.phase.value).toBe('idle');
+    expect(onStartupFailure).toHaveBeenCalledTimes(1);
+    expect(onStartupFailure.mock.calls[0][0]).toMatchObject({
+      stage: 'start-native',
+      message: 'native start failed',
+      nativePrepared: true,
+      nativeStarted: false,
+      camera: 'disabled',
+      microphone: 'disabled',
+      systemAudio: 'disabled',
+    });
+    expect(mocks.capture.cancelPreparedRecording).toHaveBeenCalled();
+  });
+});
+
+describe('useRecordingController startup', () => {
+  it('cancels a pending native start without waiting for it to settle', async () => {
+    let resolveStart: (value: { sessionId: string }) => void = () => undefined;
+    mocks.capture.startPreparedRecording.mockReturnValue(
+      new Promise((resolve) => {
+        resolveStart = resolve;
+      }),
+    );
+    const controller = useRecordingController(vi.fn(), vi.fn());
+    await controller.start({ ...baseConfig, countdownSeconds: 0 });
+    expect(controller.phase.value).toBe('starting');
+
+    await controller.cancel();
+    expect(controller.phase.value).toBe('idle');
+    expect(mocks.capture.cancelPreparedRecording).toHaveBeenCalled();
+
+    // The blocked start eventually resolves and must not resurrect the recording.
+    resolveStart({ sessionId: 'session-1' });
+    await vi.waitFor(() => expect(controller.phase.value).toBe('idle'));
+    expect(controller.phase.value).toBe('idle');
+  });
+
+  it('reports per-component state when a sidecar fails to start', async () => {
+    mocks.systemAudioRecorder.start.mockRejectedValue(new Error('system audio failed'));
+    const onStartupFailure = vi.fn();
+    const controller = useRecordingController(vi.fn(), onStartupFailure);
+    await controller.start(fullConfig);
+
+    await vi.waitFor(() => expect(onStartupFailure).toHaveBeenCalledTimes(1));
+    expect(controller.phase.value).toBe('idle');
+    expect(onStartupFailure.mock.calls[0][0]).toMatchObject({
+      stage: 'start-sidecars',
+      nativePrepared: false,
+      nativeStarted: true,
+      camera: 'started',
+      microphone: 'started',
+      systemAudio: 'failed',
+    });
+    expect(mocks.capture.discardRecording).toHaveBeenCalledWith('session-1');
+  });
+
+  it('records cleanup errors when discarding the started native session fails', async () => {
+    mocks.systemAudioRecorder.start.mockRejectedValue(new Error('system audio failed'));
+    mocks.capture.discardRecording.mockRejectedValue(new Error('discard failed'));
+    const onStartupFailure = vi.fn();
+    const controller = useRecordingController(vi.fn(), onStartupFailure);
+    await controller.start(fullConfig);
+
+    await vi.waitFor(() => expect(onStartupFailure).toHaveBeenCalledTimes(1));
+    const failure = onStartupFailure.mock.calls[0][0];
+    expect(failure.cleanupErrors).toContain('discard failed');
+  });
+
+  it('never lets a stale async callback restore the recording phase after cleanup', async () => {
+    let resolveStart: (value: { sessionId: string }) => void = () => undefined;
+    mocks.capture.startPreparedRecording.mockReturnValue(
+      new Promise((resolve) => {
+        resolveStart = resolve;
+      }),
+    );
+    const controller = useRecordingController(vi.fn(), vi.fn());
+    await controller.start({ ...baseConfig, countdownSeconds: 0 });
+    await controller.cancel();
+    expect(controller.phase.value).toBe('idle');
+
+    resolveStart({ sessionId: 'session-1' });
+    await vi.waitFor(() => expect(mocks.capture.stop).toHaveBeenCalled());
+    expect(controller.phase.value).toBe('idle');
+  });
+
+  it('starts the timer only after native and sidecars have started', async () => {
+    const controller = useRecordingController(vi.fn(), vi.fn());
+    await controller.start(fullConfig);
+    await vi.waitFor(() => expect(controller.phase.value).toBe('recording'));
+    expect(controller.recordingTime.value).toBe('00:00.0');
+  });
+});

--- a/src/components/hud/recorder/useRecordingController.test.ts
+++ b/src/components/hud/recorder/useRecordingController.test.ts
@@ -18,8 +18,10 @@ const mocks = vi.hoisted(() => {
       cancelPreparedRecording: vi.fn(async () => undefined),
       setCountdown: vi.fn(async () => undefined),
       prepareRecordingSurface: vi.fn(async () => undefined),
-      startPreparedRecording: vi.fn(async () => ({ sessionId: 'session-1' })),
-      discardRecording: vi.fn(async () => undefined),
+      startPreparedRecording: vi.fn(async (): Promise<{ sessionId?: string; projectId?: string }> => ({
+        sessionId: 'session-1',
+      })),
+      discardRecording: vi.fn(async (): Promise<void> => undefined),
       stop: vi.fn(async () => ({ sessionId: 'session-1' })),
       stopNativeRecording: vi.fn(async () => ({ sessionId: 'session-1' })),
       completeNativeRecording: vi.fn(async () => ({ sessionId: 'session-1', videoSrc: 'file:///v.mp4' })),
@@ -97,6 +99,21 @@ afterEach(() => {
 });
 
 describe('useRecordingController countdown', () => {
+  it('clamps a negative countdown and starts native capture exactly once', async () => {
+    vi.useFakeTimers();
+    const controller = useRecordingController(vi.fn(), vi.fn());
+
+    await controller.start({ ...baseConfig, countdownSeconds: -10 });
+    expect(controller.phase.value).toBe('starting');
+    expect(controller.secondsRemaining.value).toBe(0);
+
+    await vi.waitFor(() => expect(mocks.capture.startPreparedRecording).toHaveBeenCalledTimes(1));
+    expect(controller.phase.value).toBe('recording');
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(mocks.capture.startPreparedRecording).toHaveBeenCalledTimes(1);
+    expect(controller.secondsRemaining.value).toBe(0);
+  });
+
   it('starts the native recorder exactly once when the countdown reaches zero', async () => {
     vi.useFakeTimers();
     const controller = useRecordingController(vi.fn(), vi.fn());
@@ -143,6 +160,22 @@ describe('useRecordingController countdown', () => {
     });
     expect(mocks.capture.cancelPreparedRecording).toHaveBeenCalled();
   });
+
+  it('cleans up a native session when startup returns without a session id', async () => {
+    mocks.capture.startPreparedRecording.mockResolvedValueOnce({} as { sessionId?: string });
+    const onStartupFailure = vi.fn();
+    const controller = useRecordingController(vi.fn(), onStartupFailure);
+
+    await controller.start(baseConfig);
+    await vi.waitFor(() => expect(onStartupFailure).toHaveBeenCalledTimes(1));
+
+    expect(onStartupFailure.mock.calls[0][0]).toMatchObject({
+      stage: 'start-native',
+      nativeStarted: true,
+    });
+    expect(mocks.capture.discardRecording).toHaveBeenCalledWith(undefined);
+    expect(controller.phase.value).toBe('idle');
+  });
 });
 
 describe('useRecordingController startup', () => {
@@ -159,12 +192,43 @@ describe('useRecordingController startup', () => {
 
     await controller.cancel();
     expect(controller.phase.value).toBe('idle');
-    expect(mocks.capture.cancelPreparedRecording).toHaveBeenCalled();
 
-    // The blocked start eventually resolves and must not resurrect the recording.
+    // The blocked start eventually resolves and must clean up the native session
+    // explicitly, without resurrecting the recording.
     resolveStart({ sessionId: 'session-1' });
-    await vi.waitFor(() => expect(controller.phase.value).toBe('idle'));
+    await vi.waitFor(() => expect(mocks.capture.discardRecording).toHaveBeenCalledWith('session-1'));
+    expect(mocks.capture.stop).not.toHaveBeenCalled();
     expect(controller.phase.value).toBe('idle');
+  });
+
+  it('keeps a new start blocked until deferred stale-session cleanup completes', async () => {
+    let resolveStart: (value: { sessionId: string }) => void = () => undefined;
+    let resolveDiscard: () => void = () => undefined;
+    mocks.capture.startPreparedRecording.mockReturnValue(
+      new Promise((resolve) => {
+        resolveStart = resolve;
+      }),
+    );
+    mocks.capture.discardRecording.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveDiscard = resolve;
+      }),
+    );
+    const controller = useRecordingController(vi.fn(), vi.fn());
+    await controller.start({ ...baseConfig, countdownSeconds: 0 });
+    await controller.cancel();
+
+    resolveStart({ sessionId: 'stale-session' });
+    await vi.waitFor(() => expect(mocks.capture.discardRecording).toHaveBeenCalledWith('stale-session'));
+
+    const prepareCallsBeforeRetry = mocks.capture.prepareRecording.mock.calls.length;
+    await controller.start({ ...baseConfig, countdownSeconds: 0 });
+    expect(mocks.capture.prepareRecording).toHaveBeenCalledTimes(prepareCallsBeforeRetry);
+
+    resolveDiscard();
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    await controller.start({ ...baseConfig, countdownSeconds: 0 });
+    await vi.waitFor(() => expect(mocks.capture.prepareRecording).toHaveBeenCalledTimes(prepareCallsBeforeRetry + 1));
   });
 
   it('reports per-component state when a sidecar fails to start', async () => {
@@ -186,6 +250,26 @@ describe('useRecordingController startup', () => {
     expect(mocks.capture.discardRecording).toHaveBeenCalledWith('session-1');
   });
 
+  it.each([
+    ['camera', () => mocks.cameraRecorder],
+    ['microphone', () => mocks.micRecorder],
+    ['systemAudio', () => mocks.systemAudioRecorder],
+  ] as const)('reports %s startup failure after native start', async (kind, recorder) => {
+    recorder().start.mockRejectedValueOnce(new Error(`${kind} start failed`));
+    const onStartupFailure = vi.fn();
+    const controller = useRecordingController(vi.fn(), onStartupFailure);
+    await controller.start(fullConfig);
+
+    await vi.waitFor(() => expect(onStartupFailure).toHaveBeenCalledTimes(1));
+    expect(onStartupFailure.mock.calls[0][0]).toMatchObject({
+      stage: 'start-sidecars',
+      nativeStarted: true,
+      [kind]: 'failed',
+    });
+    expect(controller.phase.value).toBe('idle');
+    expect(mocks.capture.discardRecording).toHaveBeenCalledWith('session-1');
+  });
+
   it('records cleanup errors when discarding the started native session fails', async () => {
     mocks.systemAudioRecorder.start.mockRejectedValue(new Error('system audio failed'));
     mocks.capture.discardRecording.mockRejectedValue(new Error('discard failed'));
@@ -196,6 +280,21 @@ describe('useRecordingController startup', () => {
     await vi.waitFor(() => expect(onStartupFailure).toHaveBeenCalledTimes(1));
     const failure = onStartupFailure.mock.calls[0][0];
     expect(failure.cleanupErrors).toContain('discard failed');
+    const prepareCalls = mocks.capture.prepareRecording.mock.calls.length;
+    await controller.start(fullConfig);
+    expect(mocks.capture.prepareRecording).toHaveBeenCalledTimes(prepareCalls);
+    expect(controller.error.value).toContain('restart Beam');
+  });
+
+  it('preserves sidecar cleanup errors in startup failure metadata', async () => {
+    mocks.systemAudioRecorder.start.mockRejectedValue(new Error('system audio failed'));
+    mocks.cameraRecorder.stop.mockRejectedValueOnce(new Error('camera cleanup failed'));
+    const onStartupFailure = vi.fn();
+    const controller = useRecordingController(vi.fn(), onStartupFailure);
+    await controller.start(fullConfig);
+
+    await vi.waitFor(() => expect(onStartupFailure).toHaveBeenCalledTimes(1));
+    expect(onStartupFailure.mock.calls[0][0].cleanupErrors).toContain('camera cleanup failed');
   });
 
   it('never lets a stale async callback restore the recording phase after cleanup', async () => {
@@ -211,7 +310,8 @@ describe('useRecordingController startup', () => {
     expect(controller.phase.value).toBe('idle');
 
     resolveStart({ sessionId: 'session-1' });
-    await vi.waitFor(() => expect(mocks.capture.stop).toHaveBeenCalled());
+    await vi.waitFor(() => expect(mocks.capture.discardRecording).toHaveBeenCalledWith('session-1'));
+    expect(mocks.capture.stop).not.toHaveBeenCalled();
     expect(controller.phase.value).toBe('idle');
   });
 

--- a/src/components/hud/recorder/useRecordingController.ts
+++ b/src/components/hud/recorder/useRecordingController.ts
@@ -249,13 +249,16 @@ export function useRecordingController(
   const performStartup = async (generation: number) => {
     if (!configuration) return;
     let stage: RecordingStartStage = 'prepare-native';
+    let ownsPreparedSession = false;
     try {
       if (preparedGeneration !== generation || generation !== recordingGeneration) return;
+      ownsPreparedSession = true;
       stage = 'start-native';
       await capture.setCountdown(null);
       recorderHoverOnlyActive.value = configuration.recordingBarVisibility === 'hover-only';
       await capture.prepareRecordingSurface();
       const session = await capture.startPreparedRecording();
+      ownsPreparedSession = false;
       sessionTimelineStartedAt = performance.now();
       if (generation !== recordingGeneration) {
         await cleanupStaleNativeStart(session);
@@ -280,7 +283,14 @@ export function useRecordingController(
       }, 100);
       phase.value = 'recording';
     } catch (reason) {
-      if (generation !== recordingGeneration) return;
+      if (generation !== recordingGeneration) {
+        // resetState cleared preparedGeneration and deferred cleanup here while
+        // pendingNativeStart was set. If this stale start still owns the prepared
+        // session (startPreparedRecording never resolved), release it so the next
+        // session does not overlap the leaked native process.
+        if (ownsPreparedSession) await capture.cancelPreparedRecording().catch(() => undefined);
+        return;
+      }
       await terminateStartup(generation, startupFailure(generation, stage, reason));
     }
   };

--- a/src/components/hud/recorder/useRecordingController.ts
+++ b/src/components/hud/recorder/useRecordingController.ts
@@ -1,14 +1,10 @@
 import { computed, ref } from 'vue';
 import { capture } from '../../../api/capture';
-import {
-  BrowserCameraRecorder,
-  isCameraUnavailableError,
-  type CameraAppearance,
-  type CameraPlacement,
-} from '../../../api/camera-recorder';
+import { BrowserCameraRecorder, isCameraUnavailableError } from '../../../api/camera-recorder';
 import { BrowserMicrophoneRecorder } from '../../../api/microphone-recorder';
 import { BrowserSystemAudioRecorder } from '../../../api/system-audio-recorder';
 import { useDeviceToggles } from './useDeviceToggles';
+import { recordingCameraMetadata } from './recording-camera-metadata';
 import type {
   RecordingConfiguration,
   RecordingPhase,
@@ -23,7 +19,6 @@ type SidecarKind = 'camera' | 'microphone' | 'systemAudio';
 
 const inactiveCamera = 'off';
 const inactiveMicrophone = 'no-audio';
-const DEFAULT_CAMERA_PLACEMENT: CameraPlacement = { x: 0.72, y: 0.72, width: 0.24, height: 0.24 };
 
 export function useRecordingController(
   onComplete: (session: RecordingSessionResult) => void,
@@ -52,24 +47,11 @@ export function useRecordingController(
   let preparedGeneration: number | null = null;
   let nativeStarted = false;
   let cancelling = false;
+  let nativeCleanupBlocked = false;
   const sidecarStates: Record<SidecarKind, StartupSidecarState> = {
     camera: 'disabled',
     microphone: 'disabled',
     systemAudio: 'disabled',
-  };
-
-  const cameraMetadata = async (): Promise<{ appearance?: CameraAppearance; placement?: CameraPlacement }> => {
-    const overlay = await capture.getCameraOverlayState();
-    const appearance: CameraAppearance | undefined =
-      overlay &&
-      ['none', 'sm', 'md', 'lg'].includes(overlay.shadowSize) &&
-      ['none', 'sm', 'md', 'lg', 'full'].includes(overlay.cornerRadius)
-        ? {
-            shadowSize: overlay.shadowSize as CameraAppearance['shadowSize'],
-            cornerRadius: overlay.cornerRadius as CameraAppearance['cornerRadius'],
-          }
-        : undefined;
-    return { appearance, placement: { ...DEFAULT_CAMERA_PLACEMENT } };
   };
 
   const deviceToggles = useDeviceToggles({
@@ -106,7 +88,7 @@ export function useRecordingController(
     setError: (message) => {
       error.value = message;
     },
-    cameraMetadata,
+    cameraMetadata: recordingCameraMetadata,
   });
 
   const isActive = computed(
@@ -116,6 +98,15 @@ export function useRecordingController(
       phase.value === 'recording' ||
       phase.value === 'paused',
   );
+  const cleanupStaleNativeStart = async (session: { sessionId?: string | null }) => {
+    try {
+      await capture.discardRecording(session.sessionId ?? undefined);
+    } catch (reason) {
+      nativeCleanupBlocked = true;
+      const detail = reason instanceof Error ? reason.message : String(reason);
+      error.value = `The cancelled recording could not be cleaned up safely: ${detail}. Restart Beam before recording again.`;
+    }
+  };
   const clearCountdown = () => {
     if (countdown !== null) window.clearInterval(countdown);
     countdown = null;
@@ -174,7 +165,7 @@ export function useRecordingController(
 
   const startSidecars = async () => {
     if (!sessionId) return;
-    const { appearance, placement } = await cameraMetadata();
+    const { appearance, placement } = await recordingCameraMetadata();
     const results = await Promise.allSettled([
       camera?.start(sessionId, appearance, placement, sessionTimelineStartedAt),
       microphone?.start(sessionId),
@@ -232,22 +223,26 @@ export function useRecordingController(
         cleanupErrors.push(reason instanceof Error ? reason.message : String(reason));
       }
     };
-    // Break any self-reference so resetState does not await the very operation
-    // that is currently failing.
-    pendingNativeStart = null;
     const wasNativeStarted = nativeStarted;
     const wasNativePrepared = preparedGeneration === generation;
     const nativeSessionId = sessionId;
     await runCleanup(() => stopRecorderStrict(camera));
     await runCleanup(() => stopRecorderStrict(microphone));
     await runCleanup(() => stopRecorderStrict(systemAudio));
-    if (wasNativeStarted) await runCleanup(() => capture.discardRecording(nativeSessionId ?? undefined));
-    else if (wasNativePrepared) await runCleanup(() => capture.cancelPreparedRecording());
+    if (wasNativeStarted) {
+      const before = cleanupErrors.length;
+      await runCleanup(() => capture.discardRecording(nativeSessionId ?? undefined));
+      nativeCleanupBlocked ||= cleanupErrors.length > before;
+    } else if (wasNativePrepared) {
+      await runCleanup(() => capture.cancelPreparedRecording());
+    }
     preparedGeneration = null;
     capture.setTeleprompterSession(null);
     if (cleanupErrors.length > 0) failure.cleanupErrors = cleanupErrors;
     error.value = failure.message;
     await resetState(true);
+    if (nativeCleanupBlocked)
+      error.value = `${failure.message} Native cleanup is unresolved; restart Beam before recording again.`;
     onStartupFailure?.(failure);
   };
 
@@ -255,19 +250,15 @@ export function useRecordingController(
     if (!configuration) return;
     let stage: RecordingStartStage = 'prepare-native';
     try {
-      const prepared = prewarm ? await prewarm : false;
-      if (!prepared || generation !== recordingGeneration) return;
+      if (preparedGeneration !== generation || generation !== recordingGeneration) return;
       stage = 'start-native';
       await capture.setCountdown(null);
       recorderHoverOnlyActive.value = configuration.recordingBarVisibility === 'hover-only';
       await capture.prepareRecordingSurface();
       const session = await capture.startPreparedRecording();
-      // The native track creates the session timeline only once its start gate
-      // is released. Sidecars must use that same epoch, otherwise native startup
-      // latency is added to their final duration.
       sessionTimelineStartedAt = performance.now();
       if (generation !== recordingGeneration) {
-        await capture.stop().catch(() => undefined);
+        await cleanupStaleNativeStart(session);
         return;
       }
       nativeStarted = true;
@@ -280,7 +271,7 @@ export function useRecordingController(
       await startSidecars();
       if (generation !== recordingGeneration) {
         await Promise.all([stopRecorder(camera), stopRecorder(microphone), stopRecorder(systemAudio)]);
-        await capture.stop().catch(() => undefined);
+        await cleanupStaleNativeStart(session);
         return;
       }
       elapsedTenths.value = 0;
@@ -304,7 +295,14 @@ export function useRecordingController(
   };
 
   const start = async (next: RecordingConfiguration) => {
-    if (isActive.value || pendingNativeStart) return;
+    if (nativeCleanupBlocked) {
+      error.value ||= 'Native recording cleanup is unresolved. Restart Beam before recording again.';
+      return;
+    }
+    if (isActive.value || pendingNativeStart || prewarm) {
+      if (!isActive.value) error.value = 'The previous recording is still being cleaned up. Please try again.';
+      return;
+    }
     error.value = '';
     const generation = ++recordingGeneration;
     configuration = next;
@@ -322,8 +320,15 @@ export function useRecordingController(
       secondsRemaining.value = Math.max(0, next.countdownSeconds);
       phase.value = 'countdown';
       stage = 'prepare-native';
-      prewarm = prewarmNativeRecording(generation);
-      if (!(await prewarm) || generation !== recordingGeneration) return;
+      const preparation = prewarmNativeRecording(generation);
+      prewarm = preparation;
+      let prepared = false;
+      try {
+        prepared = await preparation;
+      } finally {
+        if (prewarm === preparation) prewarm = null;
+      }
+      if (!prepared || generation !== recordingGeneration) return;
       if (secondsRemaining.value === 0) {
         phase.value = 'starting';
         void launchNativeStartup(generation);
@@ -337,8 +342,6 @@ export function useRecordingController(
           return;
         }
         clearCountdown();
-        // The countdown is a visual gate, not part of the recording. Hide it
-        // at the zero boundary before waiting on IPC/native start.
         void capture.setCountdown(null);
         phase.value = 'starting';
         void launchNativeStartup(generation);
@@ -372,13 +375,14 @@ export function useRecordingController(
     sidecarStates.camera = 'disabled';
     sidecarStates.microphone = 'disabled';
     sidecarStates.systemAudio = 'disabled';
-    // Cancel a prepared native recording without waiting for a blocked start.
+    // A prepared session can be cancelled directly. Once the start command has
+    // been sent, however, the single-threaded native protocol cannot process a
+    // cancel until start returns. Keep pendingNativeStart as the cleanup gate;
+    // its stale-generation branch discards the returned session before clearing.
     if (preparedGeneration !== null) {
       preparedGeneration = null;
-      void capture.cancelPreparedRecording().catch(() => undefined);
+      if (!pendingNativeStart) await capture.cancelPreparedRecording().catch(() => undefined);
     }
-    pendingNativeStart = null;
-    prewarm = null;
     phase.value = 'idle';
   };
 
@@ -413,9 +417,6 @@ export function useRecordingController(
     phase.value = 'finalizing';
     clearTimer();
     try {
-      // Stop the native screen clock and request the sidecar recorders to stop
-      // at the same moment. Track storage is completed only after all sidecars
-      // have flushed their final chunks, so none can be cut off by native stop.
       const stopNs = timelineNowNs();
       const nativeStop = capture.stopNativeRecording();
       const sidecarsStop = Promise.all([

--- a/src/components/hud/recorder/useRecordingController.ts
+++ b/src/components/hud/recorder/useRecordingController.ts
@@ -3,21 +3,32 @@ import { capture } from '../../../api/capture';
 import {
   BrowserCameraRecorder,
   isCameraUnavailableError,
-  listBrowserCameras,
   type CameraAppearance,
   type CameraPlacement,
 } from '../../../api/camera-recorder';
-import { BrowserMicrophoneRecorder, listBrowserMicrophones } from '../../../api/microphone-recorder';
+import { BrowserMicrophoneRecorder } from '../../../api/microphone-recorder';
 import { BrowserSystemAudioRecorder } from '../../../api/system-audio-recorder';
-import type { RecordingConfiguration, RecordingPhase, RecordingSessionResult } from './recording-types';
+import { useDeviceToggles } from './useDeviceToggles';
+import type {
+  RecordingConfiguration,
+  RecordingPhase,
+  RecordingSessionResult,
+  RecordingStartFailure,
+  RecordingStartStage,
+  StartupSidecarState,
+} from './recording-types';
 
 type Recorder = BrowserCameraRecorder | BrowserMicrophoneRecorder | BrowserSystemAudioRecorder;
+type SidecarKind = 'camera' | 'microphone' | 'systemAudio';
 
 const inactiveCamera = 'off';
 const inactiveMicrophone = 'no-audio';
 const DEFAULT_CAMERA_PLACEMENT: CameraPlacement = { x: 0.72, y: 0.72, width: 0.24, height: 0.24 };
 
-export function useRecordingController(onComplete: (session: RecordingSessionResult) => void) {
+export function useRecordingController(
+  onComplete: (session: RecordingSessionResult) => void,
+  onStartupFailure?: (failure: RecordingStartFailure) => void,
+) {
   const phase = ref<RecordingPhase>('idle');
   const secondsRemaining = ref(0);
   const elapsedTenths = ref(0);
@@ -39,7 +50,13 @@ export function useRecordingController(onComplete: (session: RecordingSessionRes
   let pendingNativeStart: Promise<void> | null = null;
   let prewarm: Promise<boolean> | null = null;
   let preparedGeneration: number | null = null;
+  let nativeStarted = false;
   let cancelling = false;
+  const sidecarStates: Record<SidecarKind, StartupSidecarState> = {
+    camera: 'disabled',
+    microphone: 'disabled',
+    systemAudio: 'disabled',
+  };
 
   const cameraMetadata = async (): Promise<{ appearance?: CameraAppearance; placement?: CameraPlacement }> => {
     const overlay = await capture.getCameraOverlayState();
@@ -52,14 +69,52 @@ export function useRecordingController(onComplete: (session: RecordingSessionRes
             cornerRadius: overlay.cornerRadius as CameraAppearance['cornerRadius'],
           }
         : undefined;
-    // The native preview can be moved independently of the recorded canvas.
-    // Start every recording from a deterministic, in-frame bottom-right layout;
-    // the user can adjust the webcam clip later in the editor.
     return { appearance, placement: { ...DEFAULT_CAMERA_PLACEMENT } };
   };
 
+  const deviceToggles = useDeviceToggles({
+    getConfiguration: () => configuration,
+    setConfigurationCameraId: (id) => {
+      if (configuration) configuration.cameraId = id;
+    },
+    setConfigurationMicrophoneId: (id) => {
+      if (configuration) configuration.microphoneId = id;
+    },
+    getSessionId: () => sessionId,
+    getSessionTimelineStartedAt: () => sessionTimelineStartedAt,
+    getCamera: () => camera,
+    setCamera: (recorder) => {
+      camera = recorder;
+    },
+    getMicrophone: () => microphone,
+    setMicrophone: (recorder) => {
+      microphone = recorder;
+    },
+    getSystemAudio: () => systemAudio,
+    setSystemAudio: (recorder) => {
+      systemAudio = recorder;
+    },
+    setCameraEnabled: (enabled) => {
+      cameraEnabled.value = enabled;
+    },
+    setMicrophoneEnabled: (enabled) => {
+      microphoneEnabled.value = enabled;
+    },
+    setSystemAudioEnabled: (enabled) => {
+      systemAudioEnabled.value = enabled;
+    },
+    setError: (message) => {
+      error.value = message;
+    },
+    cameraMetadata,
+  });
+
   const isActive = computed(
-    () => phase.value === 'countdown' || phase.value === 'recording' || phase.value === 'paused',
+    () =>
+      phase.value === 'countdown' ||
+      phase.value === 'starting' ||
+      phase.value === 'recording' ||
+      phase.value === 'paused',
   );
   const clearCountdown = () => {
     if (countdown !== null) window.clearInterval(countdown);
@@ -76,21 +131,42 @@ export function useRecordingController(onComplete: (session: RecordingSessionRes
   const stopRecorder = async (recorder: Recorder | null, endNs?: number) => {
     await recorder?.stop(endNs).catch(() => undefined);
   };
+  const stopRecorderStrict = async (recorder: Recorder | null, endNs?: number) => {
+    await recorder?.stop(endNs);
+  };
 
   const prepareSources = async () => {
     if (!configuration) return;
     if (configuration.cameraId !== inactiveCamera) {
       try {
         camera = await BrowserCameraRecorder.request(configuration.cameraId);
+        sidecarStates.camera = 'prepared';
       } catch (reason) {
+        sidecarStates.camera = 'failed';
         if (!isCameraUnavailableError(reason)) throw reason;
         configuration.cameraId = inactiveCamera;
+        sidecarStates.camera = 'disabled';
         error.value = 'Camera is unavailable. Recording will continue without camera.';
       }
     }
-    if (configuration.microphoneId !== inactiveMicrophone)
-      microphone = await BrowserMicrophoneRecorder.request(configuration.microphoneId);
-    if (configuration.systemAudio) systemAudio = await BrowserSystemAudioRecorder.request();
+    if (configuration.microphoneId !== inactiveMicrophone) {
+      try {
+        microphone = await BrowserMicrophoneRecorder.request(configuration.microphoneId);
+        sidecarStates.microphone = 'prepared';
+      } catch (reason) {
+        sidecarStates.microphone = 'failed';
+        throw reason;
+      }
+    }
+    if (configuration.systemAudio) {
+      try {
+        systemAudio = await BrowserSystemAudioRecorder.request();
+        sidecarStates.systemAudio = 'prepared';
+      } catch (reason) {
+        sidecarStates.systemAudio = 'failed';
+        throw reason;
+      }
+    }
     cameraEnabled.value = Boolean(camera);
     microphoneEnabled.value = Boolean(microphone);
     systemAudioEnabled.value = Boolean(systemAudio);
@@ -99,11 +175,20 @@ export function useRecordingController(onComplete: (session: RecordingSessionRes
   const startSidecars = async () => {
     if (!sessionId) return;
     const { appearance, placement } = await cameraMetadata();
-    await Promise.all([
+    const results = await Promise.allSettled([
       camera?.start(sessionId, appearance, placement, sessionTimelineStartedAt),
       microphone?.start(sessionId),
       systemAudio?.start(sessionId),
     ]);
+    const mark = (recorder: Recorder | null, kind: SidecarKind, result: PromiseSettledResult<void>) => {
+      if (!recorder) return;
+      sidecarStates[kind] = result.status === 'fulfilled' ? 'started' : 'failed';
+    };
+    mark(camera, 'camera', results[0]);
+    mark(microphone, 'microphone', results[1]);
+    mark(systemAudio, 'systemAudio', results[2]);
+    const failed = results.find((result): result is PromiseRejectedResult => result.status === 'rejected');
+    if (failed) throw failed.reason;
   };
 
   const prewarmNativeRecording = async (generation: number) => {
@@ -127,41 +212,90 @@ export function useRecordingController(onComplete: (session: RecordingSessionRes
     return true;
   };
 
-  const beginNativeRecording = async (generation: number) => {
-    if (!configuration || generation !== recordingGeneration) return;
-    if (!prewarm || !(await prewarm) || generation !== recordingGeneration) return;
-    await capture.setCountdown(null);
-    recorderHoverOnlyActive.value = configuration.recordingBarVisibility === 'hover-only';
-    await capture.prepareRecordingSurface();
-    const session = await capture.startPreparedRecording();
-    // The native track creates the session timeline only once its start gate
-    // is released. Sidecars must use that same epoch, otherwise native startup
-    // latency is added to their final duration.
-    sessionTimelineStartedAt = performance.now();
+  const startupFailure = (generation: number, stage: RecordingStartStage, reason: unknown): RecordingStartFailure => ({
+    stage,
+    message: reason instanceof Error ? reason.message : String(reason),
+    nativePrepared: preparedGeneration === generation,
+    nativeStarted,
+    camera: sidecarStates.camera,
+    microphone: sidecarStates.microphone,
+    systemAudio: sidecarStates.systemAudio,
+  });
+
+  const terminateStartup = async (generation: number, failure: RecordingStartFailure) => {
+    if (generation !== recordingGeneration) return;
+    const cleanupErrors: string[] = [];
+    const runCleanup = async (operation: () => Promise<unknown>) => {
+      try {
+        await operation();
+      } catch (reason) {
+        cleanupErrors.push(reason instanceof Error ? reason.message : String(reason));
+      }
+    };
+    // Break any self-reference so resetState does not await the very operation
+    // that is currently failing.
+    pendingNativeStart = null;
+    const wasNativeStarted = nativeStarted;
+    const wasNativePrepared = preparedGeneration === generation;
+    const nativeSessionId = sessionId;
+    await runCleanup(() => stopRecorderStrict(camera));
+    await runCleanup(() => stopRecorderStrict(microphone));
+    await runCleanup(() => stopRecorderStrict(systemAudio));
+    if (wasNativeStarted) await runCleanup(() => capture.discardRecording(nativeSessionId ?? undefined));
+    else if (wasNativePrepared) await runCleanup(() => capture.cancelPreparedRecording());
     preparedGeneration = null;
-    if (generation !== recordingGeneration) {
-      await capture.stop().catch(() => undefined);
-      return;
-    }
-    if (!session.sessionId) throw new Error('The capture session did not provide an identifier.');
-    sessionId = session.sessionId;
-    projectId = session.projectId ?? null;
-    if (projectId) capture.setTeleprompterSession({ projectId, sessionId });
-    await startSidecars();
-    if (generation !== recordingGeneration) {
-      await Promise.all([stopRecorder(camera), stopRecorder(microphone), stopRecorder(systemAudio)]);
-      await capture.stop().catch(() => undefined);
-      return;
-    }
-    elapsedTenths.value = 0;
-    timer = window.setInterval(() => {
-      elapsedTenths.value += 1;
-    }, 100);
-    phase.value = 'recording';
+    capture.setTeleprompterSession(null);
+    if (cleanupErrors.length > 0) failure.cleanupErrors = cleanupErrors;
+    error.value = failure.message;
+    await resetState(true);
+    onStartupFailure?.(failure);
   };
 
-  const launchNativeRecording = (generation: number) => {
-    const operation = beginNativeRecording(generation);
+  const performStartup = async (generation: number) => {
+    if (!configuration) return;
+    let stage: RecordingStartStage = 'prepare-native';
+    try {
+      const prepared = prewarm ? await prewarm : false;
+      if (!prepared || generation !== recordingGeneration) return;
+      stage = 'start-native';
+      await capture.setCountdown(null);
+      recorderHoverOnlyActive.value = configuration.recordingBarVisibility === 'hover-only';
+      await capture.prepareRecordingSurface();
+      const session = await capture.startPreparedRecording();
+      // The native track creates the session timeline only once its start gate
+      // is released. Sidecars must use that same epoch, otherwise native startup
+      // latency is added to their final duration.
+      sessionTimelineStartedAt = performance.now();
+      if (generation !== recordingGeneration) {
+        await capture.stop().catch(() => undefined);
+        return;
+      }
+      nativeStarted = true;
+      preparedGeneration = null;
+      if (!session.sessionId) throw new Error('The capture session did not provide an identifier.');
+      sessionId = session.sessionId;
+      projectId = session.projectId ?? null;
+      if (projectId) capture.setTeleprompterSession({ projectId, sessionId });
+      stage = 'start-sidecars';
+      await startSidecars();
+      if (generation !== recordingGeneration) {
+        await Promise.all([stopRecorder(camera), stopRecorder(microphone), stopRecorder(systemAudio)]);
+        await capture.stop().catch(() => undefined);
+        return;
+      }
+      elapsedTenths.value = 0;
+      timer = window.setInterval(() => {
+        elapsedTenths.value += 1;
+      }, 100);
+      phase.value = 'recording';
+    } catch (reason) {
+      if (generation !== recordingGeneration) return;
+      await terminateStartup(generation, startupFailure(generation, stage, reason));
+    }
+  };
+
+  const launchNativeStartup = (generation: number) => {
+    const operation = performStartup(generation).catch(() => undefined);
     pendingNativeStart = operation;
     void operation.finally(() => {
       if (pendingNativeStart === operation) pendingNativeStart = null;
@@ -174,35 +308,44 @@ export function useRecordingController(onComplete: (session: RecordingSessionRes
     error.value = '';
     const generation = ++recordingGeneration;
     configuration = next;
+    preparedGeneration = null;
+    nativeStarted = false;
+    sidecarStates.camera = next.cameraId === inactiveCamera ? 'disabled' : 'failed';
+    sidecarStates.microphone = next.microphoneId === inactiveMicrophone ? 'disabled' : 'failed';
+    sidecarStates.systemAudio = next.systemAudio ? 'failed' : 'disabled';
+    let stage: RecordingStartStage = 'prepare-sources';
     try {
       await prepareSources();
+      if (generation !== recordingGeneration) return;
       if (next.region && next.regionOverlay)
         capture.showScreenRegionOverlay({ ...next.regionOverlay, region: next.region });
       secondsRemaining.value = Math.max(0, next.countdownSeconds);
       phase.value = 'countdown';
+      stage = 'prepare-native';
       prewarm = prewarmNativeRecording(generation);
       if (!(await prewarm) || generation !== recordingGeneration) return;
-      if (secondsRemaining.value === 0) return await launchNativeRecording(generation);
+      if (secondsRemaining.value === 0) {
+        phase.value = 'starting';
+        void launchNativeStartup(generation);
+        return;
+      }
       void capture.setCountdown(secondsRemaining.value);
       countdown = window.setInterval(() => {
-        secondsRemaining.value -= 1;
+        secondsRemaining.value = Math.max(0, secondsRemaining.value - 1);
         if (secondsRemaining.value > 0) {
           void capture.setCountdown(secondsRemaining.value);
           return;
         }
         clearCountdown();
         // The countdown is a visual gate, not part of the recording. Hide it
-        // at the exact zero boundary before waiting on IPC/native start.
+        // at the zero boundary before waiting on IPC/native start.
         void capture.setCountdown(null);
-        const operation = launchNativeRecording(generation);
-        void operation.catch((reason: unknown) => {
-          error.value = reason instanceof Error ? reason.message : String(reason);
-          void cancel();
-        });
+        phase.value = 'starting';
+        void launchNativeStartup(generation);
       }, 1000);
     } catch (reason) {
-      error.value = reason instanceof Error ? reason.message : String(reason);
-      await cancel();
+      if (generation !== recordingGeneration) return;
+      await terminateStartup(generation, startupFailure(generation, stage, reason));
     }
   };
 
@@ -220,19 +363,21 @@ export function useRecordingController(onComplete: (session: RecordingSessionRes
     sessionId = null;
     projectId = null;
     sessionTimelineStartedAt = 0;
+    nativeStarted = false;
     cameraEnabled.value = false;
     microphoneEnabled.value = false;
     systemAudioEnabled.value = false;
     recorderHoverOnlyActive.value = false;
     elapsedTenths.value = 0;
-    const pending = pendingNativeStart;
-    const armed = prewarm;
-    if (pending) await pending.catch(() => undefined);
-    if (armed) await armed.catch(() => undefined);
+    sidecarStates.camera = 'disabled';
+    sidecarStates.microphone = 'disabled';
+    sidecarStates.systemAudio = 'disabled';
+    // Cancel a prepared native recording without waiting for a blocked start.
     if (preparedGeneration !== null) {
       preparedGeneration = null;
-      await capture.cancelPreparedRecording().catch(() => undefined);
+      void capture.cancelPreparedRecording().catch(() => undefined);
     }
+    pendingNativeStart = null;
     prewarm = null;
     phase.value = 'idle';
   };
@@ -262,7 +407,7 @@ export function useRecordingController(onComplete: (session: RecordingSessionRes
   };
 
   const stop = async () => {
-    if (phase.value === 'countdown') return cancel();
+    if (phase.value === 'countdown' || phase.value === 'starting') return cancel();
     if (phase.value !== 'recording' && phase.value !== 'paused') return;
     const wasRecording = phase.value === 'recording';
     phase.value = 'finalizing';
@@ -323,105 +468,7 @@ export function useRecordingController(onComplete: (session: RecordingSessionRes
       phase.value = 'recording';
     }
   };
-  const resolveCameraSourceId = async () => {
-    if (!configuration) return null;
-    if (configuration.cameraId !== inactiveCamera) return configuration.cameraId;
-    const sources = await listBrowserCameras();
-    return (
-      sources.find((source) => source.isDefault && source.id !== 'camera:chromium:')?.id ??
-      sources.find((source) => source.id !== 'camera:chromium:')?.id ??
-      null
-    );
-  };
-  const resolveMicrophoneSourceId = async () => {
-    if (!configuration) return null;
-    if (configuration.microphoneId !== inactiveMicrophone) return configuration.microphoneId;
-    const sources = await listBrowserMicrophones();
-    return (
-      sources.find((source) => source.isDefault && source.id !== 'microphone:chromium:')?.id ??
-      sources.find((source) => source.id !== 'microphone:chromium:')?.id ??
-      null
-    );
-  };
-  const setToggleError = (reason: unknown) => {
-    error.value = reason instanceof Error ? reason.message : String(reason);
-  };
-  const toggleCamera = async () => {
-    if (!configuration || !sessionId) return;
-    if (camera) {
-      await stopRecorder(camera);
-      camera = null;
-      cameraEnabled.value = false;
-      return;
-    }
-    try {
-      const sourceId = await resolveCameraSourceId();
-      if (!sourceId) throw new Error('No camera is available.');
-      const { appearance, placement } = await cameraMetadata();
-      const nextCamera = await BrowserCameraRecorder.request(sourceId);
-      try {
-        await nextCamera.start(sessionId, appearance, placement, sessionTimelineStartedAt);
-      } catch (reason) {
-        await stopRecorder(nextCamera);
-        throw reason;
-      }
-      camera = nextCamera;
-      configuration.cameraId = sourceId;
-      cameraEnabled.value = true;
-    } catch (reason) {
-      if (isCameraUnavailableError(reason)) {
-        configuration.cameraId = inactiveCamera;
-        error.value = 'Camera is unavailable.';
-      } else setToggleError(reason);
-    }
-  };
-  const toggleMicrophone = async () => {
-    if (!configuration || !sessionId) return;
-    if (microphone) {
-      await stopRecorder(microphone);
-      microphone = null;
-      microphoneEnabled.value = false;
-      return;
-    }
-    try {
-      const sourceId = await resolveMicrophoneSourceId();
-      if (!sourceId) throw new Error('No microphone is available.');
-      const nextMicrophone = await BrowserMicrophoneRecorder.request(sourceId);
-      try {
-        await nextMicrophone.start(sessionId);
-      } catch (reason) {
-        await stopRecorder(nextMicrophone);
-        throw reason;
-      }
-      microphone = nextMicrophone;
-      configuration.microphoneId = sourceId;
-      microphoneEnabled.value = true;
-    } catch (reason) {
-      setToggleError(reason);
-    }
-  };
-  const toggleSystemAudio = async () => {
-    if (!sessionId) return;
-    if (systemAudio) {
-      await stopRecorder(systemAudio);
-      systemAudio = null;
-      systemAudioEnabled.value = false;
-      return;
-    }
-    try {
-      const nextSystemAudio = await BrowserSystemAudioRecorder.request();
-      try {
-        await nextSystemAudio.start(sessionId);
-      } catch (reason) {
-        await stopRecorder(nextSystemAudio);
-        throw reason;
-      }
-      systemAudio = nextSystemAudio;
-      systemAudioEnabled.value = true;
-    } catch (reason) {
-      setToggleError(reason);
-    }
-  };
+
   const recordingTime = computed(() => {
     const wholeSeconds = Math.floor(elapsedTenths.value / 10);
     return `${Math.floor(wholeSeconds / 60)
@@ -441,8 +488,8 @@ export function useRecordingController(onComplete: (session: RecordingSessionRes
     stop,
     cancel,
     togglePause,
-    toggleCamera,
-    toggleMicrophone,
-    toggleSystemAudio,
+    toggleCamera: deviceToggles.toggleCamera,
+    toggleMicrophone: deviceToggles.toggleMicrophone,
+    toggleSystemAudio: deviceToggles.toggleSystemAudio,
   };
 }

--- a/src/components/hud/tests/HUD.test.ts
+++ b/src/components/hud/tests/HUD.test.ts
@@ -250,7 +250,7 @@ describe('HUD', () => {
     await wrapper.get('.project-btn').trigger('click');
     expect(wrapper.find('.project-picker-stub').exists()).toBe(true);
     await wrapper.get('[aria-label="Close"]').trigger('click');
-    expect(capture.close).toHaveBeenCalledOnce();
+    expect(capture.quit).toHaveBeenCalledOnce();
   });
 
   it('keeps available interaction access out of the main HUD and preserves its height', async () => {
@@ -278,7 +278,7 @@ describe('HUD', () => {
 
     expect(wrapper.find('.hud-wrapper').exists()).toBe(true);
     expect(wrapper.find('.hud-body').exists()).toBe(false);
-    expect(wrapper.get('.editor-preparing-hud').text()).toContain('Loading the timeline');
+    expect(wrapper.get('.editor-preparing-hud').text().replaceAll('\u00a0', ' ')).toContain('Loading the timeline');
     expect(wrapper.get('[role="progressbar"]').attributes('aria-valuenow')).toBe('65');
   });
 

--- a/src/components/hud/tests/capture.mock.ts
+++ b/src/components/hud/tests/capture.mock.ts
@@ -28,6 +28,7 @@ export const captureMock = {
   discardRecording: vi.fn(),
   setSize: vi.fn(),
   close: vi.fn(),
+  quit: vi.fn(),
   minimize: vi.fn(),
   listProjects: vi.fn(),
   createProject: vi.fn(),

--- a/src/components/hud/tests/useRecordingController.test.ts
+++ b/src/components/hud/tests/useRecordingController.test.ts
@@ -74,7 +74,8 @@ describe('useRecordingController cancellation', () => {
     const cancellation = controller.cancel();
     started.resolve({ state: 'recording', sessionId: 'session-1' });
     await cancellation;
-    expect(capture.stop).toHaveBeenCalledOnce();
+    await vi.waitFor(() => expect(capture.discardRecording).toHaveBeenCalledWith('session-1'));
+    expect(capture.stop).not.toHaveBeenCalled();
     expect(controller.phase.value).toBe('idle');
   });
 
@@ -87,7 +88,8 @@ describe('useRecordingController cancellation', () => {
     const cancellation = controller.cancel();
     started.resolve({ state: 'recording', sessionId: 'session-2' });
     await Promise.all([starting, cancellation]);
-    expect(capture.stop).toHaveBeenCalledOnce();
+    await vi.waitFor(() => expect(capture.discardRecording).toHaveBeenCalledWith('session-2'));
+    expect(capture.stop).not.toHaveBeenCalled();
     expect(controller.phase.value).toBe('idle');
   });
 
@@ -100,6 +102,7 @@ describe('useRecordingController cancellation', () => {
     expect(capture.startPreparedRecording).toHaveBeenCalledOnce();
     started.resolve({ state: 'recording', sessionId: 'session-3' });
     await starting;
+    await vi.waitFor(() => expect(controller.phase.value).toBe('recording'));
     expect(controller.phase.value).toBe('recording');
   });
 
@@ -110,6 +113,7 @@ describe('useRecordingController cancellation', () => {
     });
     const controller = useRecordingController(vi.fn());
     await controller.start(configuration(0));
+    await vi.waitFor(() => expect(controller.phase.value).toBe('recording'));
 
     await controller.cancel();
 
@@ -128,6 +132,7 @@ describe('useRecordingController cancellation', () => {
     });
     const controller = useRecordingController(vi.fn());
     await controller.start(configuration(0));
+    await vi.waitFor(() => expect(controller.phase.value).toBe('recording'));
     expect(capture.setTeleprompterSession).toHaveBeenCalledWith(context);
     await controller.cancel();
   });

--- a/src/components/hud/tests/useRecordingControllerBranches.test.ts
+++ b/src/components/hud/tests/useRecordingControllerBranches.test.ts
@@ -66,6 +66,14 @@ const deferred = <T>() => {
   return { promise, resolve };
 };
 
+const waitForRecording = async (controller: ReturnType<typeof useRecordingController>) => {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (controller.phase.value === 'recording') return;
+    await Promise.resolve();
+  }
+  expect(controller.phase.value).toBe('recording');
+};
+
 let camera: ReturnType<typeof recorder>;
 let microphone: ReturnType<typeof recorder>;
 let systemAudio: ReturnType<typeof recorder>;
@@ -132,6 +140,7 @@ describe('useRecordingController branch behavior', () => {
       }),
     );
 
+    await waitForRecording(controller);
     expect(controller.phase.value).toBe('recording');
     expect(controller.cameraEnabled.value).toBe(true);
     expect(controller.microphoneEnabled.value).toBe(true);
@@ -187,6 +196,7 @@ describe('useRecordingController branch behavior', () => {
 
     await vi.advanceTimersByTimeAsync(2_000);
     await starting;
+    await waitForRecording(controller);
     await vi.advanceTimersByTimeAsync(500);
     await controller.stop();
 
@@ -203,6 +213,7 @@ describe('useRecordingController branch behavior', () => {
     await vi.advanceTimersByTimeAsync(1_000);
     expect(controller.secondsRemaining.value).toBe(1);
     await vi.advanceTimersByTimeAsync(1_000);
+    await waitForRecording(controller);
     expect(controller.phase.value).toBe('recording');
     expect(capture.setCountdown).toHaveBeenLastCalledWith(null);
     expect(capture.prepareRecordingSurface).toHaveBeenCalledOnce();
@@ -236,6 +247,7 @@ describe('useRecordingController branch behavior', () => {
     await controller.cancel();
     const active = useRecordingController(vi.fn());
     await active.start(configuration());
+    await waitForRecording(active);
     cameraApi.request.mockResolvedValueOnce(camera);
     await active.toggleCamera();
     expect(active.cameraEnabled.value).toBe(true);
@@ -244,6 +256,7 @@ describe('useRecordingController branch behavior', () => {
 
     const noCamera = useRecordingController(vi.fn());
     await noCamera.start(configuration());
+    await waitForRecording(noCamera);
     cameraApi.list.mockResolvedValueOnce([]);
     await noCamera.toggleCamera();
     expect(noCamera.error.value).toContain('No camera');
@@ -258,6 +271,7 @@ describe('useRecordingController branch behavior', () => {
   it('reports stop and preparation failures while preserving a recording phase', async () => {
     const controller = useRecordingController(vi.fn());
     await controller.start(configuration());
+    await waitForRecording(controller);
     capture.stopNativeRecording.mockRejectedValueOnce(new Error('stop failed'));
     await controller.stop();
     expect(controller.phase.value).toBe('recording');

--- a/src/i18n/bg/core.json
+++ b/src/i18n/bg/core.json
@@ -350,6 +350,7 @@
     "recordingControls": "Контроли за запис",
     "moveRecorderBar": "Преместване на лентата за запис",
     "ready": "Готово",
+    "preparing": "Подготовка…",
     "resumeRecording": "Продължаване на записа",
     "pauseRecording": "Поставяне на записа на пауза",
     "stopRecording": "Спиране на записа",

--- a/src/i18n/de/core.json
+++ b/src/i18n/de/core.json
@@ -350,6 +350,7 @@
     "recordingControls": "Aufnahmesteuerung",
     "moveRecorderBar": "Aufnahmeleiste verschieben",
     "ready": "Bereit",
+    "preparing": "Wird vorbereitet…",
     "resumeRecording": "Aufnahme fortsetzen",
     "pauseRecording": "Aufnahme pausieren",
     "stopRecording": "Aufnahme stoppen",

--- a/src/i18n/en/core.json
+++ b/src/i18n/en/core.json
@@ -350,6 +350,7 @@
     "recordingControls": "Recording controls",
     "moveRecorderBar": "Move recording bar",
     "ready": "Ready",
+    "preparing": "Preparing…",
     "resumeRecording": "Resume recording",
     "pauseRecording": "Pause recording",
     "stopRecording": "Stop recording",

--- a/src/i18n/es/core.json
+++ b/src/i18n/es/core.json
@@ -350,6 +350,7 @@
     "recordingControls": "Controles de grabación",
     "moveRecorderBar": "Mover la barra de grabación",
     "ready": "Listo",
+    "preparing": "Preparando…",
     "resumeRecording": "Reanudar grabación",
     "pauseRecording": "Pausar grabación",
     "stopRecording": "Detener grabación",

--- a/src/i18n/fr/core.json
+++ b/src/i18n/fr/core.json
@@ -350,6 +350,7 @@
     "recordingControls": "Contrôles d'enregistrement",
     "moveRecorderBar": "Déplacer la barre d’enregistrement",
     "ready": "Prêt",
+    "preparing": "Préparation…",
     "resumeRecording": "Reprendre l'enregistrement",
     "pauseRecording": "Mettre en pause",
     "stopRecording": "Arrêter l'enregistrement",

--- a/src/i18n/hi/core.json
+++ b/src/i18n/hi/core.json
@@ -350,6 +350,7 @@
     "recordingControls": "रिकॉर्डिंग नियंत्रण",
     "moveRecorderBar": "रिकॉर्डर बार खिसकाएँ",
     "ready": "तैयार",
+    "preparing": "तैयारी हो रही है…",
     "resumeRecording": "रिकॉर्डिंग जारी रखें",
     "pauseRecording": "रिकॉर्डिंग रोकें",
     "stopRecording": "रिकॉर्डिंग बंद करें",

--- a/src/i18n/it/core.json
+++ b/src/i18n/it/core.json
@@ -350,6 +350,7 @@
     "recordingControls": "Controlli registrazione",
     "moveRecorderBar": "Sposta barra di registrazione",
     "ready": "Pronto",
+    "preparing": "Preparazione…",
     "resumeRecording": "Riprendi registrazione",
     "pauseRecording": "Metti in pausa registrazione",
     "stopRecording": "Ferma registrazione",

--- a/src/i18n/ja/core.json
+++ b/src/i18n/ja/core.json
@@ -350,6 +350,7 @@
     "recordingControls": "録画コントロール",
     "moveRecorderBar": "録画バーを移動",
     "ready": "準備完了",
+    "preparing": "準備中…",
     "resumeRecording": "録画を再開",
     "pauseRecording": "録画を一時停止",
     "stopRecording": "録画を停止",

--- a/src/i18n/ko/core.json
+++ b/src/i18n/ko/core.json
@@ -350,6 +350,7 @@
     "recordingControls": "녹화 컨트롤",
     "moveRecorderBar": "녹화 막대 이동",
     "ready": "준비됨",
+    "preparing": "준비 중…",
     "resumeRecording": "녹화 재개",
     "pauseRecording": "녹화 일시 중지",
     "stopRecording": "녹화 중지",

--- a/src/i18n/pl/core.json
+++ b/src/i18n/pl/core.json
@@ -350,6 +350,7 @@
     "recordingControls": "Sterowanie nagrywaniem",
     "moveRecorderBar": "Przenieś pasek nagrywania",
     "ready": "Gotowe",
+    "preparing": "Przygotowywanie…",
     "resumeRecording": "Wznów nagrywanie",
     "pauseRecording": "Wstrzymaj nagrywanie",
     "stopRecording": "Zatrzymaj nagrywanie",

--- a/src/i18n/pt-BR/core.json
+++ b/src/i18n/pt-BR/core.json
@@ -350,6 +350,7 @@
     "recordingControls": "Controles de gravação",
     "moveRecorderBar": "Mover barra de gravação",
     "ready": "Pronto",
+    "preparing": "Preparando…",
     "resumeRecording": "Retomar gravação",
     "pauseRecording": "Pausar gravação",
     "stopRecording": "Parar gravação",

--- a/src/i18n/ru/core.json
+++ b/src/i18n/ru/core.json
@@ -350,6 +350,7 @@
     "recordingControls": "Управление записью",
     "moveRecorderBar": "Переместить панель записи",
     "ready": "Готово",
+    "preparing": "Подготовка…",
     "resumeRecording": "Продолжить запись",
     "pauseRecording": "Приостановить запись",
     "stopRecording": "Остановить запись",

--- a/src/i18n/zh-CN/core.json
+++ b/src/i18n/zh-CN/core.json
@@ -350,6 +350,7 @@
     "recordingControls": "录制控制",
     "moveRecorderBar": "移动录制栏",
     "ready": "准备就绪",
+    "preparing": "准备中…",
     "resumeRecording": "继续录制",
     "pauseRecording": "暂停录制",
     "stopRecording": "停止录制",

--- a/src/i18n/zh-TW/core.json
+++ b/src/i18n/zh-TW/core.json
@@ -350,6 +350,7 @@
     "recordingControls": "錄影控制",
     "moveRecorderBar": "移動錄影列",
     "ready": "準備就緒",
+    "preparing": "準備中…",
     "resumeRecording": "繼續錄影",
     "pauseRecording": "暫停錄影",
     "stopRecording": "停止錄影",

--- a/src/tests/App.test.ts
+++ b/src/tests/App.test.ts
@@ -9,6 +9,8 @@ const mocks = vi.hoisted(() => ({
     getPreferences: vi.fn(),
     setInteractive: vi.fn(),
     setCameraOverlayActive: vi.fn(),
+    hideScreenRegionOverlay: vi.fn(),
+    setCountdown: vi.fn(async () => undefined),
     resetCameraOverlayPlacement: vi.fn(),
     setWindowMode: vi.fn(),
     setSize: vi.fn(),
@@ -21,6 +23,8 @@ const mocks = vi.hoisted(() => ({
     onTrayStopRecording: vi.fn(),
     onPreferenceShortcut: vi.fn(),
     listProjects: vi.fn(),
+    renameProject: vi.fn(),
+    updateTrayMenu: vi.fn(),
   },
   controller: {
     recording: undefined as any,

--- a/test/auto-updater.test.cjs
+++ b/test/auto-updater.test.cjs
@@ -37,11 +37,36 @@ test('downloads only after the user requests it', async () => {
   assert.equal(updater.getState().status, 'downloaded');
 });
 
-test('restarts only after a downloaded update is ready', () => {
+test('restarts only after a downloaded update is ready', async () => {
   const { autoUpdater, updater } = setup();
-  assert.equal(updater.quitAndInstall(), false);
+  assert.equal(await updater.quitAndInstall(), false);
   autoUpdater.emit('update-downloaded', { version: '0.2.0' });
-  assert.equal(updater.quitAndInstall(), true);
+  assert.equal(await updater.quitAndInstall(), true);
+  assert.equal(autoUpdater.quitCalled, true);
+});
+
+test('waits for native shutdown before installing an update', async () => {
+  const autoUpdater = new EventEmitter();
+  autoUpdater.quitAndInstall = () => {
+    autoUpdater.quitCalled = true;
+  };
+  let releaseShutdown;
+  const updater = createAutoUpdater({
+    app: { isPackaged: true, getVersion: () => '0.1.0' },
+    BrowserWindow: { getAllWindows: () => [] },
+    autoUpdater,
+    openExternal: async () => undefined,
+    beforeQuitAndInstall: () =>
+      new Promise((resolve) => {
+        releaseShutdown = resolve;
+      }),
+  });
+  autoUpdater.emit('update-downloaded', { version: '0.2.0' });
+  const installing = updater.quitAndInstall();
+  await Promise.resolve();
+  assert.equal(autoUpdater.quitCalled, undefined);
+  releaseShutdown();
+  assert.equal(await installing, true);
   assert.equal(autoUpdater.quitCalled, true);
 });
 

--- a/test/capture-engine.test.cjs
+++ b/test/capture-engine.test.cjs
@@ -9,29 +9,43 @@ const { beforeEach, test } = require('node:test');
 const spawned = [];
 const interfaces = [];
 const writes = [];
+const childOptions = [];
 
 beforeEach(() => {
   spawned.length = 0;
   interfaces.length = 0;
   writes.length = 0;
+  childOptions.length = 0;
 });
 
-function fakeChild() {
+function fakeChild(options = {}) {
   const child = new EventEmitter();
+  const killResults = [...(options.killResults || [])];
   child.stdout = new PassThrough();
   child.stderr = new PassThrough();
+  child.stdinWriteError = options.stdinWriteError || null;
   child.stdin = {
     write: (chunk, cb) => {
       writes.push(chunk.toString());
-      if (cb) cb();
+      if (cb) cb(child.stdinWriteError);
       return true;
     },
     end: () => {},
   };
   child.killed = false;
   child.exitCode = null;
-  child.kill = () => {
+  child.killCalls = [];
+  child.kill = (signal) => {
+    child.killCalls.push(signal);
     child.killed = true;
+    const result = killResults.length ? killResults.shift() : true;
+    if (options.emitExitOnKill !== false && result !== false) {
+      queueMicrotask(() => {
+        child.exitCode = 0;
+        child.emit('exit', 0, null);
+      });
+    }
+    return result;
   };
   return child;
 }
@@ -50,13 +64,13 @@ function fakeInterface() {
 }
 
 childProcess.spawn = () => {
-  const child = fakeChild();
+  const child = fakeChild(childOptions.shift());
   spawned.push(child);
   return child;
 };
 readline.createInterface = () => fakeInterface();
 fs.existsSync = () => true;
-process.env.DEMO_RECORDER_CAPTURE_ENGINE = '/fake/capture-engine';
+process.env.BEAM_CAPTURE_ENGINE = '/fake/capture-engine';
 
 const { CaptureEngine } = require('../electron/capture/capture-engine.cjs');
 
@@ -76,20 +90,31 @@ test('a timed-out request kills the child, rejects all pending requests, and poi
   await assert.rejects(first, /Délai dépassé/);
   await assert.rejects(second, /Délai dépassé/);
   assert.equal(engine.isPoisoned, true);
+  const termination = engine.terminating?.promise;
+  assert.ok(termination);
+  spawned[0].exitCode = 1;
+  spawned[0].emit('exit', 1, null);
+  await termination;
   assert.equal(engine.process, null);
-  assert.equal(spawned[0].killed, true);
+  assert.equal(spawned[0].exitCode, 1);
 });
 
-test('the next request after a timeout spawns a fresh engine', async () => {
+test('a request cannot overlap a timed-out child while its exit is still unconfirmed', async () => {
+  childOptions.push({ emitExitOnKill: false });
   const engine = createEngine();
   await assert.rejects(engine.request('status', {}, { timeoutMs: 20 }), /Délai dépassé/);
   assert.equal(spawned.length, 1);
   assert.equal(engine.isPoisoned, true);
 
-  const next = engine.request('status', {}, { timeoutMs: 20 });
-  assert.equal(spawned.length, 2);
-  assert.equal(engine.isPoisoned, false);
+  const next = Promise.resolve().then(() => engine.request('status', {}, { timeoutMs: 20 }));
+  assert.equal(spawned.length, 1);
+  spawned[0].exitCode = 1;
+  spawned[0].emit('exit', 1, null);
   await assert.rejects(next, /Délai dépassé/);
+  assert.equal(spawned.length, 2);
+  spawned[1].exitCode = 1;
+  spawned[1].emit('exit', 1, null);
+  await engine.terminating?.promise;
 });
 
 test('a crashed child poisons the engine and rejects pending requests', async () => {
@@ -98,8 +123,111 @@ test('a crashed child poisons the engine and rejects pending requests', async ()
   spawned[0].emit('exit', 1, null);
 
   await assert.rejects(pending, /capture-engine arrêté/);
+  await engine.terminating?.promise;
   assert.equal(engine.isPoisoned, true);
   assert.equal(engine.process, null);
+});
+
+test('malformed protocol output poisons the exact child and rejects its requests', async () => {
+  const engine = createEngine();
+  const pending = engine.request('status', {}, { timeoutMs: 1000 });
+
+  interfaces[0].lineHandler('{not-json');
+
+  await assert.rejects(pending, /Réponse invalide/);
+  spawned[0].exitCode = 1;
+  spawned[0].emit('exit', 1, null);
+  await engine.terminating?.promise;
+  assert.equal(engine.isPoisoned, true);
+  assert.equal(engine.process, null);
+});
+
+test('a stdin write error rejects only the affected request and clears it from pending', async () => {
+  childOptions.push({ stdinWriteError: new Error('stdin closed') });
+  const engine = createEngine();
+
+  await assert.rejects(engine.request('status', {}, { timeoutMs: 1000 }), /stdin closed/);
+  assert.equal(engine.pending.size, 0);
+  assert.equal(engine.state, 'terminating');
+  spawned[0].exitCode = 1;
+  spawned[0].emit('exit', 1, null);
+  await engine.terminating?.promise;
+  assert.equal(engine.state, 'poisoned');
+});
+
+test('a child error poisons the engine and rejects every pending request', async () => {
+  const engine = createEngine();
+  const first = engine.request('status', {}, { timeoutMs: 1000 });
+  const second = engine.request('capabilities', {}, { timeoutMs: 1000 });
+
+  spawned[0].emit('error', new Error('spawn failed'));
+
+  await assert.rejects(first, /spawn failed/);
+  await assert.rejects(second, /spawn failed/);
+  spawned[0].exitCode = 1;
+  spawned[0].emit('exit', 1, null);
+  await engine.terminating?.promise;
+  assert.equal(engine.isPoisoned, true);
+});
+
+test('termination remains successful when the initial kill reports false but exit is observed', async () => {
+  childOptions.push({ killResults: [false] });
+  const engine = createEngine();
+  engine.ensureStarted();
+  const child = spawned[0];
+
+  const termination = engine.terminateProcess(new Error('kill reported false'));
+  const forced = engine.forceShutdown();
+  assert.deepEqual(child.killCalls, ['SIGKILL']);
+
+  const result = await Promise.all([termination, forced]).then(([value]) => value);
+  assert.equal(result.confirmed, false);
+});
+
+test('termination is bounded when a child never emits exit', async () => {
+  childOptions.push({ emitExitOnKill: false, killResults: [false, false] });
+  const engine = createEngine();
+  engine.ensureStarted();
+
+  const result = await engine.terminateProcess(new Error('missing exit'));
+
+  assert.equal(result.confirmed, false);
+  assert.equal(spawned[0].killCalls.length, 1);
+});
+
+test('forceShutdown also terminates a child already in the terminating state', async () => {
+  childOptions.push({ emitExitOnKill: false });
+  const engine = createEngine();
+  engine.ensureStarted();
+  const child = spawned[0];
+
+  const termination = engine.terminateProcess(new Error('first termination'));
+  const force = engine.forceShutdown();
+  assert.equal(spawned.length, 1);
+
+  child.exitCode = 1;
+  child.emit('exit', 1, null);
+  await Promise.all([termination, force]);
+
+  assert.equal(engine.state, 'shutdown');
+  assert.ok(child.killCalls.length >= 1, 'force shutdown must target the terminating child');
+});
+
+test('requests are gated as soon as engine shutdown begins', async () => {
+  const engine = createEngine();
+  engine.ensureStarted();
+  const shutdown = engine.shutdown();
+
+  await assert.rejects(engine.request('status', {}, { timeoutMs: 20 }), /disabled during application shutdown/);
+  const stopWrite = writes.find((line) => line.includes('"command":"stop"'));
+  const { id } = JSON.parse(stopWrite);
+  interfaces[0].lineHandler(JSON.stringify({ requestId: id, ok: true, result: {} }));
+  spawned[0].exitCode = 0;
+  spawned[0].emit('exit', 0, null);
+  await shutdown;
+
+  assert.equal(spawned.length, 1);
+  assert.equal(engine.state, 'shutdown');
 });
 
 test('shutdown gracefully stops, force-kills the child, and stays idempotent', async () => {
@@ -111,9 +239,11 @@ test('shutdown gracefully stops, force-kills the child, and stays idempotent', a
   const stopWrite = writes.find((line) => line.includes('"command":"stop"'));
   const { id } = JSON.parse(stopWrite);
   interfaces[0].lineHandler(JSON.stringify({ requestId: id, ok: true, result: { sessionId: 'done' } }));
+  spawned[0].exitCode = 0;
+  spawned[0].emit('exit', 0, null);
 
   await shutdownPromise;
-  assert.equal(spawned[0].killed, true);
+  assert.equal(spawned[0].exitCode, 0);
   assert.equal(engine.process, null);
 
   await engine.shutdown();

--- a/test/capture-engine.test.cjs
+++ b/test/capture-engine.test.cjs
@@ -1,0 +1,121 @@
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const { PassThrough } = require('node:stream');
+const childProcess = require('node:child_process');
+const readline = require('node:readline');
+const fs = require('node:fs');
+const { beforeEach, test } = require('node:test');
+
+const spawned = [];
+const interfaces = [];
+const writes = [];
+
+beforeEach(() => {
+  spawned.length = 0;
+  interfaces.length = 0;
+  writes.length = 0;
+});
+
+function fakeChild() {
+  const child = new EventEmitter();
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.stdin = {
+    write: (chunk, cb) => {
+      writes.push(chunk.toString());
+      if (cb) cb();
+      return true;
+    },
+    end: () => {},
+  };
+  child.killed = false;
+  child.exitCode = null;
+  child.kill = () => {
+    child.killed = true;
+  };
+  return child;
+}
+
+function fakeInterface() {
+  const iface = {
+    lineHandler: null,
+    on: (event, handler) => {
+      if (event === 'line') iface.lineHandler = handler;
+      return iface;
+    },
+    close: () => {},
+  };
+  interfaces.push(iface);
+  return iface;
+}
+
+childProcess.spawn = () => {
+  const child = fakeChild();
+  spawned.push(child);
+  return child;
+};
+readline.createInterface = () => fakeInterface();
+fs.existsSync = () => true;
+process.env.DEMO_RECORDER_CAPTURE_ENGINE = '/fake/capture-engine';
+
+const { CaptureEngine } = require('../electron/capture/capture-engine.cjs');
+
+function createEngine() {
+  return new CaptureEngine(
+    { isPackaged: false, getVersion: () => '1.2.3', getPath: () => '/tmp/beam' },
+    '/tmp/beam',
+    {},
+  );
+}
+
+test('a timed-out request kills the child, rejects all pending requests, and poisons the engine', async () => {
+  const engine = createEngine();
+  const first = engine.request('status', {}, { timeoutMs: 20 });
+  const second = engine.request('capabilities', {}, { timeoutMs: 20 });
+
+  await assert.rejects(first, /Délai dépassé/);
+  await assert.rejects(second, /Délai dépassé/);
+  assert.equal(engine.isPoisoned, true);
+  assert.equal(engine.process, null);
+  assert.equal(spawned[0].killed, true);
+});
+
+test('the next request after a timeout spawns a fresh engine', async () => {
+  const engine = createEngine();
+  await assert.rejects(engine.request('status', {}, { timeoutMs: 20 }), /Délai dépassé/);
+  assert.equal(spawned.length, 1);
+  assert.equal(engine.isPoisoned, true);
+
+  const next = engine.request('status', {}, { timeoutMs: 20 });
+  assert.equal(spawned.length, 2);
+  assert.equal(engine.isPoisoned, false);
+  await assert.rejects(next, /Délai dépassé/);
+});
+
+test('a crashed child poisons the engine and rejects pending requests', async () => {
+  const engine = createEngine();
+  const pending = engine.request('status', {}, { timeoutMs: 1000 });
+  spawned[0].emit('exit', 1, null);
+
+  await assert.rejects(pending, /capture-engine arrêté/);
+  assert.equal(engine.isPoisoned, true);
+  assert.equal(engine.process, null);
+});
+
+test('shutdown gracefully stops, force-kills the child, and stays idempotent', async () => {
+  const engine = createEngine();
+  engine.ensureStarted();
+  assert.equal(spawned.length, 1);
+
+  const shutdownPromise = engine.shutdown();
+  const stopWrite = writes.find((line) => line.includes('"command":"stop"'));
+  const { id } = JSON.parse(stopWrite);
+  interfaces[0].lineHandler(JSON.stringify({ requestId: id, ok: true, result: { sessionId: 'done' } }));
+
+  await shutdownPromise;
+  assert.equal(spawned[0].killed, true);
+  assert.equal(engine.process, null);
+
+  await engine.shutdown();
+  assert.equal(spawned.length, 1);
+});

--- a/test/capture-ipc.test.cjs
+++ b/test/capture-ipc.test.cjs
@@ -90,6 +90,65 @@ test('resolves display bounds by native display id without relying on desktop pr
   assert.equal(previewCalls, 0);
 });
 
+test('wraps native errors with the failing command context', async () => {
+  const handlers = new Map();
+  const ipcMain = { handle: (channel, handler) => handlers.set(channel, handler) };
+  const captureEngine = {
+    request: async () => {
+      throw new Error('boom');
+    },
+  };
+
+  registerCaptureIpc({
+    ipcMain,
+    desktopCapturer: {},
+    screen: {},
+    captureEngine,
+    app: {},
+    userPaths: { projects: 'recordings' },
+    trackStorages: [],
+  });
+
+  const request = handlers.get('capture:request');
+  await assert.rejects(() => request({}, 'start-prepared-recording'), /capture-engine a échoué pour "start": boom/);
+});
+
+test('invalidates the deferred session and rejects when the engine is poisoned', async () => {
+  const handlers = new Map();
+  const ipcMain = { handle: (channel, handler) => handlers.set(channel, handler) };
+  let poisoned = false;
+  const captureEngine = {
+    get isPoisoned() {
+      return poisoned;
+    },
+    request: async (command) => {
+      if (poisoned) {
+        const error = new Error(`Délai dépassé pour la commande "${command}"`);
+        error.code = 'capture-engine-poisoned';
+        throw error;
+      }
+      return { state: 'stopped', sessionId: 'session-1', manifestPath: null };
+    },
+  };
+
+  registerCaptureIpc({
+    ipcMain,
+    desktopCapturer: {},
+    screen: {},
+    captureEngine,
+    app: {},
+    userPaths: { projects: 'recordings' },
+    trackStorages: [],
+  });
+
+  const request = handlers.get('capture:request');
+  await request({}, 'stop-native-recording');
+  poisoned = true;
+
+  await assert.rejects(() => request({}, 'start-prepared-recording'), /capture-engine a échoué pour "start"/);
+  await assert.rejects(() => request({}, 'complete-native-recording'), /No native recording is waiting/);
+});
+
 test('does not enumerate Electron sources on the Linux Portal path', async () => {
   const handlers = new Map();
   let previewCalls = 0;

--- a/test/devtools-policy.test.cjs
+++ b/test/devtools-policy.test.cjs
@@ -11,7 +11,7 @@ test('auto-opens DevTools in development with explicit opt-in', () => {
   assert.equal(
     shouldAutoOpenDevTools({
       isPackaged: false,
-      environment: { DEMO_RECORDER_DEVTOOLS: '1' },
+      environment: { BEAM_DEVTOOLS: '1' },
     }),
     true,
   );
@@ -21,7 +21,7 @@ test('never auto-opens DevTools in packaged builds', () => {
   assert.equal(
     shouldAutoOpenDevTools({
       isPackaged: true,
-      environment: { DEMO_RECORDER_DEVTOOLS: '1' },
+      environment: { BEAM_DEVTOOLS: '1' },
     }),
     false,
   );

--- a/test/fatal-lifecycle.test.cjs
+++ b/test/fatal-lifecycle.test.cjs
@@ -1,0 +1,47 @@
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const { test } = require('node:test');
+const { registerFatalLifecycle } = require('../electron/lifecycle/fatal-events.cjs');
+
+const setup = () => {
+  const app = new EventEmitter();
+  const powerMonitor = new EventEmitter();
+  const processTarget = new EventEmitter();
+  const requests = [];
+  let accepting = true;
+  app.quit = () => requests.push('quit');
+  app.exit = (code) => requests.push(`exit:${code}`);
+  const coordinator = {
+    canAcceptWork: () => accepting,
+    requestShutdown: async (source) => {
+      accepting = false;
+      requests.push(source);
+    },
+  };
+  registerFatalLifecycle({ app, powerMonitor, processTarget, coordinator });
+  return { app, powerMonitor, processTarget, requests };
+};
+
+test('renderer, GPU and main JavaScript failures enter the central fatal shutdown path', async () => {
+  for (const trigger of [
+    ({ app }) => app.emit('render-process-gone', {}, { id: 7 }, { reason: 'crashed', exitCode: 9 }),
+    ({ app }) => app.emit('child-process-gone', {}, { type: 'GPU', reason: 'crashed', exitCode: 9 }),
+    ({ processTarget }) => processTarget.emit('uncaughtException', new Error('boom')),
+    ({ processTarget }) => processTarget.emit('unhandledRejection', new Error('boom')),
+  ]) {
+    const context = setup();
+    trigger(context);
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.ok(context.requests.includes('fatal') || context.requests.includes('renderer-crash'));
+    assert.ok(context.requests.includes('exit:1'));
+  }
+});
+
+test('OS shutdown and signals request normal quit while clean Electron children are ignored', () => {
+  const context = setup();
+  context.app.emit('child-process-gone', {}, { type: 'Utility', reason: 'clean-exit', exitCode: 0 });
+  assert.deepEqual(context.requests, []);
+  context.powerMonitor.emit('shutdown');
+  context.processTarget.emit('SIGTERM');
+  assert.deepEqual(context.requests, ['quit', 'quit']);
+});

--- a/test/shutdown-ipc.test.cjs
+++ b/test/shutdown-ipc.test.cjs
@@ -1,0 +1,30 @@
+const assert = require('node:assert/strict');
+const { test } = require('node:test');
+const { createShutdownAwareIpc } = require('../electron/lifecycle/shutdown-ipc.cjs');
+
+test('new invoke and send IPC work is rejected as soon as shutdown begins', async () => {
+  const handlers = new Map();
+  const listeners = new Map();
+  let accepting = true;
+  const ipcMain = {
+    handle: (channel, handler) => handlers.set(channel, handler),
+    on: (channel, listener) => listeners.set(channel, listener),
+  };
+  const gated = createShutdownAwareIpc(ipcMain, () => accepting);
+  let sends = 0;
+  gated.handle('record', async () => 'started');
+  gated.on('window:create', () => {
+    sends += 1;
+  });
+
+  assert.equal(await handlers.get('record')({}), 'started');
+  listeners.get('window:create')({});
+  assert.equal(sends, 1);
+  accepting = false;
+  await assert.rejects(
+    async () => handlers.get('record')({}),
+    (error) => error.code === 'application-shutting-down',
+  );
+  assert.equal(listeners.get('window:create')({}), false);
+  assert.equal(sends, 1);
+});

--- a/test/shutdown-lifecycle.test.cjs
+++ b/test/shutdown-lifecycle.test.cjs
@@ -1,0 +1,91 @@
+const assert = require('node:assert/strict');
+const { test } = require('node:test');
+const { createShutdownCoordinator } = require('../electron/lifecycle/shutdown-coordinator.cjs');
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+test('shutdown is idempotent, gates concurrent requests, and runs each cleanup once', async () => {
+  let releaseGracefulStop;
+  let gracefulCalls = 0;
+  let forceCalls = 0;
+  let cleanupCalls = 0;
+  const captureEngine = {
+    shutdown: () => {
+      gracefulCalls += 1;
+      return new Promise((resolve) => {
+        releaseGracefulStop = resolve;
+      });
+    },
+    forceShutdown: async () => {
+      forceCalls += 1;
+    },
+  };
+  const coordinator = createShutdownCoordinator({ captureEngine, gracefulDeadlineMs: 1000 });
+  coordinator.registerCleanup({ id: 'window', cleanup: () => (cleanupCalls += 1) });
+
+  const first = coordinator.requestShutdown('before-quit');
+  const second = coordinator.requestShutdown('renderer-crash');
+  assert.strictEqual(first, second);
+  assert.equal(coordinator.isShuttingDown(), true);
+  await sleep(0);
+  assert.equal(gracefulCalls, 1);
+
+  releaseGracefulStop();
+  await first;
+
+  assert.equal(forceCalls, 1);
+  assert.equal(cleanupCalls, 1);
+  assert.equal(coordinator.isComplete(), true);
+  assert.strictEqual(coordinator.requestShutdown('tray'), first);
+});
+
+test('the coordinator enforces a global shutdown deadline over a hung native stop', async () => {
+  let forceCalls = 0;
+  let cleanupCalls = 0;
+  const captureEngine = {
+    shutdown: () => new Promise(() => {}),
+    forceShutdown: async () => {
+      forceCalls += 1;
+    },
+  };
+  const coordinator = createShutdownCoordinator({
+    captureEngine,
+    gracefulDeadlineMs: 200,
+    cleanupDeadlineMs: 200,
+    shutdownDeadlineMs: 40,
+  });
+  coordinator.registerCleanup({ id: 'countdown', cleanup: () => (cleanupCalls += 1) });
+
+  const startedAt = Date.now();
+  const result = await coordinator.requestShutdown('fatal');
+  const elapsed = Date.now() - startedAt;
+
+  assert.ok(elapsed < 150, `shutdown exceeded the global deadline (${elapsed}ms)`);
+  assert.equal(forceCalls, 1);
+  assert.equal(cleanupCalls, 1);
+  assert.equal(coordinator.isComplete(), true);
+  assert.ok(result.errors.some((message) => /deadline|exceeded/i.test(message)));
+});
+
+test('cleanup errors are recorded while other resources continue to be cleaned up', async () => {
+  const cleaned = [];
+  const captureEngine = {
+    shutdown: async () => {},
+    forceShutdown: async () => {},
+  };
+  const coordinator = createShutdownCoordinator({ captureEngine, cleanupDeadlineMs: 20 });
+  coordinator.registerCleanup({
+    id: 'broken-window',
+    cleanup: async () => {
+      await sleep(50);
+      throw new Error('destroy failed');
+    },
+  });
+  coordinator.registerCleanup({ id: 'tray', cleanup: () => cleaned.push('tray') });
+
+  const result = await coordinator.requestShutdown('window-all-closed');
+
+  assert.deepEqual(cleaned, ['tray']);
+  assert.ok(result.errors.some((message) => /broken-window:.*exceeded|destroy failed/.test(message)));
+  assert.equal(coordinator.isComplete(), true);
+});

--- a/test/single-instance.test.cjs
+++ b/test/single-instance.test.cjs
@@ -1,0 +1,35 @@
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const { test } = require('node:test');
+const { initializeSingleInstance } = require('../electron/lifecycle/single-instance.cjs');
+
+test('a losing Beam instance exits before any application resource is initialized', () => {
+  const app = new EventEmitter();
+  let quit = 0;
+  let initialized = 0;
+  app.requestSingleInstanceLock = () => false;
+  app.quit = () => {
+    quit += 1;
+  };
+  const acquired = initializeSingleInstance({ app, initialize: () => (initialized += 1), restoreHud: () => {} });
+  assert.equal(acquired, false);
+  assert.equal(quit, 1);
+  assert.equal(initialized, 0);
+  assert.equal(app.listenerCount('second-instance'), 0);
+});
+
+test('a second launch restores the canonical HUD path without reinitializing Beam', () => {
+  const app = new EventEmitter();
+  let initialized = 0;
+  let restored = 0;
+  app.requestSingleInstanceLock = () => true;
+  app.quit = () => assert.fail('the owning instance must not quit');
+  initializeSingleInstance({
+    app,
+    initialize: () => (initialized += 1),
+    restoreHud: () => (restored += 1),
+  });
+  app.emit('second-instance');
+  assert.equal(initialized, 1);
+  assert.equal(restored, 1);
+});


### PR DESCRIPTION
## What changed

- makes recording startup and cancellation generation-safe, including deferred native cleanup
- blocks new recordings until stale native sessions are actually discarded
- adds a terminating state to the capture-engine child lifecycle and prevents PID overlap before respawn
- adds a bounded, idempotent application shutdown coordinator and gates new IPC/window work during shutdown
- routes HUD quit, updater install, signals, OS shutdown, renderer crashes, Electron child crashes, uncaught exceptions, and unhandled rejections through lifecycle cleanup
- enforces a single Beam instance and restores the HUD through the canonical editor/HUD path
- adds Windows parent-handle validation and a kill-on-close Job Object, Linux PDEATHSIG/process-group containment, and a macOS kqueue parent watcher
- contains FFmpeg and privileged input-helper descendants
- renames remaining demo-recorder identifiers to Beam
- adds lifecycle documentation and exact-PID Windows/Linux verification scripts

## Why

A blocked or timed-out native capture start could complete after cancellation, race a later recording, or leave an uncertain capture engine alive. Electron also cleared its only child reference before confirming exit, so a replacement engine could overlap the old PID. Hidden windows and incomplete crash/update paths could keep Beam alive after the user closed it.

## Impact

Recording startup failures return to the HUD with copyable context, stale callbacks cannot restore recording state, and application shutdown prevents new work before terminating owned windows and native processes. Process termination is exact-child/process-tree scoped; no broad executable-name kill is used.

## Validation

- `npm run typecheck`
- focused Vitest: 63 passed
- focused Node lifecycle/capture tests: 34 passed
- Rust format and strict Clippy for capture library/engine/helper
- focused Rust process/helper tests: 14 passed, 1 hardware FFmpeg test ignored
- `cargo check --target x86_64-pc-windows-gnu --lib --bin capture-engine`
- Linux real parent-death harness passed with stdin deliberately held open
- `npm run build`
- `git diff --check`

## Remaining platform proof

The real Windows recording/process matrix is intentionally still unchecked: screen/window capture, multiple monitors and DPI, camera/microphone/system audio combinations, denied permissions, cancellation/stop at every phase, engine timeout/crash, repeated recordings, and Task Manager PID evidence. Run `scripts/windows/verify-process-lifecycle.ps1` on a Windows machine before release sign-off.

Repository-wide `npm run typecheck:vue` still reports pre-existing HUD/editor/UI errors outside this lifecycle change; the changed TypeScript boundary and production build pass. macOS runtime validation is also unavailable from the Linux development host because the capture dependency requires Apple's Swift toolchain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clearer recording startup feedback with a localized “Preparing…” state.
  - Added detailed startup errors, automatic HUD restoration, and safer cancellation.
  - Added a Close action that cleanly quits the app.
  - Added single-instance behavior and improved second-launch recovery.

- **Bug Fixes**
  - Improved shutdown reliability, resource cleanup, updater restarts, and capture recovery.
  - Prevented new recording work during shutdown.
  - Added protections against lingering capture processes after app exit.

- **Documentation**
  - Added cross-platform process-lifecycle guidance and verification checklists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->