### PR TITLE
fix(linux): install the versioned input helper in deb/rpm postinst

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,9 @@ jobs:
           dpkg-deb --contents "$deb" | grep 'resources/package-type'
           rpm --query --package --list "$rpm_package" | grep "resources/capture-engine/capture-engine-$version"
           rpm --query --package --list "$rpm_package" | grep 'resources/package-type'
+          sudo apt-get install --yes "$deb"
+          test -x /usr/libexec/beam-input-helper
+          test -f /usr/share/polkit-1/actions/com.beam.input-monitor.policy
           node scripts/release/artifacts.cjs metadata dist_electron latest-linux.yml
       - uses: actions/upload-artifact@v4
         if: github.event_name == 'pull_request'

--- a/build/linux/after-install.sh
+++ b/build/linux/after-install.sh
@@ -8,14 +8,15 @@ if command -v gtk-update-icon-cache >/dev/null 2>&1; then
   gtk-update-icon-cache --force /usr/share/icons/hicolor || true
 fi
 
-for helper in \
-  /opt/Beam/resources/input-helper/beam-input-helper \
-  /opt/beam/resources/input-helper/beam-input-helper
+for directory in /opt/Beam/resources/input-helper /opt/beam/resources/input-helper
 do
-  if [ -x "$helper" ]; then
-    "$helper" install >/dev/null
-    exit 0
-  fi
+  for helper in "$directory"/beam-input-helper-*
+  do
+    if [ -x "$helper" ]; then
+      "$helper" install >/dev/null
+      exit 0
+    fi
+  done
 done
 
 echo "Beam input helper was not found in the installed application" >&2

--- a/test/linux-postinst.test.cjs
+++ b/test/linux-postinst.test.cjs
@@ -1,0 +1,57 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const test = require('node:test');
+
+const AFTER_INSTALL = path.join(__dirname, '..', 'build', 'linux', 'after-install.sh');
+
+function runAfterInstall(directory, withHelper) {
+  const helperDirectory = path.join(directory, '/opt/Beam/resources/input-helper');
+  fs.mkdirSync(helperDirectory, { recursive: true });
+  if (withHelper) {
+    const helper = path.join(helperDirectory, 'beam-input-helper-1.2.3');
+    fs.writeFileSync(helper, '#!/bin/sh\nprintf "%s" "$1" > "$MARKER"\n');
+    fs.chmodSync(helper, 0o755);
+  }
+  const script = path.join(directory, 'after-install.sh');
+  fs.writeFileSync(
+    script,
+    fs
+      .readFileSync(AFTER_INSTALL, 'utf8')
+      .replaceAll('/opt/Beam', path.join(directory, '/opt/Beam'))
+      .replaceAll('/opt/beam', path.join(directory, '/opt/beam')),
+  );
+  return spawnSync('sh', [script], {
+    env: { ...process.env, MARKER: path.join(directory, 'called') },
+    encoding: 'utf8',
+  });
+}
+
+function withTempDirectory(callback) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'beam-postinst-'));
+  try {
+    callback(directory);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+test('after-install runs the versioned input helper install', { skip: process.platform === 'win32' }, () => {
+  withTempDirectory((directory) => {
+    const result = runAfterInstall(directory, true);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(fs.readFileSync(path.join(directory, 'called'), 'utf8'), 'install');
+  });
+});
+
+test('after-install fails when no input helper is packaged', { skip: process.platform === 'win32' }, () => {
+  withTempDirectory((directory) => {
+    const result = runAfterInstall(directory, false);
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /Beam input helper was not found/);
+  });
+});


### PR DESCRIPTION
## fix(linux): install the versioned input helper in deb/rpm postinst

### Problem

Installing the `.deb` fails on Ubuntu:

``` text
Setting up beam (0.1.9)…
Beam input helper was not found in the installed application
dpkg: error processing package beam (--install):
 old beam package postinst maintainer script subprocess failed with exit status 1
```

### Root cause

Linux packages ship the input helper with a versioned filename:
`resources/input-helper/beam-input-helper-0.1.9`. This matches what the
app uses at runtime and what CI already checks.

However, `build/linux/after-install.sh` looked for an unversioned
`beam-input-helper`. It never found the helper and exited with status 1,
causing the postinst to fail.

CI did not run the postinst, so this bug shipped in 0.1.9.

### Changes

-   **`build/linux/after-install.sh`**: Find `beam-input-helper-*` under
    `/opt/Beam` and `/opt/beam` instead of requiring an unversioned
    filename. The existing error when no helper is found is preserved.
-   **`.github/workflows/ci.yml`**: Install the built `.deb` with
    `sudo apt-get install` so the real postinst runs. Verify
    `/usr/libexec/beam-input-helper` and the polkit policy exist.
-   **`test/linux-postinst.test.cjs`**: Add a hermetic test that runs
    the real `after-install.sh` against a simulated `/opt/Beam` tree. It
    verifies that the versioned helper is called with `install` and that
    the script fails when no helper exists.

### Testing

`node --test test/linux-postinst.test.cjs`: 2 passing.

Full validation runs in CI, which builds all three Linux package formats
and installs the `.deb`.

-------------

Fixes: #25 