### PR TITLE
Fix audio clip actions and transitions

### DIFF
--- a/src/components/video-editor/properties/PropertiesPanel.vue
+++ b/src/components/video-editor/properties/PropertiesPanel.vue
@@ -56,6 +56,7 @@ const { t: tBlur } = useTranslate('BlurPropertiesPanel');
 const { t: tSidebar } = useTranslate('SidebarPanel');
 const { t: tTimeline } = useTranslate('TimelineTracks');
 const { t: tTransitions } = useTranslate('TransitionsPanel');
+const { t: tAudioClip } = useTranslate('AudioClipPropertiesPanel');
 const props = withDefaults(
   defineProps<{
     activeTab: string;
@@ -251,7 +252,6 @@ const isCurrentClipEnabled = computed(() => {
 
 const isDeletable = computed(() => {
   if (props.activeTab === 'zoom' && props.selectedZoom) return true;
-  if (props.activeTab === 'clip' && props.selectedClip?.kind === 'audio') return false;
   if (props.activeTab === 'clip' && (props.selectedClip || props.selectedCaptionClip)) return true;
   return false;
 });
@@ -268,6 +268,9 @@ const deleteTooltip = computed(() => {
     return tCaption('deleteCaptionClip') || 'Delete caption';
   }
   if (props.selectedClip) {
+    if (props.selectedClip.kind === 'audio') {
+      return tAudioClip('deleteAudioClip') || 'Delete audio clip';
+    }
     if (props.selectedClip.kind === 'blur') {
       return tBlur('delete') ? `${tBlur('delete')} (${panelTitle.value.toLowerCase()})` : 'Delete blur';
     }
@@ -359,8 +362,6 @@ defineExpose({ openCanvasTransitions: openTransitionEdge });
               v-else-if="activeTab === 'clip' && normalizedSelectedClip?.kind === 'audio'"
               :clip="normalizedSelectedClip"
               @update:volume="emit('update:clip-volume', $event)"
-              @update:enabled="emit('update:clip-enabled', $event)"
-              @delete="emit('delete-clip')"
             />
             <BlurPropertiesPanel
               v-else-if="activeTab === 'clip' && normalizedSelectedClip?.kind === 'blur'"

--- a/src/components/video-editor/properties/clip/AudioClipPropertiesPanel.vue
+++ b/src/components/video-editor/properties/clip/AudioClipPropertiesPanel.vue
@@ -2,19 +2,15 @@
 import { computed } from 'vue';
 import BigSlider from '~/ui/slider/BigSlider.vue';
 import { useTranslate } from '~/i18n/useTranslate';
-import ClipActionGroup from './ClipActionGroup.vue';
 
 const { t } = useTranslate('AudioClipPropertiesPanel');
-const { t: tClip } = useTranslate('ClipPropertiesPanel');
 
 const props = defineProps<{
-  clip: { name?: string; enabled?: boolean; volume?: number } | null;
+  clip: { volume?: number } | null;
 }>();
 
 const emit = defineEmits<{
   (e: 'update:volume', value: number): void;
-  (e: 'update:enabled', value: boolean): void;
-  (e: 'delete'): void;
 }>();
 
 const volume = computed(() => props.clip?.volume ?? 100);
@@ -28,17 +24,6 @@ const volume = computed(() => props.clip?.volume ?? 100);
     </div>
     <div v-else class="options-group">
       <div class="section-block">
-        <div class="section-header">
-          <span class="section-title">{{ clip.name || t('audioClip') }}</span>
-          <ClipActionGroup
-            :enabled="clip.enabled ?? true"
-            :enabled-label="tClip('enabled')"
-            :disabled-label="tClip('disabled')"
-            :delete-label="t('deleteAudioClip')"
-            @toggle="emit('update:enabled', !(clip.enabled ?? true))"
-            @delete="emit('delete')"
-          />
-        </div>
         <BigSlider
           :model-value="volume"
           :default-value="100"
@@ -70,22 +55,6 @@ const volume = computed(() => props.clip?.volume ?? 100);
   display: flex;
   flex-direction: column;
   gap: 10px;
-}
-.section-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  min-height: 28px;
-  gap: 12px;
-}
-.section-title {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  color: var(--text-primary);
-  font-size: 12px;
-  font-weight: 700;
 }
 .empty-desc {
   color: var(--text-secondary);

--- a/src/components/video-editor/properties/clip/tests/AudioClipPropertiesPanel.test.ts
+++ b/src/components/video-editor/properties/clip/tests/AudioClipPropertiesPanel.test.ts
@@ -6,16 +6,12 @@ const BigSlider = {
   emits: ['update:modelValue'],
   template: '<button class="volume-slider" @click="$emit(\'update:modelValue\', 125)">Volume</button>',
 };
-const Button = {
-  emits: ['click'],
-  template: '<button class="button-stub" @click="$emit(\'click\')"><slot /></button>',
-};
 
 describe('AudioClipPropertiesPanel', () => {
   it('renders the empty state without a clip', () => {
     const wrapper = mount(AudioClipPropertiesPanel, {
       props: { clip: null },
-      global: { stubs: { BigSlider, Button } },
+      global: { stubs: { BigSlider } },
     });
     expect(wrapper.find('.empty-state').exists()).toBe(true);
     expect(wrapper.find('.options-group').exists()).toBe(false);
@@ -24,26 +20,21 @@ describe('AudioClipPropertiesPanel', () => {
   it('emits volume changes for a clip', async () => {
     const wrapper = mount(AudioClipPropertiesPanel, {
       props: { clip: { name: 'Voice track', enabled: true, volume: 80 } },
-      global: { stubs: { BigSlider, Button } },
+      global: { stubs: { BigSlider } },
     });
-    expect(wrapper.get('.section-title').text()).toBe('Voice track');
+    expect(wrapper.find('.section-title').exists()).toBe(false);
+    expect(wrapper.find('.button-stub').exists()).toBe(false);
     await wrapper.get('.volume-slider').trigger('click');
     expect(wrapper.emitted('update:volume')).toEqual([[125]]);
   });
 
-  it('emits enabled changes and deletes from the inline action group', async () => {
+  it('renders only the volume control for a selected clip', () => {
     const wrapper = mount(AudioClipPropertiesPanel, {
       props: { clip: { name: 'Voice track', enabled: true, volume: 80 } },
-      global: { stubs: { BigSlider, Button } },
+      global: { stubs: { BigSlider } },
     });
 
-    const buttons = wrapper.findAll('.button-stub');
-    expect(buttons).toHaveLength(2);
-
-    await buttons[0]!.trigger('click');
-    expect(wrapper.emitted('update:enabled')).toEqual([[false]]);
-
-    await wrapper.get('.button-stub.delete-button').trigger('click');
-    expect(wrapper.emitted('delete')).toHaveLength(1);
+    expect(wrapper.findAll('.volume-slider')).toHaveLength(1);
+    expect(wrapper.findAll('button')).toHaveLength(1);
   });
 });

--- a/src/components/video-editor/tests/PropertiesPanel.test.ts
+++ b/src/components/video-editor/tests/PropertiesPanel.test.ts
@@ -8,6 +8,7 @@ import { DEFAULT_WATERMARK, type OutputCanvasSettings } from '../canvas/output-c
 import { createDefaultCaptionStyle, createDefaultClipAppearance } from '~/media/shared/composition-defaults';
 import {
   emptyComposition as createEmptyComposition,
+  type AudioClip,
   type CaptionClip,
   type ClipComposition,
 } from '~/media/shared/composition-types';
@@ -60,12 +61,9 @@ const ZoomPanel = { template: '<div class="zoom-panel-stub">Zoom</div>' };
 const SettingsPanel = { template: '<div class="settings-panel-stub">Settings</div>' };
 const AudioClipPropertiesPanel = {
   props: ['clip'],
-  emits: ['update:enabled', 'delete'],
   template: `
     <div class="audio-clip-stub">
       {{ clip?.kind || "audio" }}
-      <button class="audio-toggle" @click="$emit('update:enabled', false)">Toggle</button>
-      <button class="audio-delete" @click="$emit('delete')">Delete</button>
     </div>
   `,
 };
@@ -119,13 +117,22 @@ const captionClip: CaptionClip = {
   },
 };
 
-const audioClip = {
+const audioClip: AudioClip = {
   id: 'audio',
   kind: 'audio',
   name: 'Audio',
   timelineStartMs: 0,
-  timelineDurationMs: 100,
-} as const;
+  timelineDurationMs: 2_000,
+  sourceInMs: 0,
+  sourceDurationMs: 2_000,
+  playbackRate: 1,
+  transitions: { entry: null, exit: null },
+  enabled: true,
+  order: 0,
+  assetId: 'audio-asset',
+  role: 'system',
+  volume: 100,
+};
 
 const screenClip = {
   id: 'screen',
@@ -162,6 +169,23 @@ const webcamClip = {
 
 const emptyBackgroundGroups: BackgroundMediaGroup[] = [];
 const composition: ClipComposition = createEmptyComposition();
+const audioComposition: ClipComposition = {
+  ...composition,
+  assets: [
+    {
+      id: 'audio-asset',
+      kind: 'audio',
+      name: 'Audio',
+      fileName: 'audio.wav',
+      durationMs: 2_000,
+      width: null,
+      height: null,
+      src: 'audio.wav',
+      origin: 'project',
+    },
+  ],
+  clips: [audioClip],
+};
 const noBackground: BackgroundValue | null = null;
 const noZoom: ZoomElement | null = null;
 const noEditorData: ProjectEditorData | null = null;
@@ -442,14 +466,9 @@ describe('PropertiesPanel', () => {
     await wrapper.setProps({
       activeTab: 'clip',
       selectedClip: audioClip,
+      composition: audioComposition,
     });
     expect(wrapper.find('.audio-clip-stub').exists()).toBe(true);
-    expect(wrapper.find('.panel-header-actions').exists()).toBe(false);
-
-    await wrapper.get('.audio-toggle').trigger('click');
-    expect(wrapper.emitted('update:clip-enabled')).toEqual([[false]]);
-    await wrapper.get('.audio-delete').trigger('click');
-    expect(wrapper.emitted('delete-clip')).toHaveLength(1);
 
     await wrapper.setProps({ selectedClip: null, selectedCaptionClip: captionClip });
     expect(wrapper.find('.caption-clip-stub').exists()).toBe(true);
@@ -458,6 +477,46 @@ describe('PropertiesPanel', () => {
       selectedClip: screenClip,
     });
     expect(wrapper.find('.clip-panel-stub').text()).toBe('video');
+  });
+
+  it('renders audio actions in the header and opens audio transitions with None and Fade', async () => {
+    const wrapper = mount(PropertiesPanel, {
+      props: { ...baseProps, activeTab: 'clip', selectedClip: audioClip, composition: audioComposition },
+      global,
+    });
+
+    const buttons = wrapper.findAll('.panel-header-actions button');
+    expect(buttons).toHaveLength(3);
+
+    await buttons[0]!.trigger('click');
+    expect(wrapper.emitted('update:clip-enabled')).toEqual([[false]]);
+    await buttons[2]!.trigger('click');
+    expect(wrapper.emitted('delete-clip')).toHaveLength(1);
+
+    await buttons[1]!.trigger('click');
+    expect(wrapper.get('.panel-title').text()).toBe('Audio Transitions');
+    expect(wrapper.findAll('.preset-card-info strong').map((label) => label.text())).toEqual(['None', 'Fade']);
+    expect(wrapper.get('.duration-control').text()).toContain('Select a transition');
+
+    await wrapper.findAll('.preset-card')[1]!.trigger('click');
+    expect(wrapper.emitted('update:composition')).toContainEqual([
+      expect.objectContaining({
+        clips: [
+          expect.objectContaining({
+            transitions: { entry: { preset: { kind: 'fade' }, durationMs: 500 }, exit: null },
+          }),
+        ],
+      }),
+    ]);
+
+    await wrapper.setProps({
+      composition: {
+        ...audioComposition,
+        clips: [{ ...audioClip, transitions: { entry: { preset: { kind: 'fade' }, durationMs: 500 }, exit: null } }],
+      },
+    });
+    expect(wrapper.find('.duration-slider').exists()).toBe(true);
+    expect(wrapper.get('.big-slider-value').text()).toBe('500 ms');
   });
 
   it('keeps non-audio clip actions in the header and toggles/deletes them', async () => {


### PR DESCRIPTION
## Summary

- move audio clip actions into the properties header
- remove the duplicated audio clip title and inline action group
- expose the existing audio fade transition controls and duration
- cover the audio header actions and transition panel

## Validation

Not rerun for publication, per request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Audio clips can now be deleted directly from the properties panel.
  - Audio clip settings are streamlined to focus on volume adjustment.
  - Added clearer tooltip text for audio clip deletion.
  - Audio selection now supports header actions, transition navigation, transition preset selection, transition updates, and duration display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->