### PR TITLE
fix(shortcuts): global shortcuts not working on previous gnome versions

### DIFF
--- a/electron/lifecycle/single-instance.cjs
+++ b/electron/lifecycle/single-instance.cjs
@@ -1,11 +1,28 @@
-function initializeSingleInstance({ app, initialize, restoreHud }) {
+function shortcutId(commandLine) {
+  const argument = (commandLine || []).find((value) => value.startsWith('--beam-shortcut='));
+  if (!argument) return null;
+  try {
+    const id = decodeURIComponent(argument.slice('--beam-shortcut='.length));
+    return id || null;
+  } catch {
+    return null;
+  }
+}
+
+function initializeSingleInstance({ app, initialize, restoreHud, handleShortcut = null, commandLine = process.argv }) {
   if (!app.requestSingleInstanceLock()) {
     app.quit();
     return false;
   }
-  app.on('second-instance', () => restoreHud());
+  app.on('second-instance', (_event, commandLine) => {
+    const id = shortcutId(commandLine);
+    if (id && handleShortcut) return handleShortcut(id);
+    restoreHud();
+  });
   initialize();
+  const id = shortcutId(commandLine);
+  if (id && handleShortcut) handleShortcut(id);
   return true;
 }
 
-module.exports = { initializeSingleInstance };
+module.exports = { initializeSingleInstance, shortcutId };

--- a/electron/lifecycle/single-instance.cjs
+++ b/electron/lifecycle/single-instance.cjs
@@ -16,7 +16,7 @@ function initializeSingleInstance({ app, initialize, restoreHud, handleShortcut 
   }
   app.on('second-instance', (_event, commandLine) => {
     const id = shortcutId(commandLine);
-    if (id && handleShortcut) return handleShortcut(id);
+    if (id && handleShortcut && handleShortcut(id)) return;
     restoreHud();
   });
   initialize();

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -36,6 +36,7 @@ const { createWhisperModelStore } = require('./captions/whisper-model-store.cjs'
 const { registerWhisperIpc } = require('./captions/whisper-ipc.cjs');
 const { createPreferencesStore } = require('./preferences/preferences-store.cjs');
 const { registerPreferencesIpc } = require('./preferences/preferences-ipc.cjs');
+const { createLinuxShortcutSource } = require('./preferences/linux-shortcut-source.cjs');
 const { createTeleprompterWindow } = require('./teleprompter/teleprompter-window.cjs');
 const { registerTeleprompterIpc } = require('./teleprompter/teleprompter-ipc.cjs');
 const { createTeleprompterStorage } = require('./teleprompter/teleprompter-storage.cjs');
@@ -70,12 +71,19 @@ const logStartup = (step) => {
 };
 
 const applicationRoot = path.join(__dirname, '..');
+if (process.platform === 'linux') {
+  // Use Chromium's XDG GlobalShortcuts portal on desktops that provide it.
+  app.commandLine.appendSwitch('enable-features', 'GlobalShortcutsPortal');
+}
 const controllers = new WeakMap();
 let captureEngine = null;
 let coordinator = null;
 let quitting = false;
 let showExistingHud = () => false;
 let pendingHudRestore = false;
+let shortcutReady = false;
+const pendingExternalShortcuts = [];
+let externalShortcutHandler = (id) => pendingExternalShortcuts.push(id);
 
 function restoreCanonicalHud() {
   if (showExistingHud()) pendingHudRestore = false;
@@ -247,12 +255,28 @@ function initializeApplication() {
       appIconPath,
     });
     setTimeout(() => teleprompterWindow.prepare(), 0);
+    const dispatchShortcut = (id) => {
+      if (id.startsWith('teleprompter.')) return teleprompterWindow.handleShortcut(id);
+      BrowserWindow.getAllWindows().forEach((win) => win.webContents.send('preferences:shortcut', id));
+    };
+    externalShortcutHandler = (id) => {
+      if (!shortcutReady) {
+        pendingExternalShortcuts.push(id);
+        return;
+      }
+      if (preferencesStore.read().shortcuts[id]?.scope === 'global') dispatchShortcut(id);
+    };
     const preferencesCleanup = registerPreferencesIpc({
       ipcMain: applicationIpc,
       BrowserWindow,
       globalShortcut,
       store: preferencesStore,
-      shortcutHandler: (id) => teleprompterWindow.handleShortcut(id),
+      shortcutHandler: dispatchShortcut,
+      linuxShortcutSource: createLinuxShortcutSource({
+        app,
+        applicationRoot,
+        platform: process.platform,
+      }),
       onPreferencesChanged: (preferences) => {
         for (const win of BrowserWindow.getAllWindows()) {
           const controller = controllers.get(win);
@@ -379,6 +403,10 @@ function initializeApplication() {
       if (coordinator.canAcceptWork()) app.quit();
     });
     const win = createWindow(preferencesStore, appIconPath);
+    win.webContents.once('did-finish-load', () => {
+      shortcutReady = true;
+      for (const id of pendingExternalShortcuts.splice(0)) externalShortcutHandler(id);
+    });
     const selectedTheme = preferencesStore.read().theme;
     const editorWindow = createEditorWindowManager({
       applicationRoot,
@@ -472,4 +500,5 @@ initializeSingleInstance({
   app,
   initialize: initializeApplication,
   restoreHud: restoreCanonicalHud,
+  handleShortcut: (id) => externalShortcutHandler(id),
 });

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -83,7 +83,10 @@ let showExistingHud = () => false;
 let pendingHudRestore = false;
 let shortcutReady = false;
 const pendingExternalShortcuts = [];
-let externalShortcutHandler = (id) => pendingExternalShortcuts.push(id);
+let externalShortcutHandler = (id) => {
+  pendingExternalShortcuts.push(id);
+  return false;
+};
 
 function restoreCanonicalHud() {
   if (showExistingHud()) pendingHudRestore = false;
@@ -258,13 +261,15 @@ function initializeApplication() {
     const dispatchShortcut = (id) => {
       if (id.startsWith('teleprompter.')) return teleprompterWindow.handleShortcut(id);
       BrowserWindow.getAllWindows().forEach((win) => win.webContents.send('preferences:shortcut', id));
+      return true;
     };
     externalShortcutHandler = (id) => {
       if (!shortcutReady) {
         pendingExternalShortcuts.push(id);
-        return;
+        return false;
       }
-      if (preferencesStore.read().shortcuts[id]?.scope === 'global') dispatchShortcut(id);
+      if (preferencesStore.read().shortcuts[id]?.scope === 'global') return dispatchShortcut(id);
+      return false;
     };
     const preferencesCleanup = registerPreferencesIpc({
       ipcMain: applicationIpc,

--- a/electron/preferences/linux-shortcut-source.cjs
+++ b/electron/preferences/linux-shortcut-source.cjs
@@ -135,14 +135,14 @@ function createLinuxShortcutSource({
     const entries = Object.entries(preferences.shortcuts)
       .filter(([, entry]) => entry.scope === 'global')
       .map(([id, entry]) => ({ id, path: customPath(id), binding: gnomeAccelerator(entry.keys) }));
-    if (entries.some((entry) => !entry.binding)) return false;
+    const gnomeEntries = entries.filter((entry) => entry.binding);
     try {
       const currentPaths = await readCurrentPaths();
       const paths = [
         ...currentPaths.filter((path) => !path.startsWith(BEAM_ROOT)),
-        ...entries.map((entry) => entry.path),
+        ...gnomeEntries.map((entry) => entry.path),
       ];
-      for (const entry of entries) {
+      for (const entry of gnomeEntries) {
         const schema = `${CUSTOM_SCHEMA}:${entry.path}`;
         await run(execFile, ['set', schema, 'name', gvariantString(`Beam ${entry.id}`)]);
         await run(execFile, [
@@ -154,9 +154,12 @@ function createLinuxShortcutSource({
         await run(execFile, ['set', schema, 'binding', gvariantString(entry.binding)]);
       }
       await setPaths(paths);
-      return true;
+      return {
+        gnomeIds: gnomeEntries.map((entry) => entry.id),
+        fallbackIds: entries.filter((entry) => !entry.binding).map((entry) => entry.id),
+      };
     } catch {
-      return false;
+      return null;
     }
   };
 

--- a/electron/preferences/linux-shortcut-source.cjs
+++ b/electron/preferences/linux-shortcut-source.cjs
@@ -1,0 +1,171 @@
+const { execFile: defaultExecFile } = require('node:child_process');
+const { createHash } = require('node:crypto');
+
+const SETTINGS_SCHEMA = 'org.gnome.settings-daemon.plugins.media-keys';
+const CUSTOM_SCHEMA = `${SETTINGS_SCHEMA}.custom-keybinding`;
+const CUSTOM_ROOT = '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/';
+const BEAM_ROOT = `${CUSTOM_ROOT}beam-`;
+const SHORTCUT_ARGUMENT = '--beam-shortcut=';
+
+const MODIFIERS = new Map([
+  ['ctrl', 'Control'],
+  ['control', 'Control'],
+  ['commandorcontrol', 'Control'],
+  ['alt', 'Alt'],
+  ['shift', 'Shift'],
+  ['meta', 'Super'],
+  ['super', 'Super'],
+  ['cmd', 'Super'],
+  ['command', 'Super'],
+]);
+
+const SPECIAL_KEYS = new Map([
+  ['arrowup', 'Up'],
+  ['arrowdown', 'Down'],
+  ['arrowleft', 'Left'],
+  ['arrowright', 'Right'],
+  ['up', 'Up'],
+  ['down', 'Down'],
+  ['left', 'Left'],
+  ['right', 'Right'],
+  ['escape', 'Escape'],
+  ['esc', 'Escape'],
+  ['space', 'space'],
+  ['enter', 'Return'],
+  ['return', 'Return'],
+  ['backspace', 'BackSpace'],
+  ['delete', 'Delete'],
+  ['insert', 'Insert'],
+  ['home', 'Home'],
+  ['end', 'End'],
+  ['pageup', 'Page_Up'],
+  ['pagedown', 'Page_Down'],
+]);
+
+function isGnomeWayland(platform, env) {
+  const desktop = `${env.XDG_CURRENT_DESKTOP || ''}:${env.XDG_SESSION_DESKTOP || ''}`.toLowerCase();
+  return (
+    platform === 'linux' &&
+    (env.XDG_SESSION_TYPE === 'wayland' || Boolean(env.WAYLAND_DISPLAY)) &&
+    /(^|:)gnome($|:)|(^|:)ubuntu($|:)/.test(desktop)
+  );
+}
+
+function gnomeAccelerator(keys) {
+  const tokens = String(keys)
+    .split('+')
+    .map((token) => token.trim().toLowerCase())
+    .filter(Boolean);
+  const modifiers = [];
+  let key = null;
+  for (const token of tokens) {
+    const modifier = MODIFIERS.get(token);
+    if (modifier) {
+      if (!modifiers.includes(modifier)) modifiers.push(modifier);
+      continue;
+    }
+    if (key) return null;
+    key =
+      SPECIAL_KEYS.get(token) ||
+      (/^[a-z]$/.test(token)
+        ? token
+        : /^\d$/.test(token)
+          ? token
+          : /^f(?:[1-9]|1[0-2])$/.test(token)
+            ? token.toUpperCase()
+            : null);
+  }
+  if (!key) return null;
+  return `${modifiers.map((modifier) => `<${modifier}>`).join('')}${key}`;
+}
+
+function customPath(id) {
+  const digest = createHash('sha256').update(id).digest('hex').slice(0, 16);
+  return `${BEAM_ROOT}${digest}/`;
+}
+
+function gvariantString(value) {
+  return `'${String(value).replaceAll('\\', '\\\\').replaceAll("'", "\\'")}'`;
+}
+
+function gvariantStringList(values) {
+  return `[${values.map(gvariantString).join(', ')}]`;
+}
+
+function shellQuote(value) {
+  return `'${String(value).replaceAll("'", "'\\''")}'`;
+}
+
+function readPaths(output) {
+  return [...String(output).matchAll(/'([^']+)'/g)].map((match) => match[1]);
+}
+
+function run(execFile, args) {
+  return new Promise((resolve, reject) => {
+    execFile('gsettings', args, { encoding: 'utf8' }, (error, stdout, stderr) => {
+      if (error) reject(error);
+      else resolve({ stdout, stderr });
+    });
+  });
+}
+
+function shortcutCommand({ app, applicationRoot, id }) {
+  const executable = typeof app.getPath === 'function' ? app.getPath('exe') : process.execPath;
+  const command = app.isPackaged ? [executable] : [executable, '--no-sandbox', applicationRoot];
+  return `${command.map(shellQuote).join(' ')} ${shellQuote(`${SHORTCUT_ARGUMENT}${encodeURIComponent(id)}`)}`;
+}
+
+function createLinuxShortcutSource({
+  app,
+  applicationRoot,
+  platform = process.platform,
+  env = process.env,
+  execFile = defaultExecFile,
+} = {}) {
+  if (!isGnomeWayland(platform, env)) return null;
+
+  const readCurrentPaths = async () =>
+    readPaths((await run(execFile, ['get', SETTINGS_SCHEMA, 'custom-keybindings'])).stdout);
+  const setPaths = (paths) => run(execFile, ['set', SETTINGS_SCHEMA, 'custom-keybindings', gvariantStringList(paths)]);
+  const cleanup = async () => {
+    const paths = await readCurrentPaths();
+    await setPaths(paths.filter((path) => !path.startsWith(BEAM_ROOT)));
+  };
+  const register = async (preferences) => {
+    const entries = Object.entries(preferences.shortcuts)
+      .filter(([, entry]) => entry.scope === 'global')
+      .map(([id, entry]) => ({ id, path: customPath(id), binding: gnomeAccelerator(entry.keys) }));
+    if (entries.some((entry) => !entry.binding)) return false;
+    try {
+      const currentPaths = await readCurrentPaths();
+      const paths = [
+        ...currentPaths.filter((path) => !path.startsWith(BEAM_ROOT)),
+        ...entries.map((entry) => entry.path),
+      ];
+      for (const entry of entries) {
+        const schema = `${CUSTOM_SCHEMA}:${entry.path}`;
+        await run(execFile, ['set', schema, 'name', gvariantString(`Beam ${entry.id}`)]);
+        await run(execFile, [
+          'set',
+          schema,
+          'command',
+          gvariantString(shortcutCommand({ app, applicationRoot, id: entry.id })),
+        ]);
+        await run(execFile, ['set', schema, 'binding', gvariantString(entry.binding)]);
+      }
+      await setPaths(paths);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  return { register, cleanup };
+}
+
+module.exports = {
+  createLinuxShortcutSource,
+  gnomeAccelerator,
+  isGnomeWayland,
+  customPath,
+};

--- a/electron/preferences/preferences-ipc.cjs
+++ b/electron/preferences/preferences-ipc.cjs
@@ -19,18 +19,24 @@ function registerPreferencesIpc({
       .catch(() => {})
       .then(async () => {
         globalShortcut.unregisterAll();
-        let registeredByLinux = false;
+        let fallbackIds = Object.entries(preferences.shortcuts)
+          .filter(([, entry]) => entry.scope === 'global')
+          .map(([id]) => id);
         if (linuxShortcutSource) {
           try {
-            registeredByLinux = await linuxShortcutSource.register(preferences);
-            if (!registeredByLinux) await linuxShortcutSource.cleanup();
+            const result = await linuxShortcutSource.register(preferences);
+            if (result === null) {
+              await linuxShortcutSource.cleanup().catch(() => {});
+            } else {
+              fallbackIds = result.fallbackIds;
+            }
           } catch {
             await linuxShortcutSource.cleanup().catch(() => {});
           }
         }
-        if (registeredByLinux) return;
-        for (const [id, entry] of Object.entries(preferences.shortcuts)) {
-          if (entry.scope !== 'global') continue;
+        for (const id of fallbackIds) {
+          const entry = preferences.shortcuts[id];
+          if (!entry || entry.scope !== 'global') continue;
           globalShortcut.register(entry.keys, () => dispatch(id));
         }
       });

--- a/electron/preferences/preferences-ipc.cjs
+++ b/electron/preferences/preferences-ipc.cjs
@@ -5,41 +5,67 @@ function registerPreferencesIpc({
   store,
   shortcutHandler = null,
   onPreferencesChanged = null,
+  linuxShortcutSource = null,
 }) {
   const broadcast = (preferences) =>
     BrowserWindow.getAllWindows().forEach((win) => win.webContents.send('preferences:changed', preferences));
-  const registerShortcuts = (preferences) => {
-    globalShortcut.unregisterAll();
-    for (const [id, entry] of Object.entries(preferences.shortcuts)) {
-      if (entry.scope !== 'global') continue;
-      globalShortcut.register(entry.keys, () => {
-        if (shortcutHandler && id.startsWith('teleprompter.')) return shortcutHandler(id);
-        BrowserWindow.getAllWindows().forEach((win) => win.webContents.send('preferences:shortcut', id));
-      });
-    }
+  const dispatch = (id) => {
+    if (shortcutHandler) return shortcutHandler(id);
+    BrowserWindow.getAllWindows().forEach((win) => win.webContents.send('preferences:shortcut', id));
   };
-  const update = (patch) => {
+  let registration = Promise.resolve();
+  const registerShortcuts = (preferences) => {
+    registration = registration
+      .catch(() => {})
+      .then(async () => {
+        globalShortcut.unregisterAll();
+        let registeredByLinux = false;
+        if (linuxShortcutSource) {
+          try {
+            registeredByLinux = await linuxShortcutSource.register(preferences);
+            if (!registeredByLinux) await linuxShortcutSource.cleanup();
+          } catch {
+            await linuxShortcutSource.cleanup().catch(() => {});
+          }
+        }
+        if (registeredByLinux) return;
+        for (const [id, entry] of Object.entries(preferences.shortcuts)) {
+          if (entry.scope !== 'global') continue;
+          globalShortcut.register(entry.keys, () => dispatch(id));
+        }
+      });
+    return registration;
+  };
+  const update = async (patch) => {
     const preferences = store.patch(patch);
-    registerShortcuts(preferences);
+    await registerShortcuts(preferences);
     broadcast(preferences);
     onPreferencesChanged?.(preferences);
     return preferences;
   };
-  ipcMain.handle('preferences:get', () => store.read());
-  ipcMain.handle('preferences:update', (_event, patch) => update(patch));
-  ipcMain.handle('preferences:reset', (_event, keys) => {
+  const reset = async (_event, keys) => {
     const initial = require('./preferences-store.cjs').defaults();
     const current = store.read();
     const next = Array.isArray(keys)
       ? { ...current, ...Object.fromEntries(keys.filter((key) => key in initial).map((key) => [key, initial[key]])) }
       : initial;
     const preferences = store.write(next);
-    registerShortcuts(preferences);
+    await registerShortcuts(preferences);
     broadcast(preferences);
     onPreferencesChanged?.(preferences);
     return preferences;
-  });
-  registerShortcuts(store.read());
-  return () => globalShortcut.unregisterAll();
+  };
+
+  ipcMain.handle('preferences:get', () => store.read());
+  ipcMain.handle('preferences:update', (_event, patch) => update(patch));
+  ipcMain.handle('preferences:reset', reset);
+  void registerShortcuts(store.read());
+
+  return async () => {
+    await registration.catch(() => {});
+    await linuxShortcutSource?.cleanup?.();
+    globalShortcut.unregisterAll();
+  };
 }
+
 module.exports = { registerPreferencesIpc };

--- a/test/preferences/linux-shortcut-source.test.cjs
+++ b/test/preferences/linux-shortcut-source.test.cjs
@@ -56,7 +56,10 @@ test('registers only global shortcuts and preserves unrelated GNOME bindings', a
     execFile: fake.execFile,
   });
 
-  assert.equal(await source.register(preferences), true);
+  assert.deepEqual(await source.register(preferences), {
+    gnomeIds: ['hud.startStopRecording', 'teleprompter.nextLine'],
+    fallbackIds: [],
+  });
   const sets = fake.calls.filter(({ args }) => args[0] === 'set');
   const list = sets.find(({ args }) => args[2] === 'custom-keybindings');
   assert.match(list.args[3], /\/user\/custom\//);
@@ -64,6 +67,29 @@ test('registers only global shortcuts and preserves unrelated GNOME bindings', a
   assert.equal(sets.filter(({ args }) => args[2] === 'binding').length, 2);
   assert.ok(sets.some(({ args }) => args[2] === 'binding' && args[3] === "'<Alt><Shift>r'"));
   assert.ok(sets.some(({ args }) => args[2] === 'command' && args[3].includes('beam-shortcut=hud.startStopRecording')));
+});
+
+test('splits mixed accelerators into GNOME-owned and Electron-fallback lists', async () => {
+  const fake = fakeGsettings();
+  const source = createLinuxShortcutSource({
+    app,
+    applicationRoot: '/opt/Beam',
+    platform: 'linux',
+    env,
+    execFile: fake.execFile,
+  });
+
+  const result = await source.register({
+    shortcuts: {
+      'hud.startStopRecording': { keys: 'Alt+Shift+R', scope: 'global' },
+      'editor.playPause': { keys: 'MediaPlayPause', scope: 'global' },
+    },
+  });
+  assert.deepEqual(result, { gnomeIds: ['hud.startStopRecording'], fallbackIds: ['editor.playPause'] });
+  const sets = fake.calls.filter(({ args }) => args[0] === 'set');
+  assert.equal(sets.filter(({ args }) => args[2] === 'binding').length, 1);
+  assert.ok(sets.some(({ args }) => args[2] === 'command' && args[3].includes('beam-shortcut=hud.startStopRecording')));
+  assert.ok(sets.find(({ args }) => args[2] === 'custom-keybindings').args[3].includes('beam-'));
 });
 
 test('disables the dev Electron sandbox when GNOME launches a shortcut', async () => {
@@ -100,7 +126,7 @@ test('cleanup removes only Beam-owned bindings', async () => {
   assert.equal(list.args[3], "['/user/custom/']");
 });
 
-test('falls back when GNOME cannot accept a shortcut', async () => {
+test('reports a GSettings failure instead of claiming GNOME ownership', async () => {
   const fake = fakeGsettings();
   fake.execFile = (file, args, options, callback) => {
     fake.calls.push({ file, args });
@@ -114,5 +140,5 @@ test('falls back when GNOME cannot accept a shortcut', async () => {
     execFile: fake.execFile,
   });
 
-  assert.equal(await source.register(preferences), false);
+  assert.equal(await source.register(preferences), null);
 });

--- a/test/preferences/linux-shortcut-source.test.cjs
+++ b/test/preferences/linux-shortcut-source.test.cjs
@@ -1,0 +1,118 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  createLinuxShortcutSource,
+  customPath,
+  gnomeAccelerator,
+  isGnomeWayland,
+} = require('../../electron/preferences/linux-shortcut-source.cjs');
+
+const env = { XDG_SESSION_TYPE: 'wayland', XDG_CURRENT_DESKTOP: 'ubuntu:GNOME' };
+const app = { isPackaged: true, getPath: () => '/opt/Beam/beam' };
+const devApp = { isPackaged: false, getPath: () => '/opt/electron' };
+const preferences = {
+  shortcuts: {
+    'hud.startStopRecording': { keys: 'Alt+Shift+R', scope: 'global' },
+    'teleprompter.nextLine': { keys: 'Ctrl+Shift+Right', scope: 'global' },
+    'editor.playPause': { keys: 'Space', scope: 'application' },
+  },
+};
+
+function fakeGsettings(output = "['/user/custom/']\n") {
+  const calls = [];
+  const execFile = (file, args, _options, callback) => {
+    calls.push({ file, args });
+    callback(null, args[0] === 'get' ? output : '', '');
+  };
+  return { calls, execFile };
+}
+
+test('detects GNOME Wayland but leaves other Linux sessions alone', () => {
+  assert.equal(isGnomeWayland('linux', env), true);
+  assert.equal(isGnomeWayland('linux', { ...env, XDG_SESSION_TYPE: 'x11' }), false);
+  assert.equal(isGnomeWayland('linux', { ...env, XDG_CURRENT_DESKTOP: 'KDE' }), false);
+  assert.equal(isGnomeWayland('darwin', env), false);
+  assert.match(customPath('hud.startStopRecording'), /\/beam-[0-9a-f]{16}\/$/);
+});
+
+test('maps Beam accelerators to GNOME keybinding syntax', () => {
+  assert.equal(gnomeAccelerator('Alt+Shift+R'), '<Alt><Shift>r');
+  assert.equal(gnomeAccelerator('Ctrl+Shift+Right'), '<Control><Shift>Right');
+  assert.equal(gnomeAccelerator('Super+Space'), '<Super>space');
+  assert.equal(gnomeAccelerator('MediaPlayPause'), null);
+  assert.equal(gnomeAccelerator('Ctrl+Shift'), null);
+});
+
+test('registers only global shortcuts and preserves unrelated GNOME bindings', async () => {
+  const fake = fakeGsettings(
+    "['/user/custom/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/beam-old/']\n",
+  );
+  const source = createLinuxShortcutSource({
+    app,
+    applicationRoot: '/opt/Beam',
+    platform: 'linux',
+    env,
+    execFile: fake.execFile,
+  });
+
+  assert.equal(await source.register(preferences), true);
+  const sets = fake.calls.filter(({ args }) => args[0] === 'set');
+  const list = sets.find(({ args }) => args[2] === 'custom-keybindings');
+  assert.match(list.args[3], /\/user\/custom\//);
+  assert.doesNotMatch(list.args[3], /beam-old/);
+  assert.equal(sets.filter(({ args }) => args[2] === 'binding').length, 2);
+  assert.ok(sets.some(({ args }) => args[2] === 'binding' && args[3] === "'<Alt><Shift>r'"));
+  assert.ok(sets.some(({ args }) => args[2] === 'command' && args[3].includes('beam-shortcut=hud.startStopRecording')));
+});
+
+test('disables the dev Electron sandbox when GNOME launches a shortcut', async () => {
+  const fake = fakeGsettings();
+  const source = createLinuxShortcutSource({
+    app: devApp,
+    applicationRoot: '/home/beam',
+    platform: 'linux',
+    env,
+    execFile: fake.execFile,
+  });
+
+  await source.register({ shortcuts: { 'hud.startStopRecording': { keys: 'Alt+Shift+R', scope: 'global' } } });
+  const command = fake.calls.find(({ args }) => args[0] === 'set' && args[2] === 'command').args[3];
+  assert.match(command, /opt\/electron/);
+  assert.match(command, /--no-sandbox/);
+  assert.match(command, /home\/beam/);
+});
+
+test('cleanup removes only Beam-owned bindings', async () => {
+  const fake = fakeGsettings(
+    "['/user/custom/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/beam-old/']\n",
+  );
+  const source = createLinuxShortcutSource({
+    app,
+    applicationRoot: '/opt/Beam',
+    platform: 'linux',
+    env,
+    execFile: fake.execFile,
+  });
+
+  await source.cleanup();
+  const list = fake.calls.find(({ args }) => args[0] === 'set' && args[2] === 'custom-keybindings');
+  assert.equal(list.args[3], "['/user/custom/']");
+});
+
+test('falls back when GNOME cannot accept a shortcut', async () => {
+  const fake = fakeGsettings();
+  fake.execFile = (file, args, options, callback) => {
+    fake.calls.push({ file, args });
+    callback(args[0] === 'set' ? new Error('gsettings failed') : null, '', '');
+  };
+  const source = createLinuxShortcutSource({
+    app,
+    applicationRoot: '/opt/Beam',
+    platform: 'linux',
+    env,
+    execFile: fake.execFile,
+  });
+
+  assert.equal(await source.register(preferences), false);
+});

--- a/test/preferences/preferences-ipc.test.cjs
+++ b/test/preferences/preferences-ipc.test.cjs
@@ -43,13 +43,13 @@ function storeWith(preferences) {
   };
 }
 
-function linuxSourceWith(active) {
+function linuxSourceWith(result) {
   const calls = { register: [], cleanup: 0 };
   return {
     calls,
     register: async (preferences) => {
       calls.register.push(preferences.shortcuts['hud.startStopRecording'].keys);
-      return active;
+      return result;
     },
     cleanup: async () => {
       calls.cleanup += 1;
@@ -62,7 +62,10 @@ const flush = () => new Promise((resolve) => setImmediate(resolve));
 test('an active Linux source owns registration instead of Electron globalShortcut', async () => {
   const handlers = new Map();
   const registered = [];
-  const source = linuxSourceWith(true);
+  const source = linuxSourceWith({
+    gnomeIds: ['hud.startStopRecording', 'teleprompter.toggleVisibility'],
+    fallbackIds: [],
+  });
   const cleanup = registerPreferencesIpc({
     ipcMain: ipcMainWith(handlers),
     BrowserWindow: { getAllWindows: () => [] },
@@ -81,10 +84,14 @@ test('an active Linux source owns registration instead of Electron globalShortcu
   assert.equal(source.calls.cleanup, 1);
 });
 
-test('fallback registers global entries and dispatches them to windows', async () => {
+test('a Linux source owns convertible shortcuts while the rest fall back to globalShortcut', async () => {
   const handlers = new Map();
   const sent = [];
   const registered = [];
+  const source = linuxSourceWith({
+    gnomeIds: ['hud.startStopRecording'],
+    fallbackIds: ['teleprompter.toggleVisibility'],
+  });
   const cleanup = registerPreferencesIpc({
     ipcMain: ipcMainWith(handlers),
     BrowserWindow: { getAllWindows: () => [windowWith(sent)] },
@@ -93,24 +100,49 @@ test('fallback registers global entries and dispatches them to windows', async (
       unregisterAll: () => {},
     },
     store: storeWith(shortcutPreferences()),
-    linuxShortcutSource: linuxSourceWith(false),
+    linuxShortcutSource: source,
   });
   await flush();
 
-  assert.deepEqual(registered.map(({ keys }) => keys).sort(), ['Alt+Shift+R', 'Alt+Shift+T'].sort());
+  assert.deepEqual(
+    registered.map(({ keys }) => keys),
+    ['Alt+Shift+T'],
+  );
   registered.forEach(({ callback }) => callback());
-  assert.deepEqual(sent, [
-    { channel: 'preferences:shortcut', id: 'hud.startStopRecording' },
-    { channel: 'preferences:shortcut', id: 'teleprompter.toggleVisibility' },
-  ]);
+  assert.deepEqual(sent, [{ channel: 'preferences:shortcut', id: 'teleprompter.toggleVisibility' }]);
+  assert.equal(source.calls.cleanup, 0);
   await cleanup();
+  assert.equal(source.calls.cleanup, 1);
+});
+
+test('a failed Linux registration cleans GNOME bindings and falls back entirely', async () => {
+  const handlers = new Map();
+  const registered = [];
+  const source = linuxSourceWith(null);
+  registerPreferencesIpc({
+    ipcMain: ipcMainWith(handlers),
+    BrowserWindow: { getAllWindows: () => [] },
+    globalShortcut: {
+      register: (keys, callback) => registered.push({ keys, callback }),
+      unregisterAll: () => {},
+    },
+    store: storeWith(shortcutPreferences()),
+    linuxShortcutSource: source,
+  });
+  await flush();
+
+  assert.equal(source.calls.cleanup, 1);
+  assert.deepEqual(registered.map(({ keys }) => keys).sort(), ['Alt+Shift+R', 'Alt+Shift+T'].sort());
 });
 
 test('preference updates serialize registration and use newest shortcuts', async () => {
   const handlers = new Map();
   const registered = [];
   const preferences = shortcutPreferences();
-  const source = linuxSourceWith(false);
+  const source = linuxSourceWith({
+    gnomeIds: [],
+    fallbackIds: ['hud.startStopRecording', 'teleprompter.toggleVisibility'],
+  });
   registerPreferencesIpc({
     ipcMain: ipcMainWith(handlers),
     BrowserWindow: { getAllWindows: () => [] },

--- a/test/preferences/preferences-ipc.test.cjs
+++ b/test/preferences/preferences-ipc.test.cjs
@@ -1,0 +1,153 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { registerPreferencesIpc } = require('../../electron/preferences/preferences-ipc.cjs');
+
+function ipcMainWith(handlers) {
+  return { handle: (channel, handler) => handlers.set(channel, handler) };
+}
+
+function windowWith(sent) {
+  return { webContents: { send: (channel, id) => sent.push({ channel, id }) } };
+}
+
+function shortcutPreferences() {
+  return {
+    schemaVersion: 3,
+    theme: 'light',
+    appearance: {},
+    recordingBar: { visibility: 'always' },
+    recordingInteractions: { enabled: false, noticeDismissed: false },
+    onboardingCompleted: true,
+    alwaysOnTop: true,
+    devices: {},
+    shortcuts: {
+      'hud.startStopRecording': { keys: 'Alt+Shift+R', scope: 'global', category: 'hud' },
+      'editor.playPause': { keys: 'Space', scope: 'application', category: 'video-editor' },
+      'teleprompter.toggleVisibility': { keys: 'Alt+Shift+T', scope: 'global', category: 'teleprompter' },
+    },
+    backgroundPresets: { colors: [], gradients: [] },
+    extras: {},
+  };
+}
+
+function storeWith(preferences) {
+  return {
+    read: () => structuredClone(preferences),
+    patch: (patch) => {
+      const next = { ...preferences, ...patch };
+      if (patch.shortcuts) next.shortcuts = { ...preferences.shortcuts, ...patch.shortcuts };
+      return Object.assign(preferences, next);
+    },
+    write: (next) => Object.assign(preferences, next),
+  };
+}
+
+function linuxSourceWith(active) {
+  const calls = { register: [], cleanup: 0 };
+  return {
+    calls,
+    register: async (preferences) => {
+      calls.register.push(preferences.shortcuts['hud.startStopRecording'].keys);
+      return active;
+    },
+    cleanup: async () => {
+      calls.cleanup += 1;
+    },
+  };
+}
+
+const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+test('an active Linux source owns registration instead of Electron globalShortcut', async () => {
+  const handlers = new Map();
+  const registered = [];
+  const source = linuxSourceWith(true);
+  const cleanup = registerPreferencesIpc({
+    ipcMain: ipcMainWith(handlers),
+    BrowserWindow: { getAllWindows: () => [] },
+    globalShortcut: {
+      register: (...args) => registered.push(args),
+      unregisterAll: () => {},
+    },
+    store: storeWith(shortcutPreferences()),
+    linuxShortcutSource: source,
+  });
+  await flush();
+
+  assert.equal(source.calls.register.length, 1);
+  assert.equal(registered.length, 0);
+  await cleanup();
+  assert.equal(source.calls.cleanup, 1);
+});
+
+test('fallback registers global entries and dispatches them to windows', async () => {
+  const handlers = new Map();
+  const sent = [];
+  const registered = [];
+  const cleanup = registerPreferencesIpc({
+    ipcMain: ipcMainWith(handlers),
+    BrowserWindow: { getAllWindows: () => [windowWith(sent)] },
+    globalShortcut: {
+      register: (keys, callback) => registered.push({ keys, callback }),
+      unregisterAll: () => {},
+    },
+    store: storeWith(shortcutPreferences()),
+    linuxShortcutSource: linuxSourceWith(false),
+  });
+  await flush();
+
+  assert.deepEqual(registered.map(({ keys }) => keys).sort(), ['Alt+Shift+R', 'Alt+Shift+T'].sort());
+  registered.forEach(({ callback }) => callback());
+  assert.deepEqual(sent, [
+    { channel: 'preferences:shortcut', id: 'hud.startStopRecording' },
+    { channel: 'preferences:shortcut', id: 'teleprompter.toggleVisibility' },
+  ]);
+  await cleanup();
+});
+
+test('preference updates serialize registration and use newest shortcuts', async () => {
+  const handlers = new Map();
+  const registered = [];
+  const preferences = shortcutPreferences();
+  const source = linuxSourceWith(false);
+  registerPreferencesIpc({
+    ipcMain: ipcMainWith(handlers),
+    BrowserWindow: { getAllWindows: () => [] },
+    globalShortcut: {
+      register: (keys, callback) => registered.push({ keys, callback }),
+      unregisterAll: () => {},
+    },
+    store: storeWith(preferences),
+    linuxShortcutSource: source,
+  });
+  await flush();
+
+  const update = handlers.get('preferences:update');
+  const result = await update(null, {
+    shortcuts: { 'hud.startStopRecording': { keys: 'Alt+Shift+Q', scope: 'global', category: 'hud' } },
+  });
+  assert.equal(result.shortcuts['hud.startStopRecording'].keys, 'Alt+Shift+Q');
+  assert.equal(source.calls.register.at(-1), 'Alt+Shift+Q');
+  assert.equal(registered.at(-2).keys, 'Alt+Shift+Q');
+});
+
+test('shortcut handler receives every global id when provided', async () => {
+  const handlers = new Map();
+  const received = [];
+  registerPreferencesIpc({
+    ipcMain: ipcMainWith(handlers),
+    BrowserWindow: { getAllWindows: () => [] },
+    globalShortcut: {
+      register: (_keys, callback) => received.push(callback),
+      unregisterAll: () => {},
+    },
+    store: storeWith(shortcutPreferences()),
+    shortcutHandler: (id) => received.push(id),
+  });
+  await flush();
+
+  const callbacks = received.splice(0);
+  callbacks.forEach((callback) => callback());
+  assert.deepEqual(received, ['hud.startStopRecording', 'teleprompter.toggleVisibility']);
+});

--- a/test/single-instance.test.cjs
+++ b/test/single-instance.test.cjs
@@ -1,7 +1,7 @@
 const assert = require('node:assert/strict');
 const { EventEmitter } = require('node:events');
 const { test } = require('node:test');
-const { initializeSingleInstance } = require('../electron/lifecycle/single-instance.cjs');
+const { initializeSingleInstance, shortcutId } = require('../electron/lifecycle/single-instance.cjs');
 
 test('a losing Beam instance exits before any application resource is initialized', () => {
   const app = new EventEmitter();
@@ -32,4 +32,44 @@ test('a second launch restores the canonical HUD path without reinitializing Bea
   app.emit('second-instance');
   assert.equal(initialized, 1);
   assert.equal(restored, 1);
+});
+
+test('a second launch can forward a shortcut id without restoring the HUD', () => {
+  const app = new EventEmitter();
+  const received = [];
+  let restored = 0;
+  app.requestSingleInstanceLock = () => true;
+  initializeSingleInstance({
+    app,
+    initialize: () => {},
+    restoreHud: () => (restored += 1),
+    handleShortcut: (id) => received.push(id),
+  });
+  app.emit('second-instance', {}, ['beam', '--beam-shortcut=teleprompter.toggleVisibility']);
+  assert.deepEqual(received, ['teleprompter.toggleVisibility']);
+  assert.equal(restored, 0);
+});
+
+test('a shortcut can start the first Beam instance', () => {
+  const app = new EventEmitter();
+  const received = [];
+  app.requestSingleInstanceLock = () => true;
+  initializeSingleInstance({
+    app,
+    initialize: () => {},
+    restoreHud: () => {},
+    handleShortcut: (id) => received.push(id),
+    commandLine: ['beam', '--beam-shortcut=teleprompter.nextLine'],
+  });
+  assert.deepEqual(received, ['teleprompter.nextLine']);
+});
+
+test('shortcut ids decode safely and malformed arguments are ignored', () => {
+  assert.equal(shortcutId(['beam', '--beam-shortcut=hud.startStopRecording']), 'hud.startStopRecording');
+  assert.equal(
+    shortcutId(['beam', `--beam-shortcut=${encodeURIComponent('hud.startStopRecording')}`]),
+    'hud.startStopRecording',
+  );
+  assert.equal(shortcutId(['beam', '--beam-shortcut=%']), null);
+  assert.equal(shortcutId(['beam']), null);
 });

--- a/test/single-instance.test.cjs
+++ b/test/single-instance.test.cjs
@@ -34,7 +34,7 @@ test('a second launch restores the canonical HUD path without reinitializing Bea
   assert.equal(restored, 1);
 });
 
-test('a second launch can forward a shortcut id without restoring the HUD', () => {
+test('a second launch can forward a handled shortcut id without restoring the HUD', () => {
   const app = new EventEmitter();
   const received = [];
   let restored = 0;
@@ -43,11 +43,33 @@ test('a second launch can forward a shortcut id without restoring the HUD', () =
     app,
     initialize: () => {},
     restoreHud: () => (restored += 1),
-    handleShortcut: (id) => received.push(id),
+    handleShortcut: (id) => {
+      received.push(id);
+      return true;
+    },
   });
   app.emit('second-instance', {}, ['beam', '--beam-shortcut=teleprompter.toggleVisibility']);
   assert.deepEqual(received, ['teleprompter.toggleVisibility']);
   assert.equal(restored, 0);
+});
+
+test('a second launch with an unhandled shortcut still restores the HUD', () => {
+  const app = new EventEmitter();
+  const received = [];
+  let restored = 0;
+  app.requestSingleInstanceLock = () => true;
+  initializeSingleInstance({
+    app,
+    initialize: () => {},
+    restoreHud: () => (restored += 1),
+    handleShortcut: (id) => {
+      received.push(id);
+      return false;
+    },
+  });
+  app.emit('second-instance', {}, ['beam', '--beam-shortcut=unknown.id']);
+  assert.deepEqual(received, ['unknown.id']);
+  assert.equal(restored, 1);
 });
 
 test('a shortcut can start the first Beam instance', () => {


### PR DESCRIPTION
## What changed

  - Keep Electron shortcuts where they work.
  - Add a GNOME shortcut fallback for Ubuntu Wayland.
  - Forward shortcuts back to the running Beam app.
  - Remove the privileged keyboard helper shortcut code.

## Why

  Ubuntu 24.04 GNOME Wayland does not provide the service Electron needs for global shortcuts. GNOME’s own shortcut system works instead.

## Checks

  - Focused Node tests pass.
  - Formatting and diff checks pass.
  
  Fixes: #35 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added global keyboard shortcut support for Linux GNOME Wayland.
  * Shortcuts now work when launching a second app instance and route to the appropriate action.
  * Added fallback support when Linux-specific registration is unavailable.

* **Bug Fixes**
  * Improved handling of malformed, missing, or encoded shortcut arguments.
  * Prevented shortcut events from being lost while the main window loads.
  * Improved shortcut updates, cleanup, and HUD restoration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->