### PR TITLE
fix: run set -euo pipefail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
           dpkg-deb --contents "$deb" | grep 'resources/package-type'
           rpm --query --package --list "$rpm_package" | grep "resources/capture-engine/capture-engine-$version"
           rpm --query --package --list "$rpm_package" | grep 'resources/package-type'
-          sudo apt-get install --yes "$deb"
+          sudo apt-get install --yes "./$deb"
           test -x /usr/libexec/beam-input-helper
           test -f /usr/share/polkit-1/actions/com.beam.input-monitor.policy
           node scripts/release/artifacts.cjs metadata dist_electron latest-linux.yml


### PR DESCRIPTION
## What

Fix the `package-linux` CI job failing in the "Inspect Linux packages and update metadata" step.

`sudo apt-get install --yes "$deb"` was handed the relative path `dist_electron/Beam-0.1.9-linux-amd64.deb` without a `./` prefix. apt parses that as a package spec, treating `dist_electron` as the package name, and aborts with:

E: Unable to locate package dist_electron

The fix prefixes the path with `./` so apt resolves it as a local `.deb` file (`./dist_electron/...`).

## Why

The deb-install smoke check was added to CI so the packaged input helper and polkit policy are verified after a real install. It has never passed because of the path-parsing issue.

## Verification

- `ci.yml` change is a single line; `dpkg-deb`/`rpm` listing steps above the install already confirm the deb exists at `dist_electron/`.
- Re-run of `package-linux` on this branch should now pass the install, `test -x /usr/libexec/beam-input-helper`, and `test -f /usr/share/polkit-1/actions/com.beam.input-monitor.policy` checks.
- No local run possible here (Windows host); the fix is validated by the next CI run.

## Notes

The previous step already runs `set -euo pipefail`; the commit message reflects the title as requested but the actual change is the `./` path prefix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux packaging validation by ensuring the generated Debian package is installed from the correct path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->