### PR TITLE
Add hold segments and refine timeline editing

### DIFF
--- a/electron/projects/clip-composition.cjs
+++ b/electron/projects/clip-composition.cjs
@@ -10,7 +10,8 @@ const {
   validateTrackLayout,
 } = require('./composition-tracks.cjs');
 
-const schemaVersion = 8;
+const schemaVersion = 9;
+const previousCompositionSchemaVersion = 8;
 const cameraLayoutSchemaVersion = 7;
 const transitionSchemaVersion = 6;
 const typographySchemaVersion = 5;
@@ -304,6 +305,14 @@ function normalizeComposition(value) {
         volume: finite(clip.volume) ? Math.max(0, Math.min(200, clip.volume)) : 100,
       };
     if (!id(clip.trackId)) throw new Error('Identifiant de piste visuelle invalide');
+    if (
+      clip.freezeFrameSourceMs !== undefined &&
+      (clip.kind === 'image' ||
+        !finite(clip.freezeFrameSourceMs) ||
+        Math.round(clip.freezeFrameSourceMs) !== common.sourceInMs ||
+        assets.find((asset) => asset.id === clip.assetId)?.kind !== 'video')
+    )
+      throw new Error('Image figée invalide');
     const cameraPresets = ['screen', 'video', 'image', 'webcam'].includes(clip.kind)
       ? (() => {
           const cameraLayoutPreset = clip.cameraLayoutPreset === undefined ? 'custom' : clip.cameraLayoutPreset;
@@ -329,6 +338,7 @@ function normalizeComposition(value) {
       transform: rectangle(clip.transform, 'Transformation'),
       ...(clip.crop ? { crop: rectangle(clip.crop, 'Recadrage') } : {}),
       appearance: appearance(clip.appearance),
+      ...(clip.freezeFrameSourceMs !== undefined ? { freezeFrameSourceMs: Math.round(clip.freezeFrameSourceMs) } : {}),
       ...cameraPresets,
       ...(typeof clip.isMirrored === 'boolean' && typeof clip.isMirroredY === 'boolean'
         ? { isMirrored: clip.isMirrored, isMirroredY: clip.isMirroredY }
@@ -369,15 +379,20 @@ function migrateComposition(value, showBackground, historicalSessionIds = []) {
       typographySchemaVersion,
       transitionSchemaVersion,
       cameraLayoutSchemaVersion,
+      previousCompositionSchemaVersion,
     ].includes(value.schemaVersion) ||
     !Array.isArray(value.assets) ||
     !Array.isArray(value.clips)
   )
     throw new Error(`Version de composition inconnue: ${String(value?.schemaVersion)}`);
   if (
-    [visualTrackSchemaVersion, typographySchemaVersion, transitionSchemaVersion, cameraLayoutSchemaVersion].includes(
-      value.schemaVersion,
-    )
+    [
+      visualTrackSchemaVersion,
+      typographySchemaVersion,
+      transitionSchemaVersion,
+      cameraLayoutSchemaVersion,
+      previousCompositionSchemaVersion,
+    ].includes(value.schemaVersion)
   ) {
     return normalizeComposition({
       ...value,
@@ -385,25 +400,28 @@ function migrateComposition(value, showBackground, historicalSessionIds = []) {
       keyboardCaptionSessions: Array.isArray(value.keyboardCaptionSessions)
         ? value.keyboardCaptionSessions
         : historicalSessionIds,
-      clips: (value.schemaVersion === cameraLayoutSchemaVersion
-        ? repairMigratedTrackIds(value.clips)
-        : repairMigratedTrackIds(value.clips).map(withHistoricalTypography)
-      ).map((clip) => ({
-        ...clip,
-        ...(value.schemaVersion < cameraLayoutSchemaVersion ? { transitions: { entry: null, exit: null } } : {}),
-        ...(['screen', 'video', 'image', 'webcam'].includes(clip.kind)
-          ? {
-              cameraLayoutPreset: 'custom',
-              cameraFramingPreset: 'custom',
-              ...(clip.kind === 'webcam'
+      clips:
+        value.schemaVersion === previousCompositionSchemaVersion
+          ? repairMigratedTrackIds(value.clips)
+          : (value.schemaVersion === cameraLayoutSchemaVersion
+              ? repairMigratedTrackIds(value.clips)
+              : repairMigratedTrackIds(value.clips).map(withHistoricalTypography)
+            ).map((clip) => ({
+              ...clip,
+              ...(value.schemaVersion < cameraLayoutSchemaVersion ? { transitions: { entry: null, exit: null } } : {}),
+              ...(['screen', 'video', 'image', 'webcam'].includes(clip.kind)
                 ? {
-                    cameraSplitRatio: 0.5,
-                    cameraSplitPadding: 0,
+                    cameraLayoutPreset: 'custom',
+                    cameraFramingPreset: 'custom',
+                    ...(clip.kind === 'webcam'
+                      ? {
+                          cameraSplitRatio: 0.5,
+                          cameraSplitPadding: 0,
+                        }
+                      : {}),
                   }
                 : {}),
-            }
-          : {}),
-      })),
+            })),
     });
   }
   return normalizeComposition({

--- a/electron/projects/project-editor-access.cjs
+++ b/electron/projects/project-editor-access.cjs
@@ -14,7 +14,7 @@ const {
 function createProjectEditorAccess(options) {
   const migrateEditor = (directory, manifest) => {
     const current = manifest.editor;
-    if (current?.schemaVersion === 3 && current.composition?.schemaVersion === 8) {
+    if (current?.schemaVersion === 3 && current.composition?.schemaVersion === 9) {
       const composition = normalizeComposition(current.composition);
       if (JSON.stringify(composition) === JSON.stringify(current.composition)) return current;
       manifest.editor = { ...current, composition };
@@ -28,7 +28,7 @@ function createProjectEditorAccess(options) {
     const editor = {
       schemaVersion: 3,
       composition:
-        legacyComposition.schemaVersion === 8
+        legacyComposition.schemaVersion === 9
           ? normalizeComposition(legacyComposition)
           : migrateComposition(
               legacyComposition,

--- a/src/components/export/composition/render.ts
+++ b/src/components/export/composition/render.ts
@@ -34,6 +34,7 @@ import {
   type MotionBlurSurface,
 } from '../../video-editor/zoom/zoom-motion-blur-compositor';
 import { normalizeZoomMotionBlur } from '../../video-editor/zoom/zoom-types';
+import { sourceTimeAt } from '~/media/shared';
 
 export interface RenderableMedia {
   source: CanvasImageSource;
@@ -241,6 +242,7 @@ function renderCompositionFrameContent(
   const timeMs = time * 1_000;
   const layers = resolvedLayers ?? resolveCompositionSceneLayers(snapshot.composition, timeMs);
   const screen = layers.screen;
+  const screenTime = screen ? (sourceTimeAt(screen, timeMs) ?? timeMs) / 1_000 : time;
   const sourceWidth = video?.width ?? width;
   const sourceHeight = video?.height ?? height;
   const screenGeometry = screen
@@ -356,13 +358,13 @@ function renderCompositionFrameContent(
       createCursorMotionPlayer(snapshot.cursor.events, snapshot.cursorSettings.motion, sourceWidth, sourceHeight))
     : null;
   const cursorMotion = resolvedCursorMotionPlayer
-    ? resolvedCursorMotionPlayer.sample(time, cursorStateAt(snapshot.cursor.events, time))
+    ? resolvedCursorMotionPlayer.sample(screenTime, cursorStateAt(snapshot.cursor.events, screenTime))
     : null;
   const keyboardCursorPosition =
     screen && resolvedCursorMotionPlayer
       ? cursorPositionForKeyboardCaption(
           snapshot,
-          time,
+          screenTime,
           screen,
           sourceWidth,
           sourceHeight,
@@ -386,7 +388,7 @@ function renderCompositionFrameContent(
     drawCursorLayer(
       ctx,
       snapshot,
-      time,
+      screenTime,
       screen,
       sourceWidth,
       sourceHeight,

--- a/src/components/export/composition/tests/render.test.ts
+++ b/src/components/export/composition/tests/render.test.ts
@@ -586,8 +586,11 @@ describe('canonical composition rendering', () => {
     expect(ctx.drawImage).toHaveBeenLastCalledWith(image, expect.any(Number), expect.any(Number), 50, 50);
   });
 
-  it('samples cursor motion once per exported frame', () => {
+  it('samples cursor motion at the frozen screen source time once per exported frame', () => {
     const value = snapshot();
+    const screen = value.composition.clips[0]!;
+    if (screen.kind !== 'screen') throw new Error('Expected a screen clip fixture.');
+    screen.freezeFrameSourceMs = 250;
     value.cursor = {
       available: true,
       telemetry: [],
@@ -625,6 +628,6 @@ describe('canonical composition rendering', () => {
     }
 
     expect(sample).toHaveBeenCalledTimes(frames.length);
-    expect(sample.mock.calls.map(([time]) => time)).toEqual(frames);
+    expect(sample.mock.calls.map(([time]) => time)).toEqual([0.25, 0.25, 0.25]);
   });
 });

--- a/src/components/hud/region/ScreenRegionOverlayApp.vue
+++ b/src/components/hud/region/ScreenRegionOverlayApp.vue
@@ -2,9 +2,15 @@
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
 import { Check, Move, RotateCcw, X } from '@lucide/vue';
 import Button from '~/ui/button/Button.vue';
+import Select from '~/ui/select/Select.vue';
 import { capture } from '../../../api/capture';
 import type { ScreenRegionOverlayOptions, ScreenRegion } from '../../../api/types/screen-region';
 import { useTranslate } from '~/i18n/useTranslate';
+import {
+  SCREEN_REGION_PRESETS,
+  computePresetRegion,
+  findMatchingPreset,
+} from './screen-region-presets';
 
 const { t } = useTranslate('ScreenRegionOverlay');
 
@@ -17,6 +23,7 @@ type Handle = 'nw' | 'ne' | 'sw' | 'se';
 
 const options = ref<(ScreenRegionOverlayOptions & { mode?: 'select' | 'record' }) | null>(null);
 const region = ref<ScreenRegion | null>(null);
+const selectedPreset = ref<string | null>(null);
 let interaction: Interaction = null;
 let unsubscribe: (() => void) | null = null;
 
@@ -49,6 +56,53 @@ const isFullScreenRegion = (r: ScreenRegion | null): boolean => {
   return r.x <= 0.01 && r.y <= 0.01 && r.width >= 0.98 && r.height >= 0.98;
 };
 
+const getEffectiveBounds = () =>
+  options.value?.bounds || {
+    x: 0,
+    y: 0,
+    width: window.innerWidth,
+    height: window.innerHeight,
+  };
+
+const persistPreset = async (presetValue: string | null) => {
+  try {
+    const prefs = await capture.getPreferences();
+    await capture.updatePreferences({
+      extras: {
+        ...prefs.extras,
+        screenRegionPreset: presetValue,
+      },
+    });
+  } catch {
+    // Ignored if preferences are unavailable
+  }
+};
+
+const updatePresetMatch = () => {
+  if (!region.value || isFullScreenRegion(region.value)) {
+    selectedPreset.value = null;
+    return;
+  }
+  const bounds = getEffectiveBounds();
+  selectedPreset.value = findMatchingPreset(region.value, bounds);
+};
+
+const applyPreset = (presetValue: string | number) => {
+  const value = String(presetValue);
+  const bounds = getEffectiveBounds();
+  const nextRegion = computePresetRegion(
+    value,
+    bounds,
+    region.value,
+    isFullScreenRegion(region.value),
+  );
+  if (nextRegion) {
+    region.value = nextRegion;
+    selectedPreset.value = value;
+    void persistPreset(value);
+  }
+};
+
 const begin = (event: PointerEvent) => {
   if (!isSelecting.value) return;
   const target = event.target as HTMLElement;
@@ -78,6 +132,7 @@ const move = (event: PointerEvent) => {
   const next = point(event);
   if (interaction.kind === 'draw') {
     region.value = normalize(interaction.startX, interaction.startY, next.x, next.y);
+    updatePresetMatch();
     return;
   }
   if (interaction.kind === 'move') {
@@ -105,15 +160,21 @@ const move = (event: PointerEvent) => {
     width: Math.min(1, right) - Math.max(0, left),
     height: Math.min(1, bottom) - Math.max(0, top),
   };
+  updatePresetMatch();
 };
 
 const FULL_SCREEN_REGION: ScreenRegion = { x: 0, y: 0, width: 1, height: 1 };
 
 const end = () => {
+  if (interaction && (interaction.kind === 'draw' || interaction.kind === 'resize')) {
+    updatePresetMatch();
+  }
   interaction = null;
 };
 const reset = () => {
   region.value = { ...FULL_SCREEN_REGION };
+  selectedPreset.value = null;
+  void persistPreset(null);
 };
 const confirm = () => {
   if (!region.value || region.value.width <= 0 || region.value.height <= 0) return;
@@ -121,11 +182,35 @@ const confirm = () => {
 };
 const cancel = () => capture.cancelScreenRegion();
 
+const loadSavedPreset = async () => {
+  try {
+    const prefs = await capture.getPreferences();
+    const saved = prefs.extras?.screenRegionPreset;
+    if (typeof saved === 'string' && SCREEN_REGION_PRESETS.some((p) => p.value === saved)) {
+      selectedPreset.value = saved;
+      if (!region.value || isFullScreenRegion(region.value)) {
+        applyPreset(saved);
+      }
+    }
+  } catch {
+    // Ignored if preferences are unavailable
+  }
+};
+
 onMounted(() => {
   unsubscribe = capture.onScreenRegionConfigure((next) => {
     options.value = next;
-    region.value = next.region ? { ...next.region } : { ...FULL_SCREEN_REGION };
+    if (next.region) {
+      region.value = { ...next.region };
+      updatePresetMatch();
+    } else if (selectedPreset.value) {
+      applyPreset(selectedPreset.value);
+    } else {
+      region.value = { ...FULL_SCREEN_REGION };
+      updatePresetMatch();
+    }
   });
+  void loadSavedPreset();
 });
 onBeforeUnmount(() => unsubscribe?.());
 </script>
@@ -145,6 +230,16 @@ onBeforeUnmount(() => unsubscribe?.());
     </div>
     <aside v-if="isSelecting" class="region-toolbar" @pointerdown.stop>
       <span class="region-instruction"><Move :size="16" /> {{ t('instruction') }}</span>
+      <div class="region-preset-picker">
+        <Select
+          :model-value="selectedPreset"
+          :options="SCREEN_REGION_PRESETS"
+          :placeholder="t('preset')"
+          size="sm"
+          direction="up"
+          @update:model-value="applyPreset"
+        />
+      </div>
       <div class="region-actions">
         <Button variant="ghost" size="sm" :icon="RotateCcw" @click="reset">{{ t('reset') }}</Button>
         <Button variant="ghost" size="sm" :icon="X" @click="cancel">{{ t('cancel') }}</Button>
@@ -229,7 +324,7 @@ onBeforeUnmount(() => unsubscribe?.());
   bottom: 24px;
   display: flex;
   align-items: center;
-  gap: 20px;
+  gap: 16px;
   padding: 10px 12px 10px 16px;
   border: 1px solid color-mix(in srgb, var(--color-border-strong) 76%, transparent);
   border-radius: var(--radius-lg);
@@ -246,6 +341,10 @@ onBeforeUnmount(() => unsubscribe?.());
   gap: 8px;
   font: 600 13px var(--font-sans);
   white-space: nowrap;
+}
+.region-preset-picker {
+  width: 140px;
+  flex-shrink: 0;
 }
 .region-actions {
   display: flex;

--- a/src/components/hud/region/screen-region-presets.ts
+++ b/src/components/hud/region/screen-region-presets.ts
@@ -1,0 +1,59 @@
+import type { ScreenRegion, ScreenRegionBounds } from '../../../api/types/screen-region';
+
+export interface ScreenRegionPresetOption {
+  value: string;
+  label: string;
+  width: number;
+  height: number;
+}
+
+export const SCREEN_REGION_PRESETS: ScreenRegionPresetOption[] = [
+  { value: '640x480', label: '640 × 480', width: 640, height: 480 },
+  { value: '800x600', label: '800 × 600', width: 800, height: 600 },
+  { value: '1024x768', label: '1024 × 768', width: 1024, height: 768 },
+  { value: '1366x768', label: '1366 × 768', width: 1366, height: 768 },
+  { value: '1440x990', label: '1440 × 990', width: 1440, height: 990 },
+  { value: '1920x1080', label: '1920 × 1080', width: 1920, height: 1080 },
+];
+
+export function findMatchingPreset(
+  region: ScreenRegion | null,
+  bounds: ScreenRegionBounds,
+  tolerance = 2,
+): string | null {
+  if (!region) return null;
+  const currentW = Math.round(region.width * Math.max(1, bounds.width));
+  const currentH = Math.round(region.height * Math.max(1, bounds.height));
+  const matched = SCREEN_REGION_PRESETS.find(
+    (p) => Math.abs(p.width - currentW) <= tolerance && Math.abs(p.height - currentH) <= tolerance,
+  );
+  return matched ? matched.value : null;
+}
+
+export function computePresetRegion(
+  presetValue: string,
+  bounds: ScreenRegionBounds,
+  currentRegion: ScreenRegion | null,
+  isFullScreen: boolean,
+): ScreenRegion | null {
+  const preset = SCREEN_REGION_PRESETS.find((p) => p.value === presetValue);
+  if (!preset) return null;
+
+  const boundsWidth = Math.max(1, bounds.width);
+  const boundsHeight = Math.max(1, bounds.height);
+
+  const targetWidth = Math.min(1, preset.width / boundsWidth);
+  const targetHeight = Math.min(1, preset.height / boundsHeight);
+
+  let centerX = 0.5;
+  let centerY = 0.5;
+  if (currentRegion && !isFullScreen) {
+    centerX = currentRegion.x + currentRegion.width / 2;
+    centerY = currentRegion.y + currentRegion.height / 2;
+  }
+
+  const x = Math.max(0, Math.min(1 - targetWidth, centerX - targetWidth / 2));
+  const y = Math.max(0, Math.min(1 - targetHeight, centerY - targetHeight / 2));
+
+  return { x, y, width: targetWidth, height: targetHeight };
+}

--- a/src/components/hud/tests/ScreenRegionOverlayApp.test.ts
+++ b/src/components/hud/tests/ScreenRegionOverlayApp.test.ts
@@ -2,7 +2,13 @@ import { mount } from '@vue/test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { capture } = vi.hoisted(() => ({
-  capture: { onScreenRegionConfigure: vi.fn(), confirmScreenRegion: vi.fn(), cancelScreenRegion: vi.fn() },
+  capture: {
+    onScreenRegionConfigure: vi.fn(),
+    confirmScreenRegion: vi.fn(),
+    cancelScreenRegion: vi.fn(),
+    getPreferences: vi.fn().mockResolvedValue({ extras: {} }),
+    updatePreferences: vi.fn().mockResolvedValue({ extras: {} }),
+  },
 }));
 vi.mock('../../../api/capture', () => ({ capture }));
 vi.mock('~/i18n/useTranslate', () => ({
@@ -17,9 +23,21 @@ const Button = {
   template: '<button :disabled="disabled" @click="$emit(\'click\')"><slot /></button>',
 };
 
+const Select = {
+  props: ['modelValue', 'options', 'placeholder'],
+  emits: ['update:modelValue'],
+  template: `
+    <select :value="modelValue" @change="$emit('update:modelValue', $event.target.value)">
+      <option v-for="opt in options" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
+    </select>
+  `,
+};
+
 describe('ScreenRegionOverlayApp', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    capture.getPreferences.mockResolvedValue({ extras: {} });
+    capture.updatePreferences.mockResolvedValue({ extras: {} });
     Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1000 });
     Object.defineProperty(window, 'innerHeight', { configurable: true, value: 500 });
   });
@@ -35,7 +53,7 @@ describe('ScreenRegionOverlayApp', () => {
       configure = next;
       return unsubscribe;
     });
-    const wrapper = mount(ScreenRegionOverlayApp, { global: { stubs: { Button } } });
+    const wrapper = mount(ScreenRegionOverlayApp, { global: { stubs: { Button, Select } } });
     configure({ mode: 'select', bounds: { width: 1000, height: 500 } });
     await wrapper.vm.$nextTick();
     expect(wrapper.find('.region-empty-backdrop').exists()).toBe(false);
@@ -68,7 +86,7 @@ describe('ScreenRegionOverlayApp', () => {
       configure = next;
       return vi.fn();
     });
-    const wrapper = mount(ScreenRegionOverlayApp, { global: { stubs: { Button } } });
+    const wrapper = mount(ScreenRegionOverlayApp, { global: { stubs: { Button, Select } } });
     configure({
       mode: 'select',
       bounds: { width: 1000, height: 500 },
@@ -88,6 +106,9 @@ describe('ScreenRegionOverlayApp', () => {
     await main.trigger('pointercancel');
     await wrapper.findAll('.region-actions button')[0].trigger('click');
     expect(wrapper.get('.region-frame').attributes('style')).toContain('width: 100%');
+    expect(capture.updatePreferences).toHaveBeenCalledWith({
+      extras: { screenRegionPreset: null },
+    });
   });
 
   it('cancels selection and ignores pointer input outside select mode', async () => {
@@ -96,7 +117,7 @@ describe('ScreenRegionOverlayApp', () => {
       configure = next;
       return vi.fn();
     });
-    const wrapper = mount(ScreenRegionOverlayApp, { global: { stubs: { Button } } });
+    const wrapper = mount(ScreenRegionOverlayApp, { global: { stubs: { Button, Select } } });
     configure({ mode: 'record', bounds: { width: 100, height: 100 } });
     await wrapper.vm.$nextTick();
     expect(wrapper.find('.region-toolbar').exists()).toBe(false);
@@ -110,5 +131,65 @@ describe('ScreenRegionOverlayApp', () => {
     await wrapper.vm.$nextTick();
     await wrapper.findAll('.region-actions button')[1].trigger('click');
     expect(capture.cancelScreenRegion).toHaveBeenCalledOnce();
+  });
+
+  it('applies a selected preset and persists it to preferences', async () => {
+    let configure!: (value: {
+      mode: 'select';
+      bounds: { width: number; height: number };
+    }) => void;
+    capture.onScreenRegionConfigure.mockImplementation((next: typeof configure) => {
+      configure = next;
+      return vi.fn();
+    });
+    const wrapper = mount(ScreenRegionOverlayApp, { global: { stubs: { Button, Select } } });
+    configure({ mode: 'select', bounds: { width: 2000, height: 1000 } });
+    await wrapper.vm.$nextTick();
+
+    const select = wrapper.getComponent(Select);
+    expect(select.props('options')).toHaveLength(6);
+    expect(select.props('options').map((o: { value: string }) => o.value)).toEqual([
+      '640x480',
+      '800x600',
+      '1024x768',
+      '1366x768',
+      '1440x990',
+      '1920x1080',
+    ]);
+
+    await select.vm.$emit('update:modelValue', '1024x768');
+    await wrapper.vm.$nextTick();
+
+    // 1024 / 2000 = 0.512 (51.2%), 768 / 1000 = 0.768 (76.8%)
+    expect(wrapper.get('.region-frame').attributes('style')).toContain('width: 51.2%');
+    expect(wrapper.get('.region-frame').attributes('style')).toContain('height: 76.8%');
+    expect(capture.updatePreferences).toHaveBeenCalledWith({
+      extras: { screenRegionPreset: '1024x768' },
+    });
+  });
+
+  it('loads saved preset from preferences when mounted', async () => {
+    capture.getPreferences.mockResolvedValue({
+      extras: { screenRegionPreset: '800x600' },
+    });
+
+    let configure!: (value: {
+      mode: 'select';
+      bounds: { width: number; height: number };
+    }) => void;
+    capture.onScreenRegionConfigure.mockImplementation((next: typeof configure) => {
+      configure = next;
+      return vi.fn();
+    });
+
+    const wrapper = mount(ScreenRegionOverlayApp, { global: { stubs: { Button, Select } } });
+    configure({ mode: 'select', bounds: { width: 1600, height: 1200 } });
+    await wrapper.vm.$nextTick();
+    await Promise.resolve();
+    await wrapper.vm.$nextTick();
+
+    // 800 / 1600 = 50%, 600 / 1200 = 50%
+    expect(wrapper.get('.region-frame').attributes('style')).toContain('width: 50%');
+    expect(wrapper.get('.region-frame').attributes('style')).toContain('height: 50%');
   });
 });

--- a/src/components/video-editor/VideoEditor.vue
+++ b/src/components/video-editor/VideoEditor.vue
@@ -138,6 +138,7 @@ const {
   trimClipEdge,
   moveClipTo,
   splitSelectedClip,
+  holdClip,
   deleteSelectedClip,
   reorderVisualClip,
   updateSelectedAppearance,
@@ -187,6 +188,13 @@ const zoomMotionBlur = zoomState.zoomMotionBlur ?? ref({ ...DEFAULT_ZOOM_MOTION_
 const newZoomDurationMs = computed(() => editorDefaults.value.zoom?.durationMs ?? DEFAULT_ZOOM_DURATION_MS);
 const { isExporting, progress: exportProgress } = useExportJob();
 const timelineCompositionPreview = ref<typeof composition.value | null>(null);
+const timelinePreviewDuration = computed(() => {
+  const previewDurationMs = timelineCompositionPreview.value?.clips.reduce(
+    (maximum, clip) => Math.max(maximum, clip.timelineStartMs + clip.timelineDurationMs),
+    0,
+  );
+  return previewDurationMs === undefined ? duration.value : previewDurationMs / 1_000;
+});
 const timelineCanvasPreview = ref<OutputCanvasSettings | null>(null);
 const captionCompositionPreview = ref<typeof composition.value | null>(null);
 const cursorPreview = ref<CursorType | null>(null);
@@ -248,16 +256,19 @@ const updateRoleVolume = (role: 'system' | 'microphone', value: number) => {
   for (const clip of next.clips) if (isAudioClip(clip) && clip.role === role) next = setVolume(next, clip.id, value);
   composition.value = next;
 };
-const deleteTimelineClips = (clipIds: string[]) => {
+const deleteTimelineClips = (clipIds: string[], grouped = true) => {
   const ids = new Set(clipIds);
   let next = composition.value;
-  for (const clipId of ids) next = deleteClip(next, clipId);
+  for (const clipId of ids) {
+    if (next.clips.some((clip) => clip.id === clipId)) next = deleteClip(next, clipId, grouped);
+  }
   if (selectedClipId.value && ids.has(selectedClipId.value)) selectedClipId.value = null;
   composition.value = next;
 };
 const deleteAudioRole = (role: 'system' | 'microphone') => {
   deleteTimelineClips(
     composition.value.clips.filter((clip) => isAudioClip(clip) && clip.role === role).map((clip) => clip.id),
+    false,
   );
 };
 watch(systemVolume, (value) => updateRoleVolume('system', value));
@@ -652,7 +663,7 @@ onBeforeUnmount(() => {
           />
           <TimelineToolbar
             :current-time="currentTime"
-            :duration="duration"
+            :duration="timelinePreviewDuration"
             :is-playing="isPlaying"
             :loading="!initialPlaybackSettled"
             :can-split="Boolean(selectedClipId)"
@@ -698,6 +709,7 @@ onBeforeUnmount(() => {
           @toggle:clip="toggleClip"
           @delete:clips="deleteTimelineClips"
           @delete:zoom="deleteZoomById"
+          @hold:clip="holdClip($event.id, $event.timeMs)"
           @trim:clip="trimClipEdge($event.id, $event.edge, $event.timeMs)"
           @move:clip="moveClipTo($event.id, $event.startMs)"
           @preview:composition="timelineCompositionPreview = $event"

--- a/src/components/video-editor/canvas/composables/useCursorOverlay.test.ts
+++ b/src/components/video-editor/canvas/composables/useCursorOverlay.test.ts
@@ -65,7 +65,15 @@ const baseOptions = () => ({
         ],
       },
     }) as never,
-  screenClip: () => ({ transform: { x: 0, y: 0, width: 1, height: 1 }, isMirrored: false }) as never,
+  screenClip: () =>
+    ({
+      timelineStartMs: 0,
+      timelineDurationMs: 10_000,
+      sourceInMs: 0,
+      playbackRate: 1,
+      transform: { x: 0, y: 0, width: 1, height: 1 },
+      isMirrored: false,
+    }) as never,
   isScreenEnabled: () => true,
   showBackground: () => false,
   onRenderOnce: vi.fn(),

--- a/src/components/video-editor/canvas/composables/useCursorOverlay.ts
+++ b/src/components/video-editor/canvas/composables/useCursorOverlay.ts
@@ -17,6 +17,7 @@ import {
 } from '../../../../api/types/cursor-settings';
 import type { OutputCanvasSettings } from '../output-canvas';
 import { cursorRippleAt } from '../../composables/cursor-ripple';
+import { sourceTimeAt } from '~/media/shared';
 
 export interface UseCursorOverlayOptions {
   selectedCursor: () => CursorType;
@@ -171,7 +172,10 @@ export function useCursorOverlay(options: UseCursorOverlayOptions) {
       return;
     }
     if (!(videoWidth > 0) || !(videoHeight > 0)) return;
-    const time = options.currentTime();
+    const timelineTime = options.currentTime();
+    const screen = options.screenClip();
+    const mappedTime = screen ? sourceTimeAt(screen, timelineTime * 1_000) : null;
+    const time = mappedTime !== null && Number.isFinite(mappedTime) ? mappedTime / 1_000 : timelineTime;
     const state = cursorStateAt(cursorData.events, time);
     const { player, motion: motionState } = motionStateAt(cursorData.events, time, videoWidth, videoHeight);
     drawInCameraSpace(() => {
@@ -245,7 +249,8 @@ export function useCursorOverlay(options: UseCursorOverlayOptions) {
     const image = customCursorImage.value;
     if (!cursorData?.available || !screen || !options.isScreenEnabled() || !image?.complete || image.naturalWidth <= 0)
       return null;
-    const time = options.currentTime();
+    const timelineTime = options.currentTime();
+    const time = (sourceTimeAt(screen, timelineTime * 1_000) ?? timelineTime * 1_000) / 1_000;
     const state = cursorStateAt(cursorData.events, time);
     const motionState = motionStateAt(cursorData.events, time, videoWidth, videoHeight).motion;
     if (!state?.visible || !motionState?.visible) return null;

--- a/src/components/video-editor/composables/composition-playback-signature.ts
+++ b/src/components/video-editor/composables/composition-playback-signature.ts
@@ -17,6 +17,7 @@ type PlaybackClipSignature = {
   sourceDurationMs: number;
   playbackRate: number;
   enabled: boolean;
+  freezeFrameSourceMs?: number;
   transitions: Clip['transitions'];
   volume?: number;
 };
@@ -40,6 +41,9 @@ const playbackClip = (clip: Clip): PlaybackClipSignature | null => {
     sourceDurationMs: clip.sourceDurationMs,
     playbackRate: clip.playbackRate,
     enabled: clip.enabled,
+    ...(isVisualClip(clip) && clip.freezeFrameSourceMs !== undefined
+      ? { freezeFrameSourceMs: clip.freezeFrameSourceMs }
+      : {}),
     transitions: clip.transitions,
     ...(isAudioClip(clip) ? { volume: clip.volume } : {}),
   };

--- a/src/components/video-editor/composables/tests/editor-defaults.test.ts
+++ b/src/components/video-editor/composables/tests/editor-defaults.test.ts
@@ -3,6 +3,7 @@ import { DEFAULT_OUTPUT_CANVAS } from '../../canvas/output-canvas';
 import { createDefaultCursorPresentation } from '../../../../api/types/cursor-presentation';
 import type { ProjectEditorState } from '../../../../api/types/capture-api';
 import { createDefaultCaptionStyle, createDefaultClipAppearance } from '~/media/shared/composition-defaults';
+import { COMPOSITION_SCHEMA_VERSION } from '~/media/shared/composition-types';
 import type { AudioClip, BlurClip, CaptionClip, ClipComposition, VisualClip } from '~/media/shared/composition-types';
 import type { EditorPreferenceDefaults } from '../editor-default-types';
 import {
@@ -17,7 +18,7 @@ import {
 } from '../editor-defaults';
 
 const composition = (): ClipComposition => ({
-  schemaVersion: 8,
+  schemaVersion: COMPOSITION_SCHEMA_VERSION,
   assets: [],
   clips: [],
   keyboardCaptionSessions: [],

--- a/src/components/video-editor/composables/tests/useClipComposition.test.ts
+++ b/src/components/video-editor/composables/tests/useClipComposition.test.ts
@@ -485,6 +485,69 @@ describe('useClipComposition', () => {
     expect(mounted.state.composition.value.clips.filter((clip) => clip.kind === 'video')).toHaveLength(1);
   });
 
+  it('holds an imported video at the playhead and selects the freeze segment', () => {
+    const mounted = mountComposable();
+    const videoId = mounted.state.addImportedAsset(videoAsset(), videoInspection(false), 0);
+
+    mounted.state.holdClip(videoId, 1_000);
+
+    const videoClips = mounted.state.composition.value.clips
+      .filter((clip): clip is VisualClip => clip.kind === 'video')
+      .sort((left, right) => left.timelineStartMs - right.timelineStartMs);
+    expect(videoClips).toHaveLength(3);
+    expect(videoClips.map((clip) => [clip.timelineStartMs, clip.timelineDurationMs])).toEqual([
+      [0, 1_000],
+      [1_000, 1_000],
+      [2_000, 1_500],
+    ]);
+
+    const freeze = videoClips.find((clip) => clip.freezeFrameSourceMs !== undefined);
+    expect(freeze).toMatchObject({
+      timelineStartMs: 1_000,
+      timelineDurationMs: 1_000,
+      sourceInMs: 1_000,
+      sourceDurationMs: 1_000,
+      playbackRate: 1,
+      freezeFrameSourceMs: 1_000,
+    });
+    expect(mounted.state.selectedClipId.value).toBe(freeze?.id);
+    expect(mounted.state.selectedClip.value?.id).toBe(freeze?.id);
+  });
+
+  it('deletes both fragments of a grouped imported video after splitting the selected right video', () => {
+    const mounted = mountComposable();
+    const videoId = mounted.state.addImportedAsset(
+      { ...videoAsset(), durationMs: 127_000 },
+      { ...videoInspection(true), durationMs: 127_000 },
+      0,
+    );
+    const originalVideo = mounted.state.composition.value.clips.find((clip) => clip.id === videoId)!;
+    const groupId = originalVideo.groupId;
+    expect(groupId).toBeTruthy();
+    expect(mounted.state.composition.value.clips.filter((clip) => clip.groupId === groupId)).toHaveLength(2);
+
+    mounted.currentTimeSec.value = 120;
+    mounted.state.splitSelectedClip();
+    const rightVideo = mounted.state.composition.value.clips.find(
+      (clip) => clip.kind === 'video' && clip.timelineStartMs === 120_000,
+    )!;
+    const rightAudio = mounted.state.composition.value.clips.find(
+      (clip) => clip.kind === 'audio' && clip.timelineStartMs === 120_000,
+    );
+    expect(rightAudio?.groupId).toBe(rightVideo.groupId);
+
+    mounted.state.selectClip(rightVideo.id);
+    mounted.state.deleteSelectedClip();
+
+    expect(mounted.state.composition.value.clips.some((clip) => clip.id === rightVideo.id)).toBe(false);
+    expect(rightAudio && mounted.state.composition.value.clips.some((clip) => clip.id === rightAudio.id)).toBe(false);
+    const maxEnd = Math.max(
+      0,
+      ...mounted.state.composition.value.clips.map((clip) => clip.timelineStartMs + clip.timelineDurationMs),
+    );
+    expect(maxEnd).toBe(120_000);
+  });
+
   it('places imported visuals above existing visuals and links audio only when decodable', () => {
     const mounted = mountComposable();
     const existingVisual: VisualClip = {

--- a/src/components/video-editor/composables/tests/useVideoPlayer.test.ts
+++ b/src/components/video-editor/composables/tests/useVideoPlayer.test.ts
@@ -2,8 +2,9 @@ import { describe, expect, it, vi } from 'vitest';
 import { effectScope, nextTick } from 'vue';
 import { createBackgroundMedia } from '../backgroundCatalog';
 import { useVideoPlayer } from '../useVideoPlayer';
-import type { ClipComposition } from '~/media/shared';
+import type { ClipComposition, VisualClip } from '~/media/shared';
 import { createDefaultClipAppearance } from '~/media/shared/composition-defaults';
+import { deleteClip, splitClip } from '../../composition/engine/clip-engine';
 
 const playback = vi.hoisted(() => {
   const instances: FakePlayback[] = [];
@@ -113,6 +114,47 @@ describe('useVideoPlayer', () => {
     await player.setPlaying(false);
     expect(engine.pause).toHaveBeenCalled();
     expect(player.isPlaying.value).toBe(false);
+  });
+
+  it('recomputes duration after deleting the final fragment created by a split', async () => {
+    const player = useVideoPlayer([]);
+    const longComposition: ClipComposition = {
+      ...composition,
+      schemaVersion: 9,
+      assets: [
+        {
+          id: 'asset',
+          kind: 'video',
+          name: 'Asset',
+          fileName: 'asset.mp4',
+          durationMs: 127_000,
+          width: 1_920,
+          height: 1_080,
+          src: 'project-media://asset',
+          origin: 'project',
+        },
+      ],
+      clips: [
+        {
+          ...(composition.clips[0]! as VisualClip),
+          kind: 'video',
+          trackId: 'video-track',
+          timelineStartMs: 0,
+          timelineDurationMs: 127_000,
+          sourceDurationMs: 127_000,
+          transitions: { entry: null, exit: null },
+          crop: { x: 0, y: 0, width: 1, height: 1 },
+        },
+      ],
+    };
+    const split = splitClip(longComposition, 'clip', 120_000, () => 'final-fragment');
+    const shortened = deleteClip(split, 'final-fragment');
+
+    await player.loadComposition(split);
+    expect(player.duration.value).toBe(127);
+
+    await player.loadComposition(shortened);
+    expect(player.duration.value).toBe(120);
   });
 
   it('exposes playback and audio performance metrics as reactive refs', async () => {

--- a/src/components/video-editor/composables/useClipComposition.ts
+++ b/src/components/video-editor/composables/useClipComposition.ts
@@ -25,9 +25,10 @@ import { audioDefaultsFor, blurDefaultsFor, captionDefaultsFor, visualClipDefaul
 import { createDefaultClipAppearance } from '~/media/shared/composition-defaults';
 import {
   addClip,
+  clipTrimBounds,
   deleteClip,
   detachClip,
-  MIN_CLIP_DURATION_MS,
+  holdClipAtPlayhead,
   moveClip,
   reorderClip,
   setAppearance,
@@ -334,39 +335,9 @@ export function useClipComposition(options: {
   const previewClipEdge = (clipId: string, edge: 'start' | 'end', timeMs: number) => {
     const clip = composition.value.clips.find((entry) => entry.id === clipId);
     if (!clip) return;
-    const asset =
-      clip.kind === 'caption' || isBlurClip(clip)
-        ? undefined
-        : composition.value.assets.find((entry) => entry.id === clip.assetId);
-    const originalStartMs = clip.timelineStartMs;
-    const originalEndMs = endMs(clip);
-
-    if (edge === 'start') {
-      const maxLeftExpansionMs =
-        asset?.durationMs != null && clip.kind !== 'caption'
-          ? Math.round(clip.sourceInMs / Math.max(0.01, clip.playbackRate))
-          : originalStartMs;
-      const minStartMs = Math.max(0, originalStartMs - maxLeftExpansionMs);
-      const maxStartMs = originalEndMs - MIN_CLIP_DURATION_MS;
-      const clamped = Math.max(minStartMs, Math.min(maxStartMs, Math.round(timeMs)));
-      composition.value = trimClip(composition.value, clipId, edge, clamped);
-    } else {
-      const remainingSourceMs =
-        asset?.durationMs != null && clip.kind !== 'caption'
-          ? Math.max(0, asset.durationMs - (clip.sourceInMs + clip.sourceDurationMs))
-          : Infinity;
-      const maxRightExpansionMs =
-        asset?.durationMs != null && clip.kind !== 'caption'
-          ? Math.round(remainingSourceMs / Math.max(0.01, clip.playbackRate))
-          : Infinity;
-      const minEndMs = originalStartMs + MIN_CLIP_DURATION_MS;
-      const maxEndMs = Number.isFinite(maxRightExpansionMs) ? originalEndMs + maxRightExpansionMs : Infinity;
-      const clamped = Math.max(
-        minEndMs,
-        Number.isFinite(maxEndMs) ? Math.min(maxEndMs, Math.round(timeMs)) : Math.round(timeMs),
-      );
-      composition.value = trimClip(composition.value, clipId, edge, clamped);
-    }
+    const bounds = clipTrimBounds(composition.value, clipId, edge);
+    const clamped = Math.max(bounds.minMs, Math.min(bounds.maxMs, Math.round(timeMs)));
+    composition.value = trimClip(composition.value, clipId, edge, clamped);
   };
 
   const trimClipEdge = (clipId: string, edge: 'start' | 'end', timeMs: number) => previewClipEdge(clipId, edge, timeMs);
@@ -380,9 +351,22 @@ export function useClipComposition(options: {
     if (!clip || timeMs <= clip.timelineStartMs || timeMs >= endMs(clip)) return;
     composition.value = splitClip(composition.value, clip.id, timeMs);
   };
+  const holdClip = (clipId: string, timeMs: number) => {
+    const clip = composition.value.clips.find((entry) => entry.id === clipId);
+    if (!clip) return;
+    composition.value = holdClipAtPlayhead(composition.value, clipId, timeMs);
+    const hold = composition.value.clips.find(
+      (entry) =>
+        isVisualClip(entry) &&
+        entry.trackId === clip.trackId &&
+        entry.timelineStartMs === Math.round(timeMs) &&
+        entry.freezeFrameSourceMs !== undefined,
+    );
+    if (hold) selectedClipId.value = hold.id;
+  };
   const deleteSelectedClip = () => {
     if (!selectedClipId.value) return;
-    composition.value = deleteClip(composition.value, selectedClipId.value);
+    composition.value = deleteClip(composition.value, selectedClipId.value, true);
     selectedClipId.value = null;
   };
   const reorderVisualClip = (clipId: string, targetIndex: number) => {
@@ -477,6 +461,7 @@ export function useClipComposition(options: {
     previewMoveClip,
     moveClipTo,
     splitSelectedClip,
+    holdClip,
     deleteSelectedClip,
     reorderVisualClip,
     updateSelectedAppearance,

--- a/src/components/video-editor/composables/useVideoPlayer.ts
+++ b/src/components/video-editor/composables/useVideoPlayer.ts
@@ -6,7 +6,7 @@ import {
   type PlaybackState,
   type PreviewQuality,
 } from '~/media/playback';
-import type { ClipComposition, MediaError } from '~/media/shared';
+import { compositionDurationMs, type ClipComposition, type MediaError } from '~/media/shared';
 import {
   BACKGROUND_MEDIA,
   getRandomBackgroundImage,
@@ -100,10 +100,7 @@ export function useVideoPlayer(availableBackgrounds: readonly BackgroundMedia[] 
     const generation = ++loadGeneration;
     const previousTime = currentTime.value;
     const wasPlaying = playingIntent;
-    duration.value = composition.clips.reduce(
-      (end, clip) => Math.max(end, (clip.timelineStartMs + clip.timelineDurationMs) / 1_000),
-      0,
-    );
+    duration.value = compositionDurationMs(composition) / 1_000;
     playbackError.value = null;
     const playback = ensureEngine();
     const targetTime = Math.min(previousTime, duration.value);

--- a/src/components/video-editor/composition/engine/clip-composition-validation.ts
+++ b/src/components/video-editor/composition/engine/clip-composition-validation.ts
@@ -101,7 +101,12 @@ export function validateComposition(composition: ClipComposition): void {
     }
     if (
       isVisualClip(clip) &&
-      ((clip.cameraLayoutPreset !== undefined && !isCameraLayoutPreset(clip.cameraLayoutPreset)) ||
+      ((clip.freezeFrameSourceMs !== undefined &&
+        (!finite(clip.freezeFrameSourceMs) ||
+          clip.freezeFrameSourceMs !== clip.sourceInMs ||
+          composition.assets.find((asset) => asset.id === clip.assetId)?.kind !== 'video')) ||
+        (clip.kind === 'image' && clip.freezeFrameSourceMs !== undefined) ||
+        (clip.cameraLayoutPreset !== undefined && !isCameraLayoutPreset(clip.cameraLayoutPreset)) ||
         (clip.cameraFramingPreset !== undefined && !isCameraFramingPreset(clip.cameraFramingPreset)) ||
         (clip.kind !== 'webcam' &&
           clip.cameraLayoutPreset !== undefined &&

--- a/src/components/video-editor/composition/engine/clip-engine.test.ts
+++ b/src/components/video-editor/composition/engine/clip-engine.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 import {
   CompositionEngineError,
   createComposition,
+  HOLD_SEGMENT_DURATION_MS,
+  holdClipAtPlayhead,
   setCameraFraming,
   setCameraLayout,
   setCameraSplitRatio,
@@ -12,6 +14,7 @@ import {
 } from './clip-engine';
 import type { AudioClip, ClipComposition, MediaAsset, VisualClip } from '~/media/shared/composition-types';
 import { createDefaultClipAppearance } from '~/media/shared/composition-defaults';
+import { sourceTimeAt } from '~/media/shared/timeline-mapping';
 
 const videoAsset = (id: string, kind: MediaAsset['kind'] = 'video'): MediaAsset => ({
   id,
@@ -522,5 +525,179 @@ describe('camera layout engine operations', () => {
       width: 1,
       height: 0.5,
     });
+  });
+});
+
+describe('hold clip engine operation', () => {
+  it('captures the exact source frame and inserts a one-second frozen segment', () => {
+    const composition = createComposition(
+      [videoAsset('video-asset')],
+      [
+        visual('video', 'video', 'video-asset', {
+          groupId: undefined,
+          trackId: 'video-track',
+          timelineStartMs: 1_000,
+          timelineDurationMs: 4_000,
+          sourceInMs: 125,
+          sourceDurationMs: 5_000,
+          playbackRate: 1.25,
+        }),
+      ],
+    );
+    let id = 0;
+    const sourceAtPlayhead = sourceTimeAt(composition.clips[0]!, 2_400)!;
+
+    const held = holdClipAtPlayhead(composition, 'video', 2_400, () => `generated-${++id}`);
+    const segments = held.clips
+      .filter((clip): clip is VisualClip => clip.kind === 'video')
+      .sort((left, right) => left.timelineStartMs - right.timelineStartMs);
+    const [left, freeze, right] = segments;
+
+    expect(segments).toHaveLength(3);
+    expect(left).toMatchObject({
+      timelineStartMs: 1_000,
+      timelineDurationMs: 1_400,
+      sourceInMs: 125,
+      sourceDurationMs: 1_750,
+    });
+    expect(freeze).toMatchObject({
+      timelineStartMs: 2_400,
+      timelineDurationMs: HOLD_SEGMENT_DURATION_MS,
+      sourceInMs: sourceAtPlayhead,
+      sourceDurationMs: HOLD_SEGMENT_DURATION_MS,
+      playbackRate: 1,
+      freezeFrameSourceMs: sourceAtPlayhead,
+    });
+    expect(sourceAtPlayhead).toBe(1_875);
+    expect(sourceTimeAt(freeze!, 2_400)).toBe(sourceAtPlayhead);
+    expect(sourceTimeAt(freeze!, 3_399)).toBe(sourceAtPlayhead);
+    expect(right).toMatchObject({
+      timelineStartMs: 3_400,
+      timelineDurationMs: 2_600,
+      sourceInMs: 1_875,
+      sourceDurationMs: 3_250,
+      playbackRate: 1.25,
+    });
+    expect(right?.freezeFrameSourceMs).toBeUndefined();
+  });
+
+  it('splits linked screen, webcam, and audio while leaving a one-second audio gap', () => {
+    let id = 0;
+    const held = holdClipAtPlayhead(compositionFixture(), 'camera', 400, () => `generated-${++id}`);
+    const left = held.clips.filter((clip) => clip.timelineStartMs === 0);
+    const holds = held.clips.filter(
+      (clip): clip is VisualClip => 'freezeFrameSourceMs' in clip && clip.freezeFrameSourceMs !== undefined,
+    );
+    const right = held.clips.filter((clip) => clip.timelineStartMs === 1_400);
+
+    expect(held.clips).toHaveLength(8);
+    expect(left.map((clip) => clip.kind).sort()).toEqual(['audio', 'screen', 'webcam']);
+    expect(holds.map((clip) => clip.kind).sort()).toEqual(['screen', 'webcam']);
+    expect(right.map((clip) => clip.kind).sort()).toEqual(['audio', 'screen', 'webcam']);
+    expect(new Set(left.map((clip) => clip.groupId))).toEqual(new Set(['recording-segment']));
+    const holdGroupId = holds[0]?.groupId;
+    const rightGroupId = right[0]?.groupId;
+    expect(holdGroupId).toBeTruthy();
+    expect(rightGroupId).toBeTruthy();
+    expect(new Set(holds.map((clip) => clip.groupId))).toEqual(new Set([holdGroupId]));
+    expect(new Set(right.map((clip) => clip.groupId))).toEqual(new Set([rightGroupId]));
+    expect(rightGroupId).not.toBe(holdGroupId);
+    expect(rightGroupId).not.toBe('recording-segment');
+
+    for (const clip of holds) {
+      expect(clip).toMatchObject({
+        timelineStartMs: 400,
+        timelineDurationMs: HOLD_SEGMENT_DURATION_MS,
+        sourceInMs: 400,
+        sourceDurationMs: HOLD_SEGMENT_DURATION_MS,
+        playbackRate: 1,
+        freezeFrameSourceMs: 400,
+      });
+    }
+
+    const audioSegments = held.clips.filter((clip): clip is AudioClip => clip.kind === 'audio');
+    const audioLeft = audioSegments.find((clip) => clip.timelineStartMs === 0)!;
+    const audioRight = audioSegments.find((clip) => clip.timelineStartMs === 1_400)!;
+    expect(audioLeft).toMatchObject({ timelineDurationMs: 400, sourceInMs: 0, sourceDurationMs: 400 });
+    expect(audioRight).toMatchObject({ timelineDurationMs: 600, sourceInMs: 400, sourceDurationMs: 600 });
+    expect(sourceTimeAt(audioLeft, 399)).toBe(399);
+    expect(sourceTimeAt(audioLeft, 400)).toBeNull();
+    expect(sourceTimeAt(audioRight, 1_399)).toBeNull();
+    expect(sourceTimeAt(audioRight, 1_400)).toBe(400);
+  });
+
+  it('pushes downstream fragments and their grouped companions while leaving other tracks in place', () => {
+    const composition = createComposition(
+      [
+        videoAsset('main-asset'),
+        videoAsset('later-asset'),
+        videoAsset('later-companion-asset'),
+        videoAsset('other-asset'),
+      ],
+      [
+        visual('main', 'video', 'main-asset', {
+          groupId: undefined,
+          trackId: 'video-track',
+          timelineDurationMs: 2_000,
+          sourceDurationMs: 2_000,
+        }),
+        visual('later', 'video', 'later-asset', {
+          groupId: 'later-group',
+          trackId: 'video-track',
+          timelineStartMs: 2_000,
+          timelineDurationMs: 500,
+          sourceDurationMs: 500,
+        }),
+        visual('later-companion', 'webcam', 'later-companion-asset', {
+          groupId: 'later-group',
+          trackId: 'camera-track',
+          timelineStartMs: 2_000,
+          timelineDurationMs: 500,
+          sourceDurationMs: 500,
+        }),
+        visual('other-track', 'video', 'other-asset', {
+          groupId: undefined,
+          trackId: 'other-track',
+          timelineStartMs: 2_000,
+          timelineDurationMs: 500,
+          sourceDurationMs: 500,
+        }),
+      ],
+    );
+
+    let id = 0;
+    const held = holdClipAtPlayhead(composition, 'main', 1_000, () => `generated-${++id}`);
+    const later = held.clips.find((clip) => clip.id === 'later')!;
+    const laterCompanion = held.clips.find((clip) => clip.id === 'later-companion')!;
+    const otherTrack = held.clips.find((clip) => clip.id === 'other-track')!;
+    const right = held.clips.find((clip) => clip.id === 'generated-1')!;
+
+    expect(right).toMatchObject({ timelineStartMs: 2_000, timelineDurationMs: 1_000 });
+    expect(later).toMatchObject({ timelineStartMs: 3_000, timelineDurationMs: 500 });
+    expect(laterCompanion).toMatchObject({ timelineStartMs: 3_000, timelineDurationMs: 500 });
+    expect(otherTrack).toMatchObject({ timelineStartMs: 2_000, timelineDurationMs: 500 });
+    expect(later.sourceInMs).toBe(0);
+    expect(later.sourceDurationMs).toBe(500);
+  });
+
+  it('rejects images, existing holds, and playhead boundary positions', () => {
+    const composition = visualPresetComposition();
+
+    expect(() => holdClipAtPlayhead(composition, 'image-clip', 500, () => 'unused')).toThrow(
+      'Only video clips can be held.',
+    );
+    expect(() => holdClipAtPlayhead(composition, 'video-clip', 0, () => 'unused')).toThrow(
+      'Hold must be inside the clip.',
+    );
+    expect(() => holdClipAtPlayhead(composition, 'video-clip', 1_000, () => 'unused')).toThrow(
+      'Hold must be inside the clip.',
+    );
+
+    let id = 0;
+    const held = holdClipAtPlayhead(composition, 'video-clip', 500, () => `generated-${++id}`);
+    const freeze = held.clips.find(
+      (clip): clip is VisualClip => 'freezeFrameSourceMs' in clip && clip.freezeFrameSourceMs !== undefined,
+    )!;
+    expect(() => holdClipAtPlayhead(held, freeze.id, 750, () => 'unused')).toThrow('Only video clips can be held.');
   });
 });

--- a/src/components/video-editor/composition/engine/clip-engine.ts
+++ b/src/components/video-editor/composition/engine/clip-engine.ts
@@ -22,7 +22,6 @@ import {
   normalizeClipOrders,
   reorderClipOrders,
   visualMoveDeltaBounds,
-  visualTrimBounds,
 } from './visual-track-layout';
 import {
   CompositionEngineError,
@@ -32,6 +31,8 @@ import {
   validateComposition,
 } from './clip-composition-validation';
 export { setCameraLayout, setCameraSplitPadding, setCameraSplitRatio } from './camera-layout-operations';
+export { HOLD_SEGMENT_DURATION_MS, holdClipAtPlayhead } from './hold-clip';
+export { clipTrimBounds, trimClip } from './trim-clip';
 export {
   CompositionEngineError,
   MAX_PLAYBACK_RATE,
@@ -184,82 +185,6 @@ export function setPlaybackRate(composition: ClipComposition, clipId: string, pl
   return next;
 }
 
-export function trimClip(
-  composition: ClipComposition,
-  clipId: string,
-  edge: 'start' | 'end',
-  timelineTimeMs: number,
-): ClipComposition {
-  const next = clone(composition);
-  const source = byId(next, clipId);
-  const target = integer(timelineTimeMs);
-  if (!finite(target)) throw new CompositionEngineError('Invalid trim target time.');
-  const originalEnd = clipEndMs(source);
-
-  if (edge === 'start') {
-    if (target < 0 || target > originalEnd - MIN_CLIP_DURATION_MS) {
-      throw new CompositionEngineError('Invalid start trim boundary.');
-    }
-  } else {
-    if (target < source.timelineStartMs + MIN_CLIP_DURATION_MS) {
-      throw new CompositionEngineError('Invalid end trim boundary.');
-    }
-  }
-
-  const ids = new Set(targetIds(next, clipId));
-  const trackBounds = visualTrimBounds(next.clips, ids, edge);
-  if ((edge === 'start' && target < trackBounds.min) || (edge === 'end' && target > trackBounds.max)) {
-    throw new CompositionEngineError('Trim would overlap another fragment on the same visual track.');
-  }
-  next.clips = next.clips.map((clip) => {
-    if (!ids.has(clip.id)) return clip;
-    const rate = Math.max(0.01, clip.playbackRate);
-    if (edge === 'start') {
-      const startDelta = target - clip.timelineStartMs;
-      const newTimelineDuration = clip.timelineStartMs + clip.timelineDurationMs - target;
-      const newSourceDuration = integer(newTimelineDuration * rate);
-      if (clip.kind === 'caption') {
-        return {
-          ...clip,
-          timelineStartMs: target,
-          timelineDurationMs: newTimelineDuration,
-          sourceInMs: 0,
-          sourceDurationMs: newSourceDuration,
-          transitions: normalizeClipTransitions(
-            clip.transitions ?? EMPTY_CLIP_TRANSITIONS,
-            newTimelineDuration,
-            clip.kind,
-          ),
-        };
-      }
-      const sourceDelta = integer(startDelta * rate);
-      const newSourceInMs = Math.max(0, clip.sourceInMs + sourceDelta);
-      return {
-        ...clip,
-        timelineStartMs: target,
-        timelineDurationMs: newTimelineDuration,
-        sourceInMs: newSourceInMs,
-        sourceDurationMs: newSourceDuration,
-        transitions: normalizeClipTransitions(
-          clip.transitions ?? EMPTY_CLIP_TRANSITIONS,
-          newTimelineDuration,
-          clip.kind,
-        ),
-      };
-    }
-    const newTimelineDuration = target - clip.timelineStartMs;
-    const newSourceDuration = integer(newTimelineDuration * rate);
-    return {
-      ...clip,
-      timelineDurationMs: newTimelineDuration,
-      sourceDurationMs: newSourceDuration,
-      transitions: normalizeClipTransitions(clip.transitions ?? EMPTY_CLIP_TRANSITIONS, newTimelineDuration, clip.kind),
-    };
-  });
-  validateComposition(next);
-  return next;
-}
-
 export function splitClip(
   composition: ClipComposition,
   clipId: string,
@@ -278,13 +203,14 @@ export function splitClip(
   next.clips = next.clips.map((clip) => {
     if (!ids.has(clip.id)) return clip;
     const leftSourceDuration = integer(offset * clip.playbackRate);
+    const freezeFrameSourceMs = isVisualClip(clip) ? clip.freezeFrameSourceMs : undefined;
     const right: Clip = {
       ...clip,
       id: idFactory(),
       groupId: rightGroupId,
       timelineStartMs: target,
       timelineDurationMs: clip.timelineDurationMs - offset,
-      sourceInMs: clip.sourceInMs + leftSourceDuration,
+      sourceInMs: freezeFrameSourceMs ?? clip.sourceInMs + leftSourceDuration,
       sourceDurationMs: clip.sourceDurationMs - leftSourceDuration,
       transitions: normalizeClipTransitions(
         { entry: null, exit: clip.transitions?.exit ?? null },

--- a/src/components/video-editor/composition/engine/clip-paste.test.ts
+++ b/src/components/video-editor/composition/engine/clip-paste.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { createDefaultCaptionStyle, createDefaultClipAppearance } from '~/media/shared/composition-defaults';
+import { COMPOSITION_SCHEMA_VERSION } from '~/media/shared/composition-types';
 import type {
   AudioClip,
   CaptionClip,
@@ -121,7 +122,7 @@ const caption = (
 });
 
 const composition = (clips: Clip[], assets: MediaAsset[]): ClipComposition => ({
-  schemaVersion: 8,
+  schemaVersion: COMPOSITION_SCHEMA_VERSION,
   assets,
   clips,
   keyboardCaptionSessions: [],

--- a/src/components/video-editor/composition/engine/clip-paste.ts
+++ b/src/components/video-editor/composition/engine/clip-paste.ts
@@ -74,7 +74,11 @@ const fragmentAt = (
     groupId: undefined,
     timelineStartMs: startMs,
     timelineDurationMs: durationMs,
-    sourceInMs: isCaptionClip(clip) ? 0 : clip.sourceInMs + Math.round(elapsedMs * clip.playbackRate),
+    sourceInMs: isCaptionClip(clip)
+      ? 0
+      : 'freezeFrameSourceMs' in clip && clip.freezeFrameSourceMs !== undefined
+        ? clip.freezeFrameSourceMs
+        : clip.sourceInMs + Math.round(elapsedMs * clip.playbackRate),
     sourceDurationMs,
     transitions: transitionEdges(clip, keepEntry, keepExit, durationMs),
   };

--- a/src/components/video-editor/composition/engine/hold-clip.ts
+++ b/src/components/video-editor/composition/engine/hold-clip.ts
@@ -1,0 +1,95 @@
+import { clipEndMs, isVisualClip, type Clip, type ClipComposition } from '~/media/shared/composition-types';
+import { normalizeClipTransitions } from '~/media/shared/clip-transitions';
+import { CompositionEngineError, MIN_CLIP_DURATION_MS, validateComposition } from './clip-composition-validation';
+import { normalizeClipOrders } from './visual-track-layout';
+import { downstreamVisualTrackRippleIds } from './visual-track-ripple';
+
+export const HOLD_SEGMENT_DURATION_MS = 1_000;
+
+const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
+const createId = (): string => crypto.randomUUID();
+const isVideoClip = (composition: ClipComposition, clip: Clip) =>
+  isVisualClip(clip) &&
+  clip.kind !== 'image' &&
+  composition.assets.some((asset) => asset.id === clip.assetId && asset.kind === 'video');
+
+export function holdClipAtPlayhead(
+  composition: ClipComposition,
+  clipId: string,
+  timelineTimeMs: number,
+  idFactory: () => string = createId,
+): ClipComposition {
+  const next = clone(composition);
+  const source = next.clips.find((clip) => clip.id === clipId);
+  if (!source) throw new CompositionEngineError(`Unknown clip: ${clipId}`);
+  if (!isVideoClip(next, source) || (isVisualClip(source) && source.freezeFrameSourceMs !== undefined))
+    throw new CompositionEngineError('Only video clips can be held.');
+
+  const target = Math.round(timelineTimeMs);
+  if (
+    !Number.isFinite(target) ||
+    target < source.timelineStartMs + MIN_CLIP_DURATION_MS ||
+    target > clipEndMs(source) - MIN_CLIP_DURATION_MS
+  )
+    throw new CompositionEngineError('Hold must be inside the clip.');
+
+  const targetIds = new Set(
+    source.groupId ? next.clips.filter((clip) => clip.groupId === source.groupId).map((clip) => clip.id) : [source.id],
+  );
+  const heldTargets = next.clips.filter((clip) => targetIds.has(clip.id) && isVideoClip(next, clip));
+  const rippleIds = downstreamVisualTrackRippleIds(next.clips, targetIds, target);
+  const rightGroupId = source.groupId ? idFactory() : undefined;
+  const holdGroupId = heldTargets.length > 1 ? idFactory() : undefined;
+  const additions: Clip[] = [];
+
+  next.clips = next.clips.map((clip) => {
+    if (!targetIds.has(clip.id))
+      return rippleIds.has(clip.id)
+        ? { ...clip, timelineStartMs: clip.timelineStartMs + HOLD_SEGMENT_DURATION_MS }
+        : clip;
+
+    const offset = target - clip.timelineStartMs;
+    const leftSourceDuration = Math.round(offset * clip.playbackRate);
+    const rightDuration = clip.timelineDurationMs - offset;
+    additions.push({
+      ...clip,
+      id: idFactory(),
+      groupId: rightGroupId,
+      timelineStartMs: target + HOLD_SEGMENT_DURATION_MS,
+      timelineDurationMs: rightDuration,
+      sourceInMs: clip.sourceInMs + leftSourceDuration,
+      sourceDurationMs: clip.sourceDurationMs - leftSourceDuration,
+      transitions: normalizeClipTransitions(
+        { entry: null, exit: clip.transitions?.exit ?? null },
+        rightDuration,
+        clip.kind,
+      ),
+    });
+
+    if (isVideoClip(next, clip) && isVisualClip(clip)) {
+      const freezeFrameSourceMs = clip.sourceInMs + leftSourceDuration;
+      additions.push({
+        ...clip,
+        id: idFactory(),
+        groupId: holdGroupId,
+        timelineStartMs: target,
+        timelineDurationMs: HOLD_SEGMENT_DURATION_MS,
+        sourceInMs: freezeFrameSourceMs,
+        sourceDurationMs: HOLD_SEGMENT_DURATION_MS,
+        playbackRate: 1,
+        transitions: { entry: null, exit: null },
+        freezeFrameSourceMs,
+      });
+    }
+
+    return {
+      ...clip,
+      timelineDurationMs: offset,
+      sourceDurationMs: leftSourceDuration,
+      transitions: normalizeClipTransitions({ entry: clip.transitions?.entry ?? null, exit: null }, offset, clip.kind),
+    };
+  });
+  next.clips = normalizeClipOrders([...next.clips, ...additions]);
+  validateComposition(next);
+  return next;
+}

--- a/src/components/video-editor/composition/engine/trim-clip.test.ts
+++ b/src/components/video-editor/composition/engine/trim-clip.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it } from 'vitest';
+import { clipTrimBounds, createComposition, holdClipAtPlayhead, trimClip } from './clip-engine';
+import type { ClipComposition, MediaAsset, VisualClip } from '~/media/shared/composition-types';
+import { createDefaultClipAppearance } from '~/media/shared/composition-defaults';
+import { sourceTimeAt } from '~/media/shared/timeline-mapping';
+
+const videoAsset = (id: string, durationMs = 5_000): MediaAsset => ({
+  id,
+  kind: 'video',
+  name: id,
+  fileName: `${id}.mp4`,
+  durationMs,
+  width: 1_920,
+  height: 1_080,
+  src: `${id}.mp4`,
+  origin: 'project',
+});
+
+const videoClip = (id: string, overrides: Partial<VisualClip> = {}): VisualClip => ({
+  id,
+  kind: 'video',
+  name: id,
+  assetId: `${id}-asset`,
+  timelineStartMs: 0,
+  timelineDurationMs: 1_000,
+  sourceInMs: 0,
+  sourceDurationMs: 1_000,
+  playbackRate: 1,
+  transitions: { entry: null, exit: null },
+  enabled: true,
+  order: 0,
+  trackId: `${id}-track`,
+  transform: { x: 0, y: 0, width: 1, height: 1 },
+  appearance: createDefaultClipAppearance('video'),
+  isMirrored: false,
+  isMirroredY: false,
+  ...overrides,
+});
+
+const assertNoVisualOverlap = (composition: ClipComposition) => {
+  const clipsByTrack = new Map<string, VisualClip[]>();
+  for (const clip of composition.clips) {
+    if (clip.kind !== 'screen' && clip.kind !== 'video' && clip.kind !== 'image' && clip.kind !== 'webcam') continue;
+    const track = clipsByTrack.get(clip.trackId!);
+    if (track) track.push(clip);
+    else clipsByTrack.set(clip.trackId!, [clip]);
+  }
+
+  for (const clips of clipsByTrack.values()) {
+    const ordered = [...clips].sort((left, right) => left.timelineStartMs - right.timelineStartMs);
+    for (let index = 1; index < ordered.length; index += 1) {
+      const previous = ordered[index - 1]!;
+      const current = ordered[index]!;
+      expect(current.timelineStartMs).toBeGreaterThanOrEqual(previous.timelineStartMs + previous.timelineDurationMs);
+    }
+  }
+};
+
+const sourceData = (clip: VisualClip) => ({
+  sourceInMs: clip.sourceInMs,
+  sourceDurationMs: clip.sourceDurationMs,
+  playbackRate: clip.playbackRate,
+  timelineDurationMs: clip.timelineDurationMs,
+});
+
+const heldComposition = () => {
+  const composition = createComposition(
+    [
+      videoAsset('main-asset'),
+      videoAsset('following-asset'),
+      videoAsset('following-companion-asset'),
+      videoAsset('other-asset'),
+    ],
+    [
+      videoClip('main', {
+        assetId: 'main-asset',
+        trackId: 'main-track',
+        timelineDurationMs: 2_000,
+        sourceDurationMs: 2_000,
+      }),
+      videoClip('following', {
+        assetId: 'following-asset',
+        trackId: 'main-track',
+        groupId: 'following-group',
+        timelineStartMs: 2_000,
+        timelineDurationMs: 500,
+        sourceInMs: 2_000,
+        sourceDurationMs: 500,
+      }),
+      videoClip('following-companion', {
+        assetId: 'following-companion-asset',
+        trackId: 'companion-track',
+        groupId: 'following-group',
+        timelineStartMs: 2_000,
+        timelineDurationMs: 500,
+        sourceInMs: 2_000,
+        sourceDurationMs: 500,
+      }),
+      videoClip('other-track-clip', {
+        assetId: 'other-asset',
+        trackId: 'other-track',
+        order: 1,
+        timelineStartMs: 2_000,
+        timelineDurationMs: 500,
+        sourceInMs: 2_000,
+        sourceDurationMs: 500,
+      }),
+    ],
+  );
+
+  let id = 0;
+  const held = holdClipAtPlayhead(composition, 'main', 1_000, () => `generated-${++id}`);
+  const hold = held.clips.find(
+    (clip): clip is VisualClip => clip.kind === 'video' && clip.freezeFrameSourceMs !== undefined,
+  );
+  if (!hold) throw new Error('Fixture did not create a hold segment.');
+  return { held, hold };
+};
+
+describe('trimClip ripple behavior', () => {
+  it('pushes downstream fragments and grouped companions when a hold is extended', () => {
+    const { held, hold } = heldComposition();
+    const oldEnd = hold.timelineStartMs + hold.timelineDurationMs;
+    const before = new Map(held.clips.map((clip) => [clip.id, clip]));
+
+    const trimmed = trimClip(held, hold.id, 'end', oldEnd + 500);
+    const updatedHold = trimmed.clips.find((clip) => clip.id === hold.id) as VisualClip;
+
+    expect(updatedHold).toMatchObject({
+      timelineStartMs: hold.timelineStartMs,
+      timelineDurationMs: hold.timelineDurationMs + 500,
+      sourceInMs: hold.sourceInMs,
+      sourceDurationMs: hold.sourceDurationMs + 500,
+      freezeFrameSourceMs: hold.freezeFrameSourceMs,
+    });
+    expect(sourceTimeAt(updatedHold, updatedHold.timelineStartMs + 499)).toBe(hold.freezeFrameSourceMs);
+    expect(trimmed.clips).toHaveLength(held.clips.length);
+
+    for (const clip of held.clips) {
+      const updated = trimmed.clips.find((entry) => entry.id === clip.id)!;
+      if (clip.id === hold.id) continue;
+      const shouldRipple =
+        clip.timelineStartMs >= oldEnd && (clip.trackId === hold.trackId || clip.groupId === 'following-group');
+      expect(updated.timelineStartMs).toBe(clip.timelineStartMs + (shouldRipple ? 500 : 0));
+      expect(sourceData(updated as VisualClip)).toEqual(sourceData(clip as VisualClip));
+      expect(before.get(clip.id)?.id).toBe(updated.id);
+    }
+
+    assertNoVisualOverlap(trimmed);
+  });
+
+  it('brings downstream fragments and grouped companions back when a hold is shortened', () => {
+    const { held, hold } = heldComposition();
+    const oldEnd = hold.timelineStartMs + hold.timelineDurationMs;
+    const before = new Map(held.clips.map((clip) => [clip.id, sourceData(clip as VisualClip)]));
+
+    const trimmed = trimClip(held, hold.id, 'end', oldEnd - 500);
+    const updatedHold = trimmed.clips.find((clip) => clip.id === hold.id) as VisualClip;
+
+    expect(updatedHold).toMatchObject({
+      timelineStartMs: hold.timelineStartMs,
+      timelineDurationMs: hold.timelineDurationMs - 500,
+      sourceInMs: hold.sourceInMs,
+      sourceDurationMs: hold.sourceDurationMs - 500,
+      freezeFrameSourceMs: hold.freezeFrameSourceMs,
+    });
+    expect(sourceTimeAt(updatedHold, updatedHold.timelineStartMs + 499)).toBe(hold.freezeFrameSourceMs);
+    expect(trimmed.clips).toHaveLength(held.clips.length);
+
+    for (const clip of held.clips) {
+      const updated = trimmed.clips.find((entry) => entry.id === clip.id)!;
+      if (clip.id === hold.id) continue;
+      const shouldRipple =
+        clip.timelineStartMs >= oldEnd && (clip.trackId === hold.trackId || clip.groupId === 'following-group');
+      expect(updated.timelineStartMs).toBe(clip.timelineStartMs - (shouldRipple ? 500 : 0));
+      expect(sourceData(updated as VisualClip)).toEqual(before.get(clip.id));
+    }
+
+    assertNoVisualOverlap(trimmed);
+  });
+
+  it('extends a truncated video into available source and pushes the adjacent fragment intact', () => {
+    const composition = createComposition(
+      [videoAsset('truncated-asset', 3_000), videoAsset('adjacent-asset', 3_000)],
+      [
+        videoClip('truncated', {
+          assetId: 'truncated-asset',
+          trackId: 'shared-track',
+          timelineDurationMs: 1_000,
+          sourceDurationMs: 1_000,
+        }),
+        videoClip('adjacent', {
+          assetId: 'adjacent-asset',
+          trackId: 'shared-track',
+          timelineStartMs: 1_000,
+          timelineDurationMs: 1_000,
+          sourceInMs: 1_000,
+          sourceDurationMs: 1_000,
+        }),
+      ],
+    );
+    const adjacentBefore = composition.clips.find((clip) => clip.id === 'adjacent') as VisualClip;
+    const adjacentSourceBefore = sourceData(adjacentBefore);
+
+    const trimmed = trimClip(composition, 'truncated', 'end', 1_500);
+    const updated = trimmed.clips.find((clip) => clip.id === 'truncated') as VisualClip;
+    const adjacent = trimmed.clips.find((clip) => clip.id === 'adjacent') as VisualClip;
+
+    expect(updated).toMatchObject({
+      timelineStartMs: 0,
+      timelineDurationMs: 1_500,
+      sourceInMs: 0,
+      sourceDurationMs: 1_500,
+    });
+    expect(updated.freezeFrameSourceMs).toBeUndefined();
+    expect(sourceTimeAt(updated, 1_499)).toBe(1_499);
+    expect(adjacent.timelineStartMs).toBe(1_500);
+    expect(sourceData(adjacent)).toEqual(adjacentSourceBefore);
+    expect(trimmed.clips).toHaveLength(composition.clips.length);
+    assertNoVisualOverlap(trimmed);
+  });
+
+  it('uses the same finite source bound for preview clamping and the engine commit', () => {
+    const composition = createComposition(
+      [videoAsset('bounded-asset', 2_000)],
+      [
+        videoClip('bounded', {
+          assetId: 'bounded-asset',
+          sourceInMs: 500,
+          sourceDurationMs: 1_000,
+          timelineDurationMs: 1_000,
+        }),
+      ],
+    );
+
+    expect(clipTrimBounds(composition, 'bounded', 'end')).toEqual({ minMs: 40, maxMs: 1_500 });
+    expect(() => trimClip(composition, 'bounded', 'end', 1_501)).toThrow('Invalid end trim boundary.');
+    expect(trimClip(composition, 'bounded', 'end', 1_500).clips[0]).toMatchObject({
+      timelineDurationMs: 1_500,
+      sourceDurationMs: 1_500,
+    });
+  });
+});

--- a/src/components/video-editor/composition/engine/trim-clip.ts
+++ b/src/components/video-editor/composition/engine/trim-clip.ts
@@ -1,0 +1,138 @@
+import {
+  clipEndMs,
+  isVisualClip,
+  type Clip,
+  type ClipComposition,
+  type VisualClip,
+} from '~/media/shared/composition-types';
+import { EMPTY_CLIP_TRANSITIONS, normalizeClipTransitions } from '~/media/shared/clip-transitions';
+import { CompositionEngineError, MIN_CLIP_DURATION_MS, validateComposition } from './clip-composition-validation';
+import { visualTrimBounds } from './visual-track-layout';
+import { downstreamVisualTrackRippleIds } from './visual-track-ripple';
+
+const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
+const integer = (value: number) => Math.round(value);
+const isFreeze = (clip: Clip): clip is VisualClip & { freezeFrameSourceMs: number } =>
+  isVisualClip(clip) && clip.freezeFrameSourceMs !== undefined;
+
+const targetIds = (composition: ClipComposition, clip: Clip) =>
+  new Set(
+    clip.groupId
+      ? composition.clips.filter((entry) => entry.groupId === clip.groupId).map((entry) => entry.id)
+      : [clip.id],
+  );
+
+const assetDurationFor = (composition: ClipComposition, clip: Clip) =>
+  clip.kind === 'caption' || clip.kind === 'blur'
+    ? null
+    : (composition.assets.find((asset) => asset.id === clip.assetId)?.durationMs ?? null);
+
+const hasUnlimitedDuration = (clip: Clip) =>
+  clip.kind === 'caption' ||
+  clip.kind === 'blur' ||
+  (isVisualClip(clip) && (clip.kind === 'image' || clip.freezeFrameSourceMs !== undefined));
+
+export function clipTrimBounds(
+  composition: ClipComposition,
+  clipId: string,
+  edge: 'start' | 'end',
+): { minMs: number; maxMs: number } {
+  const source = composition.clips.find((clip) => clip.id === clipId);
+  if (!source) throw new CompositionEngineError(`Unknown clip: ${clipId}`);
+  const ids = targetIds(composition, source);
+  const targets = composition.clips.filter((clip) => ids.has(clip.id));
+  const trackBounds = visualTrimBounds(composition.clips, ids, edge);
+  if (edge === 'start') {
+    const sourceMin = Math.max(
+      0,
+      ...targets.map((clip) =>
+        hasUnlimitedDuration(clip) ? 0 : clip.timelineStartMs - clip.sourceInMs / Math.max(0.01, clip.playbackRate),
+      ),
+    );
+    return {
+      minMs: Math.ceil(Math.max(sourceMin, trackBounds.min)),
+      maxMs: clipEndMs(source) - MIN_CLIP_DURATION_MS,
+    };
+  }
+  const sourceMax = Math.min(
+    Infinity,
+    ...targets.map((clip) => {
+      if (hasUnlimitedDuration(clip)) return Infinity;
+      const assetDurationMs = assetDurationFor(composition, clip);
+      if (assetDurationMs === null) return Infinity;
+      const remainingSourceMs = Math.max(0, assetDurationMs - (clip.sourceInMs + clip.sourceDurationMs));
+      return clipEndMs(clip) + remainingSourceMs / Math.max(0.01, clip.playbackRate);
+    }),
+  );
+  return {
+    minMs: source.timelineStartMs + MIN_CLIP_DURATION_MS,
+    maxMs: Math.floor(isVisualClip(source) ? sourceMax : Math.min(sourceMax, trackBounds.max)),
+  };
+}
+
+export function trimClip(
+  composition: ClipComposition,
+  clipId: string,
+  edge: 'start' | 'end',
+  timelineTimeMs: number,
+): ClipComposition {
+  const next = clone(composition);
+  const source = next.clips.find((clip) => clip.id === clipId);
+  if (!source) throw new CompositionEngineError(`Unknown clip: ${clipId}`);
+  const target = integer(timelineTimeMs);
+  if (!Number.isFinite(target)) throw new CompositionEngineError('Invalid trim target time.');
+  const originalEnd = clipEndMs(source);
+  const bounds = clipTrimBounds(next, clipId, edge);
+  if (target < bounds.minMs || target > bounds.maxMs) {
+    throw new CompositionEngineError(`Invalid ${edge} trim boundary.`);
+  }
+
+  const ids = targetIds(next, source);
+  const trackBounds = visualTrimBounds(next.clips, ids, edge);
+  const freezeRipple = edge === 'end' && [...ids].some((id) => isFreeze(next.clips.find((clip) => clip.id === id)!));
+  const collisionRipple = edge === 'end' && target > trackBounds.max && isVisualClip(source);
+  if (edge === 'end' && target > trackBounds.max && !collisionRipple) {
+    throw new CompositionEngineError('Trim would overlap another fragment on the same visual track.');
+  }
+  const rippleDelta = freezeRipple || collisionRipple ? target - originalEnd : 0;
+  const rippleIds = downstreamVisualTrackRippleIds(next.clips, ids, originalEnd);
+
+  next.clips = next.clips.map((clip) => {
+    if (!ids.has(clip.id)) {
+      return rippleDelta !== 0 && rippleIds.has(clip.id)
+        ? { ...clip, timelineStartMs: clip.timelineStartMs + rippleDelta }
+        : clip;
+    }
+    const rate = Math.max(0.01, clip.playbackRate);
+    if (edge === 'start') {
+      const newTimelineDuration = clipEndMs(clip) - target;
+      const sourceDelta = integer((target - clip.timelineStartMs) * rate);
+      return {
+        ...clip,
+        timelineStartMs: target,
+        timelineDurationMs: newTimelineDuration,
+        sourceInMs:
+          clip.kind === 'caption'
+            ? 0
+            : isFreeze(clip)
+              ? clip.freezeFrameSourceMs!
+              : Math.max(0, clip.sourceInMs + sourceDelta),
+        sourceDurationMs: integer(newTimelineDuration * rate),
+        transitions: normalizeClipTransitions(
+          clip.transitions ?? EMPTY_CLIP_TRANSITIONS,
+          newTimelineDuration,
+          clip.kind,
+        ),
+      };
+    }
+    const newTimelineDuration = target - clip.timelineStartMs;
+    return {
+      ...clip,
+      timelineDurationMs: newTimelineDuration,
+      sourceDurationMs: integer(newTimelineDuration * rate),
+      transitions: normalizeClipTransitions(clip.transitions ?? EMPTY_CLIP_TRANSITIONS, newTimelineDuration, clip.kind),
+    };
+  });
+  validateComposition(next);
+  return next;
+}

--- a/src/components/video-editor/composition/engine/visual-track-ripple.ts
+++ b/src/components/video-editor/composition/engine/visual-track-ripple.ts
@@ -1,0 +1,26 @@
+import { isCompositingClip, type Clip } from '~/media/shared/composition-types';
+
+export function downstreamVisualTrackRippleIds(clips: Clip[], editedIds: Set<string>, boundaryMs: number): Set<string> {
+  const trackIds = new Set(
+    clips.flatMap((clip) => (editedIds.has(clip.id) && isCompositingClip(clip) && clip.trackId ? [clip.trackId] : [])),
+  );
+  const direct = clips.filter(
+    (clip) =>
+      !editedIds.has(clip.id) &&
+      clip.timelineStartMs >= boundaryMs &&
+      isCompositingClip(clip) &&
+      clip.trackId !== undefined &&
+      trackIds.has(clip.trackId),
+  );
+  const directIds = new Set(direct.map((clip) => clip.id));
+  const linkedGroupIds = new Set(direct.flatMap((clip) => (clip.groupId ? [clip.groupId] : [])));
+  return new Set(
+    clips.flatMap((clip) =>
+      !editedIds.has(clip.id) &&
+      clip.timelineStartMs >= boundaryMs &&
+      (directIds.has(clip.id) || (clip.groupId && linkedGroupIds.has(clip.groupId)))
+        ? [clip.id]
+        : [],
+    ),
+  );
+}

--- a/src/components/video-editor/composition/tests/session-clips.test.ts
+++ b/src/components/video-editor/composition/tests/session-clips.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { ProjectEditorData, SessionTrackAsset, SessionTrackData } from '../../../../api/types/capture-api';
 import type { InputEventSidecar } from '../../../../api/types/capture-session';
-import { emptyComposition, type ClipComposition } from '~/media/shared/composition-types';
+import { COMPOSITION_SCHEMA_VERSION, emptyComposition, type ClipComposition } from '~/media/shared/composition-types';
 import { synchronizeRecordingClips } from '../session-clips';
 import { createDefaultClipAppearance } from '~/media/shared/composition-defaults';
 
@@ -93,7 +93,7 @@ describe('synchronizeRecordingClips', () => {
     } as unknown as ClipComposition;
 
     expect(synchronizeRecordingClips(legacy, null)).toEqual({
-      schemaVersion: 8,
+      schemaVersion: COMPOSITION_SCHEMA_VERSION,
       assets: [],
       clips: [],
       keyboardCaptionSessions: [],
@@ -282,7 +282,7 @@ describe('synchronizeRecordingClips', () => {
 
     const first = synchronizeRecordingClips(emptyComposition(), data);
     const keyboardCaptions = first.clips.filter((clip) => clip.kind === 'caption');
-    expect(first.schemaVersion).toBe(8);
+    expect(first.schemaVersion).toBe(COMPOSITION_SCHEMA_VERSION);
     expect(first.keyboardCaptionSessions).toEqual(['session-1']);
     expect(keyboardCaptions).toHaveLength(1);
     expect(keyboardCaptions[0]).toMatchObject({

--- a/src/components/video-editor/tests/VideoEditor.test.mocks.ts
+++ b/src/components/video-editor/tests/VideoEditor.test.mocks.ts
@@ -193,6 +193,9 @@ vi.mock('../composables/useVideoEditor', async () => {
       const outputCanvas = ref({ preset: '16:9', width: 1920, height: 1080, showBackground: false });
       const store = {
         activeTab,
+        initialPlaybackSettled: ref(true),
+        includeAudioInExport: ref(true),
+        editorDefaults: ref({ zoom: { durationMs: 1_500 } }),
         systemVolume: ref(100),
         micVolume: ref(100),
         sourceSize: ref({ width: 1280, height: 720 }),
@@ -510,6 +513,7 @@ vi.mock('../timeline/EditorTimeline.vue', async () => {
         'add:caption',
         'delete:clips',
         'reorder:clip',
+        'preview:composition',
         'paste:item',
         'clipboard:copied',
       ],

--- a/src/components/video-editor/tests/VideoEditor.test.setup.ts
+++ b/src/components/video-editor/tests/VideoEditor.test.setup.ts
@@ -20,10 +20,10 @@ let editorComponent: Component | null = null;
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
-    callback(0);
-    return 1;
-  });
+  vi.stubGlobal(
+    'requestAnimationFrame',
+    vi.fn(() => 1),
+  );
   vi.stubGlobal('cancelAnimationFrame', vi.fn());
   editorState.store = undefined;
 });

--- a/src/components/video-editor/tests/VideoEditor.test.ts
+++ b/src/components/video-editor/tests/VideoEditor.test.ts
@@ -120,6 +120,59 @@ describe('VideoEditor', () => {
     expect(editorState.store.outputCanvas.value.preset).toBe('1:1');
   });
 
+  it('deletes a grouped video fragment and its linked audio through the timeline event', async () => {
+    const mounted = mountEditor();
+    const state = editorState.store;
+    const current = state.compositionState.composition.value as ClipComposition;
+    const video = current.clips.find((clip) => clip.id === 'screen')!;
+    const audio = current.clips.find((clip) => clip.id === 'audio')!;
+    const leftVideo = {
+      ...video,
+      id: 'left-video',
+      groupId: 'left-group',
+      timelineDurationMs: 120_000,
+      sourceDurationMs: 120_000,
+    };
+    const rightVideo = {
+      ...video,
+      id: 'right-video',
+      groupId: 'right-group',
+      timelineStartMs: 120_000,
+      timelineDurationMs: 7_000,
+      sourceInMs: 120_000,
+      sourceDurationMs: 7_000,
+    };
+    const leftAudio = {
+      ...audio,
+      id: 'left-audio',
+      groupId: 'left-group',
+      timelineDurationMs: 120_000,
+      sourceDurationMs: 120_000,
+    };
+    const rightAudio = {
+      ...audio,
+      id: 'right-audio',
+      groupId: 'right-group',
+      timelineStartMs: 120_000,
+      timelineDurationMs: 7_000,
+      sourceInMs: 120_000,
+      sourceDurationMs: 7_000,
+    };
+    state.compositionState.composition.value = {
+      ...current,
+      assets: current.assets.map((asset) => ({ ...asset, durationMs: 127_000 })),
+      clips: [leftVideo, rightVideo, leftAudio, rightAudio],
+    };
+    await mounted.vm.$nextTick();
+
+    mounted.findComponent({ name: 'MockEditorTimeline' }).vm.$emit('delete:clips', ['right-video']);
+    await mounted.vm.$nextTick();
+
+    const remaining = state.compositionState.composition.value.clips as ClipComposition['clips'];
+    expect(remaining.some((clip) => clip.id === 'right-video' || clip.id === 'right-audio')).toBe(false);
+    expect(Math.max(...remaining.map((clip) => clip.timelineStartMs + clip.timelineDurationMs))).toBe(120_000);
+  });
+
   it('applies composition previews without saving or recording history, while final updates save', async () => {
     const mounted = mountEditor();
     await flushPromises();
@@ -140,6 +193,29 @@ describe('VideoEditor', () => {
     expect(editorState.store.compositionState.composition.value.clips[0].transform.x).toBe(0.5);
     expect(mounted.get('.mock-canvas').attributes('data-composition-transform-x')).toBe('0.5');
     expect(scheduleSave).toHaveBeenCalledOnce();
+  });
+
+  it('shows the preview composition duration in the timeline toolbar and restores the canonical duration', async () => {
+    const mounted = mountEditor();
+    const composition = editorState.store.compositionState.composition.value as ClipComposition;
+    const preview = {
+      ...composition,
+      clips: composition.clips.map((clip) =>
+        clip.id === 'screen' ? { ...clip, timelineDurationMs: 3_500, sourceDurationMs: 3_500 } : clip,
+      ),
+    } satisfies ClipComposition;
+    const timeline = mounted.findComponent({ name: 'MockEditorTimeline' });
+    const toolbar = () => mounted.findComponent({ name: 'MockTimelineToolbar' });
+
+    expect(toolbar().attributes('duration')).toBe('2');
+
+    timeline.vm.$emit('preview:composition', preview);
+    await mounted.vm.$nextTick();
+    expect(toolbar().attributes('duration')).toBe('3.5');
+
+    timeline.vm.$emit('preview:composition', null);
+    await mounted.vm.$nextTick();
+    expect(toolbar().attributes('duration')).toBe('2');
   });
 
   it('keeps the canvas background enabled when changing the output format', async () => {

--- a/src/components/video-editor/timeline/EditorTimeline.vue
+++ b/src/components/video-editor/timeline/EditorTimeline.vue
@@ -46,6 +46,7 @@ const emit = defineEmits<{
   (event: 'toggle:clip', clipId: string): void;
   (event: 'delete:clips', clipIds: string[]): void;
   (event: 'delete:zoom', zoomId: string): void;
+  (event: 'hold:clip', payload: { id: string; timeMs: number }): void;
   (event: 'trim:clip', payload: { id: string; edge: 'start' | 'end'; timeMs: number }): void;
   (event: 'move:clip', payload: { id: string; startMs: number }): void;
   (event: 'preview:composition', value: ClipComposition | null): void;
@@ -102,6 +103,7 @@ onUnmounted(() => window.removeEventListener('keydown', handleKeyDown));
         @toggle:clip="emit('toggle:clip', $event)"
         @delete:clips="emit('delete:clips', $event)"
         @delete:zoom="emit('delete:zoom', $event)"
+        @hold:clip="emit('hold:clip', $event)"
         @trim:clip="emit('trim:clip', $event)"
         @move:clip="emit('move:clip', $event)"
         @preview:composition="emit('preview:composition', $event)"

--- a/src/components/video-editor/timeline/TimelineClip.vue
+++ b/src/components/video-editor/timeline/TimelineClip.vue
@@ -1,18 +1,19 @@
 <script setup lang="ts">
 import { computed, onUnmounted, ref, watch } from 'vue';
 import type { Clip, MediaAsset } from '~/media/shared/composition-types';
-import type { MediaError } from '~/media/shared';
+import { sourceTimeAt, type MediaError } from '~/media/shared';
 import { useThumbnails } from './waveform/useThumbnails';
 import { useTranslate } from '~/i18n/useTranslate';
 import type { TimelineThumbnailSlot } from './composables/timeline-viewport';
 import type { AudioWaveformStatus } from './composables/useCompositionAudioWaveforms';
 import WaveformCanvas from './waveform/WaveformCanvas.vue';
-
+import { timelineClipStyle, timelineFrameStyle, timelineTransitionStyle } from './timeline-clip-geometry';
 const { t } = useTranslate('TimelineTracks');
 const props = defineProps<{
   clip: Clip;
   asset?: MediaAsset | null;
   duration: number;
+  timelineWidthPx?: number;
   thumbnailSlots: readonly TimelineThumbnailSlot[];
   selected: boolean;
   waveformBars?: number[];
@@ -31,7 +32,6 @@ const emit = defineEmits<{
   (event: 'trim', value: { event: PointerEvent; edge: 'start' | 'end' }): void;
   (event: 'contextmenu', value: MouseEvent): void;
 }>();
-
 const videoAsset = computed(() => (props.clip.kind !== 'audio' && props.asset?.kind === 'video' ? props.asset : null));
 const { thumbnails, requestVisibleFrames } = useThumbnails(videoAsset);
 const clipEndMs = computed(() => props.clip.timelineStartMs + props.clip.timelineDurationMs);
@@ -44,7 +44,8 @@ const frames = computed<TimelineFrame[]>(() =>
     const timelineMs = Math.max(slotStartMs, props.clip.timelineStartMs);
     const timelineEndMs = Math.min(slotEndMs, clipEndMs.value);
     if (timelineEndMs <= timelineMs) return [];
-    const sourceMs = props.clip.sourceInMs + (timelineMs - props.clip.timelineStartMs) * props.clip.playbackRate;
+    const sourceMs = sourceTimeAt(props.clip, timelineMs);
+    if (sourceMs === null) return [];
     return [
       {
         timelineSecond: slot.timelineSeconds,
@@ -57,9 +58,6 @@ const frames = computed<TimelineFrame[]>(() =>
 );
 const frozenFrames = ref<TimelineFrame[]>([]);
 const displayedFrames = computed(() => (frozenFrames.value.length ? frozenFrames.value : frames.value));
-// Moving a clip changes only its timeline placement. The thumbnail content is
-// still the same source segment, so do not replace it (or show skeletons) on a
-// move commit. Refresh only when the viewport or source timing actually changes.
 const thumbnailRefreshKey = computed(() =>
   [
     props.thumbnailSlots.map((slot) => `${slot.timelineSeconds}:${slot.durationSeconds}`).join(','),
@@ -67,6 +65,7 @@ const thumbnailRefreshKey = computed(() =>
     props.clip.sourceInMs,
     props.clip.sourceDurationMs,
     props.clip.playbackRate,
+    'freezeFrameSourceMs' in props.clip ? props.clip.freezeFrameSourceMs : '',
   ].join('|'),
 );
 watch(
@@ -79,18 +78,9 @@ watch(
   },
   { immediate: true },
 );
-
-const clipStyle = computed(() => ({
-  left: `${props.duration > 0 ? (props.clip.timelineStartMs / (props.duration * 1_000)) * 100 : 0}%`,
-  width: `${props.duration > 0 ? (props.clip.timelineDurationMs / (props.duration * 1_000)) * 100 : 0}%`,
-}));
-const frameStyle = (frame: TimelineFrame) => ({
-  left: `${(frame.relativeMs / Math.max(1, props.clip.timelineDurationMs)) * 100}%`,
-  width: `${(frame.durationMs / Math.max(1, props.clip.timelineDurationMs)) * 100}%`,
-});
-const transitionStyle = (edge: 'entry' | 'exit') => ({
-  width: `${((props.clip.transitions?.[edge]?.durationMs ?? 0) / Math.max(1, props.clip.timelineDurationMs)) * 100}%`,
-});
+const clipStyle = computed(() => timelineClipStyle(props.clip, props.duration, props.timelineWidthPx));
+const frameStyle = (frame: TimelineFrame) => timelineFrameStyle(props.clip, frame.relativeMs, frame.durationMs);
+const transitionStyle = (edge: 'entry' | 'exit') => timelineTransitionStyle(props.clip, edge);
 const thumbnailFor = (frame: TimelineFrame) => {
   const exact = thumbnails[frame.mediaSecond];
   if (exact) return exact;
@@ -108,7 +98,6 @@ const formatTrimTime = (milliseconds: number) => {
   const tenths = Math.floor((seconds % 1) * 10);
   return `${minutes > 0 ? `${minutes}:` : ''}${wholeSeconds.toString().padStart(2, '0')}.${tenths}s`;
 };
-
 let marqueeFrame = 0;
 let marqueeTimer = 0;
 const stopMarquee = (target?: HTMLElement | null) => {
@@ -140,7 +129,6 @@ const startMarquee = (event: PointerEvent) => {
 };
 onUnmounted(() => stopMarquee());
 </script>
-
 <template>
   <button
     type="button"
@@ -223,7 +211,7 @@ onUnmounted(() => stopMarquee());
       }}</span>
     </span>
     <span class="clip-label-overlay">
-      <span class="clip-label-text">{{ clip.name }}</span>
+      <span class="clip-label-text">{{ 'freezeFrameSourceMs' in clip ? t('holdSegment') : clip.name }}</span>
       <span v-if="Math.abs(clip.playbackRate - 1) > 0.01" class="speed-badge">{{ clip.playbackRate.toFixed(2) }}×</span>
     </span>
     <span
@@ -238,7 +226,6 @@ onUnmounted(() => stopMarquee());
     </span>
   </button>
 </template>
-
 <style scoped>
 .timeline-clip {
   position: absolute;
@@ -253,8 +240,12 @@ onUnmounted(() => stopMarquee());
   color: var(--text-primary);
   cursor: grab;
   isolation: isolate;
+  contain: layout paint style;
   box-sizing: border-box;
-  transition: opacity var(--fast) ease;
+  transition:
+    opacity var(--fast) ease,
+    transform 180ms cubic-bezier(0.22, 1, 0.36, 1),
+    width 180ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 .timeline-clip:active {
   cursor: grabbing;

--- a/src/components/video-editor/timeline/TimelineTracks.vue
+++ b/src/components/video-editor/timeline/TimelineTracks.vue
@@ -12,7 +12,6 @@ import TimelineCanvasTransitionTrack from './TimelineCanvasTransitionTrack.vue';
 import { EMPTY_CLIP_TRANSITIONS } from '~/media/shared/clip-transitions';
 import { DEFAULT_OUTPUT_CANVAS } from '../canvas/output-canvas';
 import { useTimelineClipboardShortcuts } from './composables/useTimelineClipboardShortcuts';
-
 const { t } = useTranslate('TimelineTracks');
 const props = withDefaults(defineProps<TimelineTracksProps>(), {
   isSnappingEnabled: true,
@@ -22,14 +21,14 @@ const props = withDefaults(defineProps<TimelineTracksProps>(), {
   canvas: () => ({ ...DEFAULT_OUTPUT_CANVAS, transitions: { ...EMPTY_CLIP_TRANSITIONS } }),
 });
 const emit = defineEmits<TimelineTracksEmits>();
-
 const {
+  layoutDurationMs,
   visualTracks,
   keyboardCaptionClips,
   textCaptionClips,
   systemAudioClips,
   microphoneClips,
-  importedAudioClips,
+  importedAudioTracks,
   assetFor,
   audioWaveforms,
   audioWaveformErrors,
@@ -38,6 +37,7 @@ const {
   sidebarScrollRef,
   tracksViewportRef,
   ticksAreaRef,
+  rulerWidth,
   tracksWidthStyle,
   playheadStyle,
   rulerSeconds,
@@ -49,6 +49,7 @@ const {
   percentageStyle,
   beginScrub,
   handleWheel,
+  activeTrimState,
   activeSnapTimeMs,
   movingClipIds,
   displayedClip,
@@ -73,7 +74,6 @@ const {
   DEFAULT_CAPTION_DURATION_MS,
 } = useTimelineTracks(props, emit, t);
 void [tracksScrollRef, sidebarScrollRef, tracksViewportRef, ticksAreaRef];
-
 const {
   contextMenuState,
   contextMenuItems,
@@ -95,7 +95,6 @@ const {
   emit,
   t,
 });
-
 useTimelineClipboardShortcuts({
   composition: () => props.composition,
   selectedClipId: () => props.selectedClipId,
@@ -103,7 +102,6 @@ useTimelineClipboardShortcuts({
   copySelected,
   pasteClipboard,
 });
-
 const exportProgressPercent = computed(() => {
   const current = props.exportProgress?.currentTimeMs;
   const total = props.exportProgress?.totalTimeMs;
@@ -117,7 +115,6 @@ const updateCanvasTransitions = (transitions: NonNullable<typeof props.canvas.tr
 const previewCanvasTransitions = (transitions: NonNullable<typeof props.canvas.transitions> | null) =>
   emit('preview:canvas', transitions ? { ...props.canvas, transitions } : null);
 </script>
-
 <template>
   <div class="timeline-root" @wheel="handleWheel">
     <div class="timeline-sidebar">
@@ -128,7 +125,7 @@ const previewCanvasTransitions = (transitions: NonNullable<typeof props.canvas.t
             v-if="hasCanvasTransitions"
             mode="sidebar"
             :transitions="canvasTransitions"
-            :duration-ms="Math.round(duration * 1000)"
+            :duration-ms="layoutDurationMs"
             @open="emit('open:canvas-transition', $event)"
           />
           <TransitionGroup name="track-reorder" tag="div" class="visual-tracks-group">
@@ -155,13 +152,11 @@ const previewCanvasTransitions = (transitions: NonNullable<typeof props.canvas.t
               </button>
             </div>
           </TransitionGroup>
-
           <div class="sidebar-track-item cursor-track" @contextmenu="openTrackContextMenu($event, 'zoom')">
             <div class="track-info static-info">
               <MousePointer class="track-icon" /><span class="track-title">{{ t('zooms') }}</span>
             </div>
           </div>
-
           <div
             v-if="keyboardCaptionClips.length"
             class="sidebar-track-item annotation-track keyboard-caption-track"
@@ -179,7 +174,6 @@ const previewCanvasTransitions = (transitions: NonNullable<typeof props.canvas.t
               <Type class="track-icon" /><span class="track-title">{{ t('textCaptions') }}</span>
             </div>
           </div>
-
           <div
             v-if="systemAudioClips.length"
             class="sidebar-track-item audio-track"
@@ -193,7 +187,6 @@ const previewCanvasTransitions = (transitions: NonNullable<typeof props.canvas.t
               }}</span>
             </div>
           </div>
-
           <div
             v-if="microphoneClips.length"
             class="sidebar-track-item audio-track"
@@ -207,16 +200,15 @@ const previewCanvasTransitions = (transitions: NonNullable<typeof props.canvas.t
               }}</span>
             </div>
           </div>
-
           <div
-            v-for="clip in importedAudioClips"
-            :key="clip.id"
+            v-for="track in importedAudioTracks"
+            :key="track.id"
             class="sidebar-track-item audio-track"
-            :class="{ disabled: !includeAudioInExport || !clip.enabled }"
+            :class="{ disabled: !includeAudioInExport || !track.clips.some((clip) => clip.enabled) }"
             @contextmenu="openTrackContextMenu($event, 'audio')"
           >
             <div class="track-info">
-              <Volume2 class="track-icon" /><span class="track-title">{{ clip.name }}</span>
+              <Volume2 class="track-icon" /><span class="track-title">{{ track.representative.name }}</span>
               <span v-if="!includeAudioInExport" class="export-disabled-status">{{
                 t('audioDisabledFromExport')
               }}</span>
@@ -225,9 +217,13 @@ const previewCanvasTransitions = (transitions: NonNullable<typeof props.canvas.t
         </div>
       </div>
     </div>
-
     <div ref="tracksScrollRef" class="timeline-tracks-container" @scroll="onScroll">
-      <div ref="tracksViewportRef" class="timeline-viewport" :style="tracksWidthStyle">
+      <div
+        ref="tracksViewportRef"
+        class="timeline-viewport"
+        :class="{ 'is-trimming': activeTrimState !== null }"
+        :style="tracksWidthStyle"
+      >
         <div class="timeline-ruler">
           <div ref="ticksAreaRef" class="ruler-ticks-area" @pointerdown="beginScrub">
             <div
@@ -249,7 +245,6 @@ const previewCanvasTransitions = (transitions: NonNullable<typeof props.canvas.t
             </div>
           </div>
         </div>
-
         <div class="timeline-playhead-overlay">
           <div class="timeline-playhead" :style="playheadStyle">
             <div class="playhead-head">
@@ -268,13 +263,12 @@ const previewCanvasTransitions = (transitions: NonNullable<typeof props.canvas.t
             <span class="snap-guide-badge">{{ (activeSnapTimeMs / 1000).toFixed(2) }}s</span>
           </div>
         </div>
-
         <div class="tracks-stack">
           <TimelineCanvasTransitionTrack
             v-if="hasCanvasTransitions"
             mode="track"
             :transitions="canvasTransitions"
-            :duration-ms="Math.round(duration * 1000)"
+            :duration-ms="layoutDurationMs"
             @open="emit('open:canvas-transition', $event)"
             @preview="previewCanvasTransitions"
             @update="updateCanvasTransitions"
@@ -294,11 +288,12 @@ const previewCanvasTransitions = (transitions: NonNullable<typeof props.canvas.t
                   :key="clip.id"
                   :clip="displayedClip(clip)"
                   :asset="assetFor(clip)"
-                  :duration="duration"
+                  :duration="layoutDurationMs / 1000"
+                  :timeline-width-px="rulerWidth"
                   :thumbnail-slots="thumbnailSlots"
+                  :defer-thumbnail-requests="activeTrimState !== null || movingClipIds.includes(clip.id)"
                   :selected="selectedClipId === clip.id"
                   :trim-state="trimStateFor(clip.id)"
-                  :defer-thumbnail-requests="movingClipIds.includes(clip.id)"
                   :paste-highlight="recentPaste?.type === 'clip' && recentPaste.id === clip.id"
                   @select="emit('select:clip', clip.id)"
                   @contextmenu="openClipContextMenu($event, clip)"
@@ -308,7 +303,6 @@ const previewCanvasTransitions = (transitions: NonNullable<typeof props.canvas.t
               </div>
             </div>
           </TransitionGroup>
-
           <div class="track-row cursor-track" @contextmenu="openTrackContextMenu($event, 'zoom')">
             <div
               class="track-content cursor-content"
@@ -363,7 +357,6 @@ const previewCanvasTransitions = (transitions: NonNullable<typeof props.canvas.t
               </button>
             </div>
           </div>
-
           <TimelineCaptionTracks
             :keyboard-clips="keyboardCaptionClips"
             :text-clips="textCaptionClips"
@@ -383,7 +376,6 @@ const previewCanvasTransitions = (transitions: NonNullable<typeof props.canvas.t
             @contextmenu:clip="openClipContextMenu($event.event, $event.clip)"
             @contextmenu:track="openTrackContextMenu($event, 'caption')"
           />
-
           <div
             v-if="systemAudioClips.length"
             class="track-row audio-track"
@@ -397,8 +389,10 @@ const previewCanvasTransitions = (transitions: NonNullable<typeof props.canvas.t
                 :key="clip.id"
                 :clip="displayedClip(clip)"
                 :asset="assetFor(clip)"
-                :duration="duration"
+                :duration="layoutDurationMs / 1000"
+                :timeline-width-px="rulerWidth"
                 :thumbnail-slots="thumbnailSlots"
+                :defer-thumbnail-requests="activeTrimState !== null"
                 :selected="selectedClipId === clip.id"
                 :waveform-bars="audioWaveforms[clip.id]?.bars"
                 :waveform-left-percent="audioWaveforms[clip.id]?.leftPercent"
@@ -415,7 +409,6 @@ const previewCanvasTransitions = (transitions: NonNullable<typeof props.canvas.t
               />
             </div>
           </div>
-
           <div
             v-if="microphoneClips.length"
             class="track-row audio-track"
@@ -429,8 +422,10 @@ const previewCanvasTransitions = (transitions: NonNullable<typeof props.canvas.t
                 :key="clip.id"
                 :clip="displayedClip(clip)"
                 :asset="assetFor(clip)"
-                :duration="duration"
+                :duration="layoutDurationMs / 1000"
+                :timeline-width-px="rulerWidth"
                 :thumbnail-slots="thumbnailSlots"
+                :defer-thumbnail-requests="activeTrimState !== null"
                 :selected="selectedClipId === clip.id"
                 :waveform-bars="audioWaveforms[clip.id]?.bars"
                 :waveform-left-percent="audioWaveforms[clip.id]?.leftPercent"
@@ -447,21 +442,24 @@ const previewCanvasTransitions = (transitions: NonNullable<typeof props.canvas.t
               />
             </div>
           </div>
-
           <div
-            v-for="clip in importedAudioClips"
-            :key="clip.id"
+            v-for="track in importedAudioTracks"
+            :key="track.id"
             class="track-row audio-track"
-            :class="{ disabled: !includeAudioInExport || !clip.enabled }"
+            :class="{ disabled: !includeAudioInExport || !track.clips.some((clip) => clip.enabled) }"
             @contextmenu="openTrackContextMenu($event, 'audio')"
           >
             <div class="track-content audio-content">
               <span v-if="!includeAudioInExport" class="export-audio-disabled">{{ t('audioDisabledFromExport') }}</span>
               <TimelineClip
+                v-for="clip in track.clips"
+                :key="clip.id"
                 :clip="displayedClip(clip)"
                 :asset="assetFor(clip)"
-                :duration="duration"
+                :duration="layoutDurationMs / 1000"
+                :timeline-width-px="rulerWidth"
                 :thumbnail-slots="thumbnailSlots"
+                :defer-thumbnail-requests="activeTrimState !== null"
                 :selected="selectedClipId === clip.id"
                 :waveform-bars="audioWaveforms[clip.id]?.bars"
                 :waveform-left-percent="audioWaveforms[clip.id]?.leftPercent"
@@ -481,7 +479,6 @@ const previewCanvasTransitions = (transitions: NonNullable<typeof props.canvas.t
         </div>
       </div>
     </div>
-
     <!-- Track & Clip Context Menu -->
     <ContextMenu
       :is-open="contextMenuState.isOpen"
@@ -493,6 +490,5 @@ const previewCanvasTransitions = (transitions: NonNullable<typeof props.canvas.t
     />
   </div>
 </template>
-
 <style scoped src="./timeline-tracks.css"></style>
 <style src="./timeline-paste-feedback.css"></style>

--- a/src/components/video-editor/timeline/composables/audio-timeline-tracks.ts
+++ b/src/components/video-editor/timeline/composables/audio-timeline-tracks.ts
@@ -1,0 +1,21 @@
+import type { AudioClip } from '~/media/shared/composition-types';
+
+export interface ImportedAudioTimelineTrack {
+  id: string;
+  clips: AudioClip[];
+  representative: AudioClip;
+}
+
+export function groupImportedAudioTimelineTracks(clips: AudioClip[]): ImportedAudioTimelineTrack[] {
+  const grouped = new Map<string, AudioClip[]>();
+  for (const clip of clips) {
+    const track = grouped.get(clip.assetId);
+    if (track) track.push(clip);
+    else grouped.set(clip.assetId, [clip]);
+  }
+  return [...grouped.entries()].map(([id, trackClips]) => ({
+    id,
+    clips: trackClips,
+    representative: trackClips[0]!,
+  }));
+}

--- a/src/components/video-editor/timeline/composables/tests/timeline-composition-preview.test.ts
+++ b/src/components/video-editor/timeline/composables/tests/timeline-composition-preview.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import type { ClipComposition, VisualClip } from '~/media/shared/composition-types';
+import { COMPOSITION_SCHEMA_VERSION, createDefaultClipAppearance } from '~/media/shared';
+import { previewClipTrim } from '../timeline-composition-preview';
+
+const videoClip = (id: string, overrides: Partial<VisualClip> = {}): VisualClip => ({
+  id,
+  kind: 'video',
+  name: id,
+  assetId: 'asset-1',
+  timelineStartMs: 0,
+  timelineDurationMs: 1_000,
+  sourceInMs: 0,
+  sourceDurationMs: 1_000,
+  playbackRate: 1,
+  transitions: { entry: null, exit: null },
+  enabled: true,
+  order: 0,
+  trackId: 'video-track',
+  transform: { x: 0, y: 0, width: 1, height: 1 },
+  appearance: createDefaultClipAppearance('video'),
+  isMirrored: false,
+  isMirroredY: false,
+  ...overrides,
+});
+
+const composition = (...clips: VisualClip[]): ClipComposition => ({
+  schemaVersion: COMPOSITION_SCHEMA_VERSION,
+  assets: [],
+  clips,
+  keyboardCaptionSessions: [],
+});
+
+describe('previewClipTrim', () => {
+  it('ripples clips after an extended hold and preserves its frozen source', () => {
+    const hold = videoClip('hold', {
+      timelineStartMs: 1_000,
+      timelineDurationMs: 1_000,
+      sourceInMs: 1_000,
+      sourceDurationMs: 1_000,
+      freezeFrameSourceMs: 1_000,
+    });
+    const downstream = videoClip('downstream', { timelineStartMs: 2_000 });
+
+    const preview = previewClipTrim(composition(hold, downstream), hold, 'end', 2_500);
+    const previewHold = preview.clips.find((clip) => clip.id === hold.id) as VisualClip;
+    const previewDownstream = preview.clips.find((clip) => clip.id === downstream.id) as VisualClip;
+
+    expect(previewHold).toMatchObject({
+      timelineStartMs: 1_000,
+      timelineDurationMs: 1_500,
+      sourceInMs: 1_000,
+      sourceDurationMs: 1_500,
+      freezeFrameSourceMs: 1_000,
+    });
+    expect(previewDownstream.timelineStartMs).toBe(2_500);
+  });
+
+  it('ripples a sibling when a video end trim extends past its current boundary', () => {
+    const video = videoClip('video');
+    const sibling = videoClip('sibling', { timelineStartMs: 1_000 });
+
+    const preview = previewClipTrim(composition(video, sibling), video, 'end', 1_500);
+
+    expect(preview.clips.find((clip) => clip.id === video.id)).toMatchObject({
+      timelineDurationMs: 1_500,
+      sourceDurationMs: 1_500,
+    });
+    expect(preview.clips.find((clip) => clip.id === sibling.id)?.timelineStartMs).toBe(1_500);
+  });
+});

--- a/src/components/video-editor/timeline/composables/tests/useTimelineContextMenu.test.ts
+++ b/src/components/video-editor/timeline/composables/tests/useTimelineContextMenu.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ref } from 'vue';
-import type { Clip, ClipComposition, MediaAsset, VisualClip } from '~/media/shared/composition-types';
+import type { AudioClip, Clip, ClipComposition, MediaAsset, VisualClip } from '~/media/shared/composition-types';
 import { COMPOSITION_SCHEMA_VERSION } from '~/media/shared/composition-types';
 import { createDefaultClipAppearance } from '~/media/shared/composition-defaults';
 import type { ZoomElement } from '../../../zoom/zoom-types';
@@ -40,6 +40,29 @@ const clip = (): VisualClip => ({
   isMirroredY: false,
 });
 
+const visualClip = (kind: VisualClip['kind']): VisualClip => ({
+  ...clip(),
+  id: `${kind}-clip`,
+  kind,
+});
+
+const audioClip = (): AudioClip => ({
+  id: 'audio-clip',
+  kind: 'audio',
+  name: 'Demo audio',
+  assetId: asset.id,
+  timelineStartMs: 0,
+  timelineDurationMs: 2_000,
+  sourceInMs: 0,
+  sourceDurationMs: 2_000,
+  playbackRate: 1,
+  transitions: { entry: null, exit: null },
+  enabled: true,
+  order: 0,
+  role: 'system',
+  volume: 1,
+});
+
 const zoom = (id: string, startMs: number): ZoomElement => ({
   id,
   sessionId: 'session-1',
@@ -75,6 +98,9 @@ const createMenu = (overrides: Partial<Parameters<typeof useTimelineContextMenu>
   };
   return { ...useTimelineContextMenu(options), options, emitSpy, sourceClip, sourceZoom };
 };
+
+const contextMenuItem = (menu: ReturnType<typeof createMenu>, id: string) =>
+  menu.contextMenuItems.value.find((item) => !('isDivider' in item) && item.id === id);
 
 afterEach(() => {
   useTimelineClipboard().clearClipboard();
@@ -128,5 +154,49 @@ describe('useTimelineContextMenu', () => {
 
     expect(menu.emitSpy).toHaveBeenCalledWith('paste:error', 'Copy an item first.');
     expect(menu.emitSpy).not.toHaveBeenCalledWith('paste:item', expect.anything());
+  });
+
+  it.each(['screen', 'video', 'webcam'] as const)(
+    'offers Hold Segment at Playhead for %s clips when the playhead is inside the clip',
+    (kind) => {
+      const menu = createMenu({ currentTimeMs: ref(1_000) });
+
+      menu.openClipContextMenu(new MouseEvent('contextmenu'), visualClip(kind));
+
+      expect(contextMenuItem(menu, 'hold')).toEqual(
+        expect.objectContaining({ id: 'hold', label: 'holdSegment', disabled: false }),
+      );
+    },
+  );
+
+  it.each([
+    ['image', visualClip('image')],
+    ['audio', audioClip()],
+  ] as const)('does not offer Hold Segment for %s clips', (_kind, source) => {
+    const menu = createMenu({ currentTimeMs: ref(1_000) });
+
+    menu.openClipContextMenu(new MouseEvent('contextmenu'), source);
+
+    expect(contextMenuItem(menu, 'hold')).toBeUndefined();
+  });
+
+  it.each([39, 1_961, -1, 2_001])(
+    'disables Hold Segment at playhead time %s near or outside the clip boundary',
+    (timeMs) => {
+      const menu = createMenu({ currentTimeMs: ref(timeMs) });
+
+      menu.openClipContextMenu(new MouseEvent('contextmenu'), menu.sourceClip);
+
+      expect(contextMenuItem(menu, 'hold')).toEqual(expect.objectContaining({ id: 'hold', disabled: true }));
+    },
+  );
+
+  it('emits hold:clip with the selected clip and current playhead time', () => {
+    const menu = createMenu({ currentTimeMs: ref(1_000) });
+
+    menu.openClipContextMenu(new MouseEvent('contextmenu'), menu.sourceClip);
+    menu.handleContextMenuSelect('hold');
+
+    expect(menu.emitSpy).toHaveBeenCalledWith('hold:clip', { id: menu.sourceClip.id, timeMs: 1_000 });
   });
 });

--- a/src/components/video-editor/timeline/composables/timeline-composition-preview.ts
+++ b/src/components/video-editor/timeline/composables/timeline-composition-preview.ts
@@ -1,4 +1,6 @@
-import type { Clip, ClipComposition } from '~/media/shared/composition-types';
+import { clipEndMs, isVisualClip, type Clip, type ClipComposition } from '~/media/shared/composition-types';
+import { visualTrimBounds } from '../../composition/engine/visual-track-layout';
+import { downstreamVisualTrackRippleIds } from '../../composition/engine/visual-track-ripple';
 
 const linkedIds = (composition: ClipComposition, clip: Clip) =>
   new Set(
@@ -25,10 +27,24 @@ export function previewClipTrim(
   timelineTimeMs: number,
 ): ClipComposition {
   const ids = linkedIds(composition, clip);
+  const originalEndMs = clipEndMs(clip);
+  const trackBounds = visualTrimBounds(composition.clips, ids, edge);
+  const freezeRipple =
+    edge === 'end' &&
+    composition.clips.some(
+      (entry) => ids.has(entry.id) && isVisualClip(entry) && entry.freezeFrameSourceMs !== undefined,
+    );
+  const collisionRipple = edge === 'end' && isVisualClip(clip) && timelineTimeMs > trackBounds.max;
+  const rippleDeltaMs = freezeRipple || collisionRipple ? timelineTimeMs - originalEndMs : 0;
+  const rippleIds = downstreamVisualTrackRippleIds(composition.clips, ids, originalEndMs);
   return {
     ...composition,
     clips: composition.clips.map((entry) => {
-      if (!ids.has(entry.id)) return entry;
+      if (!ids.has(entry.id)) {
+        return rippleDeltaMs !== 0 && rippleIds.has(entry.id)
+          ? { ...entry, timelineStartMs: entry.timelineStartMs + rippleDeltaMs }
+          : entry;
+      }
       if (edge === 'end') {
         const timelineDurationMs = timelineTimeMs - entry.timelineStartMs;
         return {
@@ -47,7 +63,9 @@ export function previewClipTrim(
         sourceInMs:
           entry.kind === 'caption'
             ? 0
-            : Math.max(0, entry.sourceInMs + Math.round(startDeltaMs * Math.max(0.01, entry.playbackRate))),
+            : 'freezeFrameSourceMs' in entry && entry.freezeFrameSourceMs !== undefined
+              ? entry.freezeFrameSourceMs
+              : Math.max(0, entry.sourceInMs + Math.round(startDeltaMs * Math.max(0.01, entry.playbackRate))),
         sourceDurationMs,
       };
     }),

--- a/src/components/video-editor/timeline/composables/timeline-tracks-types.ts
+++ b/src/components/video-editor/timeline/composables/timeline-tracks-types.ts
@@ -37,6 +37,7 @@ export interface TimelineTracksEmits {
   (event: 'toggle:clip', clipId: string): void;
   (event: 'delete:clips', clipIds: string[]): void;
   (event: 'delete:zoom', zoomId: string): void;
+  (event: 'hold:clip', payload: { id: string; timeMs: number }): void;
   (event: 'trim:clip', payload: { id: string; edge: 'start' | 'end'; timeMs: number }): void;
   (event: 'move:clip', payload: { id: string; startMs: number }): void;
   (event: 'preview:composition', value: ClipComposition | null): void;

--- a/src/components/video-editor/timeline/composables/useTimelineClipTrim.ts
+++ b/src/components/video-editor/timeline/composables/useTimelineClipTrim.ts
@@ -1,0 +1,151 @@
+import { nextTick, type Ref } from 'vue';
+import type { Clip, ClipComposition } from '~/media/shared/composition-types';
+import { MIN_CLIP_DURATION_MS } from '../../composition/engine/clip-composition-validation';
+import { clipTrimBounds } from '../../composition/engine/trim-clip';
+import { createAnimationFrameCoalescer } from './animation-frame-coalescer';
+import { calculateSnapThresholdMs, collectSnapTargets, snapValue } from './timeline-snap';
+import { previewClipTrim } from './timeline-composition-preview';
+import type { TimelineTracksEmits, TimelineTracksProps } from './timeline-tracks-types';
+
+type TrimState = { ids: string[]; edge: 'start' | 'end'; durationMs: number; atLimit?: boolean } | null;
+type ClipPreview = Record<string, { startMs: number; durationMs: number }>;
+
+export function useTimelineClipTrim(options: {
+  props: TimelineTracksProps;
+  emit: TimelineTracksEmits;
+  tracksScrollRef: Ref<HTMLDivElement | null>;
+  displayedPlayheadTime: Ref<number>;
+  activeSnapTimeMs: Ref<number | null>;
+  previewDurationMs: Ref<number | null>;
+  clipPreview: Ref<ClipPreview>;
+  activeTrimState: Ref<TrimState>;
+  linkedIdsFor: (clip: Clip) => string[];
+  clearLinkedPreview: (ids: string[]) => void;
+  resolveMsPerPx: () => { baseDurationMs: number; width: number; msPerPx: number };
+  updateAutoScroll: (clientX: number, onScroll?: ((deltaPx: number) => void) | null) => void;
+  stopAutoScroll: () => void;
+}) {
+  const beginClipTrim = (event: PointerEvent, clip: Clip, edge: 'start' | 'end') => {
+    event.preventDefault();
+    event.stopPropagation();
+    const ids = options.linkedIdsFor(clip);
+    const pointerStartX = event.clientX;
+    const { baseDurationMs, width: baseRulerWidth, msPerPx } = options.resolveMsPerPx();
+    const originalStartMs = clip.timelineStartMs;
+    const originalEndMs = clip.timelineStartMs + clip.timelineDurationMs;
+    const bounds = clipTrimBounds(options.props.composition, clip.id, edge);
+    const snapTargets = collectSnapTargets({
+      composition: options.props.composition,
+      zoomElements: options.props.zoomElements,
+      currentTime: options.displayedPlayheadTime.value,
+      duration: options.props.duration,
+      ignoreClipIds: ids,
+    });
+    const snapThresholdMs = calculateSnapThresholdMs(baseDurationMs, baseRulerWidth);
+    let finalTimeMs = edge === 'start' ? originalStartMs : originalEndMs;
+    let previewedIds = ids;
+    let trimActive = true;
+    let autoScrollDeltaPx = 0;
+    options.activeTrimState.value = {
+      ids,
+      edge,
+      durationMs: clip.timelineDurationMs,
+      atLimit: false,
+    };
+
+    const applyMove = (next: PointerEvent) => {
+      const scrollBounds = options.tracksScrollRef.value?.getBoundingClientRect();
+      const visibleClientX =
+        scrollBounds && scrollBounds.width > 0
+          ? Math.max(scrollBounds.left, Math.min(scrollBounds.right, next.clientX))
+          : next.clientX;
+      const deltaPx = visibleClientX - pointerStartX + autoScrollDeltaPx;
+      const raw = (edge === 'start' ? originalStartMs : originalEndMs) + Math.round(deltaPx * msPerPx);
+      let proposedTimeMs =
+        edge === 'start'
+          ? Math.max(bounds.minMs, Math.min(originalEndMs - MIN_CLIP_DURATION_MS, raw))
+          : Math.max(originalStartMs + MIN_CLIP_DURATION_MS, Math.min(bounds.maxMs, raw));
+      const snap =
+        options.props.isSnappingEnabled !== false ? snapValue(proposedTimeMs, snapTargets, snapThresholdMs) : null;
+      if (snap) {
+        proposedTimeMs =
+          edge === 'start'
+            ? Math.max(bounds.minMs, Math.min(originalEndMs - MIN_CLIP_DURATION_MS, snap.snappedValueMs))
+            : Math.max(originalStartMs + MIN_CLIP_DURATION_MS, Math.min(bounds.maxMs, snap.snappedValueMs));
+        options.activeSnapTimeMs.value = snap.targetMs;
+      } else {
+        options.activeSnapTimeMs.value = null;
+      }
+
+      finalTimeMs = proposedTimeMs;
+      const startMs = edge === 'start' ? finalTimeMs : originalStartMs;
+      const endMs = edge === 'end' ? finalTimeMs : originalEndMs;
+      const previewComposition = previewClipTrim(options.props.composition, clip, edge, finalTimeMs);
+      options.clearLinkedPreview(previewedIds);
+      previewedIds = changedTimingIds(options.props.composition, previewComposition);
+      const nextPreview = { ...options.clipPreview.value };
+      for (const entry of previewComposition.clips) {
+        if (previewedIds.includes(entry.id)) {
+          nextPreview[entry.id] = { startMs: entry.timelineStartMs, durationMs: entry.timelineDurationMs };
+        }
+      }
+      options.clipPreview.value = nextPreview;
+      const previewEndMs = previewComposition.clips.reduce(
+        (maximum, entry) => Math.max(maximum, entry.timelineStartMs + entry.timelineDurationMs),
+        endMs,
+      );
+      options.previewDurationMs.value = previewEndMs;
+      options.emit('preview:composition', previewComposition);
+      options.activeTrimState.value = {
+        ids,
+        edge,
+        durationMs: endMs - startMs,
+        atLimit: raw <= bounds.minMs || raw >= bounds.maxMs,
+      };
+      void nextTick(() => {
+        if (!trimActive) return;
+        options.updateAutoScroll(next.clientX, (scrollDeltaPx) => {
+          autoScrollDeltaPx += scrollDeltaPx;
+          applyMove(next);
+        });
+      });
+    };
+    const moveUpdates = createAnimationFrameCoalescer(applyMove);
+    const move = moveUpdates.schedule;
+    const cleanup = () => {
+      trimActive = false;
+      options.stopAutoScroll();
+      window.removeEventListener('pointermove', move);
+      window.removeEventListener('pointerup', end);
+      window.removeEventListener('pointercancel', cancel);
+      options.clearLinkedPreview(previewedIds);
+      options.previewDurationMs.value = null;
+      options.activeTrimState.value = null;
+      options.activeSnapTimeMs.value = null;
+      options.emit('preview:composition', null);
+    };
+    const end = () => {
+      moveUpdates.flush();
+      cleanup();
+      const original = edge === 'start' ? originalStartMs : originalEndMs;
+      if (finalTimeMs !== original) options.emit('trim:clip', { id: clip.id, edge, timeMs: finalTimeMs });
+    };
+    const cancel = () => {
+      moveUpdates.cancel();
+      cleanup();
+    };
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', end, { once: true });
+    window.addEventListener('pointercancel', cancel, { once: true });
+  };
+  return { beginClipTrim };
+}
+
+const changedTimingIds = (before: ClipComposition, after: ClipComposition) =>
+  after.clips.flatMap((clip) => {
+    const original = before.clips.find((candidate) => candidate.id === clip.id);
+    return original &&
+      (original.timelineStartMs !== clip.timelineStartMs || original.timelineDurationMs !== clip.timelineDurationMs)
+      ? [clip.id]
+      : [];
+  });

--- a/src/components/video-editor/timeline/composables/useTimelineContextMenu.ts
+++ b/src/components/video-editor/timeline/composables/useTimelineContextMenu.ts
@@ -1,11 +1,12 @@
 import { computed, ref, type Ref } from 'vue';
-import { ClipboardPaste, Copy, Trash2 } from '@lucide/vue';
+import { ClipboardPaste, Copy, Pause, Trash2 } from '@lucide/vue';
 import type { Clip, ClipComposition, MediaAsset } from '~/media/shared/composition-types';
 import type { ZoomElement } from '../../zoom/zoom-types';
 import type { ContextMenuItemOrDivider } from '~/components/ui/context-menu';
 import { getClipCategory, useTimelineClipboard } from './useTimelineClipboard';
 import type { TimelineClipboardItem, TimelineItemCategory, TimelinePasteTarget } from './timeline-clipboard-types';
 import type { TimelineTracksEmits } from './timeline-tracks-types';
+import { MIN_CLIP_DURATION_MS } from '../../composition/engine/clip-engine';
 
 export interface TimelineContextMenuState {
   isOpen: boolean;
@@ -119,10 +120,24 @@ export function useTimelineContextMenu(options: {
     options.emit('paste:item', { item, timeMs: options.currentTimeMs.value, target });
   };
 
+  const canHoldClip = (clip: Clip | null) =>
+    clip !== null &&
+    clip.enabled &&
+    (clip.kind === 'screen' || clip.kind === 'video' || clip.kind === 'webcam') &&
+    options.assetFor(clip)?.kind === 'video' &&
+    clip.freezeFrameSourceMs === undefined &&
+    options.currentTimeMs.value >= clip.timelineStartMs + MIN_CLIP_DURATION_MS &&
+    options.currentTimeMs.value <= clip.timelineStartMs + clip.timelineDurationMs - MIN_CLIP_DURATION_MS;
+
   const contextMenuItems = computed<ContextMenuItemOrDivider[]>(() => {
     const { category, clip, zoom } = contextMenuState.value;
     const canCopy = Boolean(options.scopeId.value && (category === 'zoom' ? zoom : clip));
-    const items: ContextMenuItemOrDivider[] = [
+    const canHold = canHoldClip(clip);
+    const items: ContextMenuItemOrDivider[] = [];
+    if (clip && (clip.kind === 'screen' || clip.kind === 'video' || clip.kind === 'webcam')) {
+      items.push({ id: 'hold', label: options.t('holdSegment'), icon: Pause, disabled: !canHold }, { isDivider: true });
+    }
+    items.push(
       { id: 'copy', label: options.t('copy'), icon: Copy, shortcut: 'Ctrl+C', disabled: !canCopy },
       {
         id: 'paste',
@@ -140,13 +155,15 @@ export function useTimelineContextMenu(options: {
         shortcut: 'Del',
         disabled: category === 'zoom' ? !zoom : !clip,
       },
-    ];
+    );
     return items;
   });
 
   const handleContextMenuSelect = (actionId: string) => {
     const { category, clip, zoom, trackId } = contextMenuState.value;
-    if (actionId === 'copy') copyItem(clip, zoom);
+    if (actionId === 'hold' && clip && canHoldClip(clip))
+      options.emit('hold:clip', { id: clip.id, timeMs: options.currentTimeMs.value });
+    else if (actionId === 'copy') copyItem(clip, zoom);
     else if (actionId === 'paste') pasteClipboard({ category, trackId });
     else if (actionId === 'delete') {
       if (category === 'zoom' && zoom) options.emit('delete:zoom', zoom.id);

--- a/src/components/video-editor/timeline/composables/useTimelineTracks.ts
+++ b/src/components/video-editor/timeline/composables/useTimelineTracks.ts
@@ -13,20 +13,21 @@ import {
   type BlurClip,
   type VisualClip,
 } from '~/media/shared/composition-types';
-import { calculateSnapThresholdMs, collectSnapTargets, snapSpan, snapValue } from './timeline-snap';
+import { calculateSnapThresholdMs, collectSnapTargets, snapSpan } from './timeline-snap';
 import { createAnimationFrameCoalescer } from './animation-frame-coalescer';
 import { useTimelineViewport } from './useTimelineViewport';
 import { useTimelineZoomInteractions } from './useTimelineZoomInteractions';
 import type { TimelineTracksEmits, TimelineTracksProps } from './timeline-tracks-types';
 import { groupVisualTimelineTracks, previewVisualTrackOrder } from './visual-timeline-tracks';
-import { visualMoveDeltaBounds, visualTrimBounds } from '../../composition/engine/visual-track-layout';
-import { previewClipMove, previewClipTrim } from './timeline-composition-preview';
+import { visualMoveDeltaBounds } from '../../composition/engine/visual-track-layout';
+import { previewClipMove } from './timeline-composition-preview';
 import { useVisualTrackReorder } from './useVisualTrackReorder';
+import { useTimelineClipTrim } from './useTimelineClipTrim';
+import { groupImportedAudioTimelineTracks } from './audio-timeline-tracks';
 export type { TimelineTracksEmits, TimelineTracksProps } from './timeline-tracks-types';
 
 export { DEFAULT_ZOOM_DURATION_MS } from '../../zoom/zoom-types';
 export const DEFAULT_CAPTION_DURATION_MS = 2_000;
-export const MIN_DURATION_MS = 40;
 
 export function useTimelineTracks(props: TimelineTracksProps, emit: TimelineTracksEmits, t: (key: string) => string) {
   const newZoomDurationMs = computed(() =>
@@ -35,14 +36,20 @@ export function useTimelineTracks(props: TimelineTracksProps, emit: TimelineTrac
       : DEFAULT_ZOOM_DURATION_MS,
   );
   const previewDurationMs = ref<number | null>(null);
+  const canonicalDurationMs = computed(() =>
+    Math.max(
+      1_000,
+      Math.round(typeof props.duration === 'number' && Number.isFinite(props.duration) ? props.duration * 1_000 : 0),
+    ),
+  );
   const durationMs = computed(() => {
-    const raw = typeof props.duration === 'number' && Number.isFinite(props.duration) ? props.duration * 1_000 : 0;
     const preview =
       typeof previewDurationMs.value === 'number' && Number.isFinite(previewDurationMs.value)
         ? previewDurationMs.value
-        : 0;
-    return Math.max(1_000, Math.round(Math.max(raw, preview)));
+        : null;
+    return Math.max(1_000, Math.round(preview ?? canonicalDurationMs.value));
   });
+  const layoutDurationMs = computed(() => Math.max(canonicalDurationMs.value, durationMs.value));
   const orderedClips = computed(() => [...props.composition.clips].sort((left, right) => left.order - right.order));
   const baseVisualClips = computed(() => orderedClips.value.filter(isCompositingClip));
   const baseVisualTracks = computed(() => groupVisualTimelineTracks(baseVisualClips.value));
@@ -57,14 +64,19 @@ export function useTimelineTracks(props: TimelineTracksProps, emit: TimelineTrac
   const microphoneClips = computed(() =>
     orderedClips.value.filter((clip): clip is AudioClip => isAudioClip(clip) && clip.role === 'microphone'),
   );
-  const importedAudioClips = computed(() =>
-    orderedClips.value.filter((clip): clip is AudioClip => isAudioClip(clip) && clip.role === 'imported'),
+  const importedAudioTracks = computed(() =>
+    groupImportedAudioTimelineTracks(
+      orderedClips.value.filter((clip): clip is AudioClip => isAudioClip(clip) && clip.role === 'imported'),
+    ),
   );
   const assets = computed(() => new Map(props.composition.assets.map((asset: MediaAsset) => [asset.id, asset])));
   const assetFor = (clip: Clip) =>
     isCaptionClip(clip) || clip.kind === 'blur' ? null : (assets.value.get(clip.assetId) ?? null);
 
   const activeSnapTimeMs = ref<number | null>(null);
+  const activeTrimState = ref<{ ids: string[]; edge: 'start' | 'end'; durationMs: number; atLimit?: boolean } | null>(
+    null,
+  );
   const {
     tracksScrollRef,
     sidebarScrollRef,
@@ -93,13 +105,16 @@ export function useTimelineTracks(props: TimelineTracksProps, emit: TimelineTrac
     centeredStartAt,
     beginScrub,
     handleWheel,
-  } = useTimelineViewport(props, emit, durationMs, activeSnapTimeMs);
+  } = useTimelineViewport(
+    props,
+    emit,
+    layoutDurationMs,
+    activeSnapTimeMs,
+    computed(() => activeTrimState.value !== null),
+  );
 
   const clipPreview = ref<Record<string, { startMs: number; durationMs: number }>>({});
   const zoomPreview = ref<Record<string, { startMs: number; endMs: number }>>({});
-  const activeTrimState = ref<{ ids: string[]; edge: 'start' | 'end'; durationMs: number; atLimit?: boolean } | null>(
-    null,
-  );
   const movingClipIds = ref<string[]>([]);
   const displayedClip = (clip: Clip): Clip => {
     const preview = clipPreview.value[clip.id];
@@ -254,98 +269,21 @@ export function useTimelineTracks(props: TimelineTracksProps, emit: TimelineTrac
     window.addEventListener('pointerup', end, { once: true });
     window.addEventListener('pointercancel', cancel, { once: true });
   };
-  const beginClipTrim = (event: PointerEvent, clip: Clip, edge: 'start' | 'end') => {
-    event.preventDefault();
-    event.stopPropagation();
-    const ids = linkedIdsFor(clip);
-    const pointerStartX = event.clientX;
-    const initialScrollLeft = tracksScrollRef.value?.scrollLeft ?? 0;
-    const { baseDurationMs, width: baseRulerWidth, msPerPx } = resolveMsPerPx();
-    const originalStartMs = clip.timelineStartMs;
-    const originalEndMs = clip.timelineStartMs + clip.timelineDurationMs;
-    const asset = assetFor(clip);
-    const maxLeftExpansionMs =
-      asset?.durationMs != null ? Math.round(clip.sourceInMs / Math.max(0.01, clip.playbackRate)) : Infinity;
-    const trackBounds = visualTrimBounds(props.composition.clips, new Set(ids), edge);
-    const minStartMs = Math.max(0, originalStartMs - maxLeftExpansionMs, trackBounds.min);
-
-    const remainingSourceMs =
-      asset?.durationMs != null ? Math.max(0, asset.durationMs - (clip.sourceInMs + clip.sourceDurationMs)) : Infinity;
-    const maxRightExpansionMs =
-      asset?.durationMs != null ? Math.round(remainingSourceMs / Math.max(0.01, clip.playbackRate)) : Infinity;
-    const maxEndMs = Math.min(originalEndMs + maxRightExpansionMs, trackBounds.max);
-
-    const snapTargets = collectSnapTargets({
-      composition: props.composition,
-      zoomElements: props.zoomElements,
-      currentTime: displayedPlayheadTime.value,
-      duration: props.duration,
-      ignoreClipIds: ids,
-    });
-    const snapThresholdMs = calculateSnapThresholdMs(baseDurationMs, baseRulerWidth);
-
-    let finalTimeMs = edge === 'start' ? originalStartMs : originalEndMs;
-    const applyMove = (next: PointerEvent) => {
-      updateAutoScroll(next.clientX);
-      const currentScrollLeft = tracksScrollRef.value?.scrollLeft ?? 0;
-      const deltaPx = next.clientX - pointerStartX + (currentScrollLeft - initialScrollLeft);
-      const deltaMs = Math.round(deltaPx * msPerPx);
-      const raw = edge === 'start' ? originalStartMs + deltaMs : originalEndMs + deltaMs;
-      let proposedTimeMs =
-        edge === 'start'
-          ? Math.max(minStartMs, Math.min(originalEndMs - MIN_DURATION_MS, raw))
-          : Math.max(originalStartMs + MIN_DURATION_MS, Math.min(maxEndMs, raw));
-
-      const snap = props.isSnappingEnabled !== false ? snapValue(proposedTimeMs, snapTargets, snapThresholdMs) : null;
-      if (snap) {
-        proposedTimeMs =
-          edge === 'start'
-            ? Math.max(minStartMs, Math.min(originalEndMs - MIN_DURATION_MS, snap.snappedValueMs))
-            : Math.max(originalStartMs + MIN_DURATION_MS, Math.min(maxEndMs, snap.snappedValueMs));
-        activeSnapTimeMs.value = snap.targetMs;
-      } else {
-        activeSnapTimeMs.value = null;
-      }
-
-      finalTimeMs = proposedTimeMs;
-      const isAtLimit =
-        (edge === 'start' && raw <= minStartMs && Number.isFinite(minStartMs)) ||
-        (edge === 'end' && raw >= maxEndMs && Number.isFinite(maxEndMs));
-
-      const startMs = edge === 'start' ? finalTimeMs : originalStartMs;
-      const endMs = edge === 'end' ? finalTimeMs : originalEndMs;
-      previewDurationMs.value = endMs > baseDurationMs ? endMs : null;
-      previewLinked(ids, startMs, endMs - startMs);
-      emit('preview:composition', previewClipTrim(props.composition, clip, edge, finalTimeMs));
-      activeTrimState.value = { ids, edge, durationMs: endMs - startMs, atLimit: isAtLimit };
-    };
-    const moveUpdates = createAnimationFrameCoalescer(applyMove);
-    const move = moveUpdates.schedule;
-    const cleanup = () => {
-      stopAutoScroll();
-      window.removeEventListener('pointermove', move);
-      window.removeEventListener('pointerup', end);
-      window.removeEventListener('pointercancel', cancel);
-      clearLinkedPreview(ids);
-      previewDurationMs.value = null;
-      activeTrimState.value = null;
-      activeSnapTimeMs.value = null;
-      emit('preview:composition', null);
-    };
-    const end = () => {
-      moveUpdates.flush();
-      cleanup();
-      const original = edge === 'start' ? originalStartMs : originalEndMs;
-      if (finalTimeMs !== original) emit('trim:clip', { id: clip.id, edge, timeMs: finalTimeMs });
-    };
-    const cancel = () => {
-      moveUpdates.cancel();
-      cleanup();
-    };
-    window.addEventListener('pointermove', move);
-    window.addEventListener('pointerup', end, { once: true });
-    window.addEventListener('pointercancel', cancel, { once: true });
-  };
+  const { beginClipTrim } = useTimelineClipTrim({
+    props,
+    emit,
+    tracksScrollRef,
+    displayedPlayheadTime,
+    activeSnapTimeMs,
+    previewDurationMs,
+    clipPreview,
+    activeTrimState,
+    linkedIdsFor,
+    clearLinkedPreview,
+    resolveMsPerPx,
+    updateAutoScroll,
+    stopAutoScroll,
+  });
 
   const { beginZoomMove, beginZoomTrim } = useTimelineZoomInteractions({
     props,
@@ -438,6 +376,7 @@ export function useTimelineTracks(props: TimelineTracksProps, emit: TimelineTrac
 
   return {
     durationMs,
+    layoutDurationMs,
     orderedClips,
     baseVisualClips,
     baseVisualTracks,
@@ -448,7 +387,7 @@ export function useTimelineTracks(props: TimelineTracksProps, emit: TimelineTrac
     textCaptionClips,
     systemAudioClips,
     microphoneClips,
-    importedAudioClips,
+    importedAudioTracks,
     assets,
     assetFor,
     audioWaveforms,

--- a/src/components/video-editor/timeline/composables/useTimelineViewport.ts
+++ b/src/components/video-editor/timeline/composables/useTimelineViewport.ts
@@ -10,6 +10,7 @@ export function useTimelineViewport(
   emit: TimelineTracksEmits,
   durationMs: Ref<number>,
   activeSnapTimeMs: Ref<number | null>,
+  isMediaPreviewFrozen: Ref<boolean>,
 ) {
   const tracksScrollRef = ref<HTMLDivElement | null>(null);
   const sidebarScrollRef = ref<HTMLDivElement | null>(null);
@@ -20,9 +21,13 @@ export function useTimelineViewport(
     const ms = typeof durationMs.value === 'number' && Number.isFinite(durationMs.value) ? durationMs.value : 1_000;
     return Math.max(1, ms / 1_000);
   });
+  const previewWidthScale = computed(() => {
+    const baseDurationMs = Math.round(Math.max(0, props.duration) * 1_000);
+    return baseDurationMs > 0 ? durationMs.value / baseDurationMs : 1;
+  });
   const tracksWidthStyle = computed(() => ({
-    width: `calc(${props.zoomLevel}% + 230px)`,
-    minWidth: 'calc(100% + 230px)',
+    width: `calc(${props.zoomLevel * previewWidthScale.value}% + 230px)`,
+    minWidth: `calc(${100 * previewWidthScale.value}% + 230px)`,
   }));
   const scrubPreviewTime = ref<number | null>(null);
   const displayedPlayheadTime = computed(() => scrubPreviewTime.value ?? props.currentTime);
@@ -63,19 +68,28 @@ export function useTimelineViewport(
   const visibleStartSecond = ref(0);
   const visibleEndSecond = ref(0);
   const viewportReady = ref(false);
+  const liveMediaViewport = computed(() => ({
+    startSeconds: viewportReady.value ? visibleStartSecond.value : 0,
+    endSeconds: viewportReady.value ? visibleEndSecond.value : 0,
+    pixelsPerSecond: rulerWidth.value / Math.max(1, currentDuration.value),
+  }));
+  const mediaViewport = ref(liveMediaViewport.value);
+  watch(
+    [liveMediaViewport, isMediaPreviewFrozen],
+    ([viewport, frozen]) => {
+      if (!frozen) mediaViewport.value = viewport;
+    },
+    { immediate: true },
+  );
   const {
     slices: audioWaveforms,
     errors: audioWaveformErrors,
     status: audioWaveformStatus,
   } = useCompositionAudioWaveforms(
     () => props.composition,
-    () => ({
-      startSeconds: viewportReady.value ? visibleStartSecond.value : 0,
-      endSeconds: viewportReady.value ? visibleEndSecond.value : 0,
-      pixelsPerSecond: rulerWidth.value / Math.max(1, currentDuration.value),
-    }),
+    () => mediaViewport.value,
   );
-  const thumbnailSlots = computed(() =>
+  const liveThumbnailSlots = computed(() =>
     viewportReady.value
       ? timelineThumbnailSlots(
           currentDuration.value,
@@ -85,6 +99,15 @@ export function useTimelineViewport(
         )
       : [],
   );
+  const stableThumbnailSlots = ref(liveThumbnailSlots.value);
+  watch(
+    [liveThumbnailSlots, isMediaPreviewFrozen],
+    ([slots, frozen]) => {
+      if (!frozen) stableThumbnailSlots.value = slots;
+    },
+    { immediate: true },
+  );
+  const thumbnailSlots = computed(() => stableThumbnailSlots.value);
 
   let scrollFrame: number | null = null;
   let scrubFrame: number | null = null;
@@ -134,25 +157,36 @@ export function useTimelineViewport(
     updateVisibleRange();
   };
   let autoScrollRaf: number | null = null;
-  let autoScrollSpeed = 0;
-  let autoScrollUpdate: (() => void) | null = null;
-  const runAutoScroll = () => {
+  let autoScrollVelocity = 0;
+  let lastAutoScrollTime: number | null = null;
+  let autoScrollUpdate: ((deltaPx: number) => void) | null = null;
+  const runAutoScroll = (timestamp?: number) => {
     autoScrollRaf = null;
     const scrollEl = tracksScrollRef.value;
-    if (!scrollEl || autoScrollSpeed === 0) return;
+    if (!scrollEl || autoScrollVelocity === 0) return;
+    const reportedFrameTime =
+      typeof timestamp === 'number' && Number.isFinite(timestamp) ? timestamp : (lastAutoScrollTime ?? 0) + 16;
+    const frameTime =
+      lastAutoScrollTime !== null && reportedFrameTime <= lastAutoScrollTime
+        ? lastAutoScrollTime + 16
+        : reportedFrameTime;
+    const elapsedMs = lastAutoScrollTime === null ? 16 : Math.max(1, Math.min(32, frameTime - lastAutoScrollTime));
+    lastAutoScrollTime = frameTime;
     const previousScrollLeft = scrollEl.scrollLeft;
-    scrollEl.scrollLeft += autoScrollSpeed;
-    if (scrollEl.scrollLeft === previousScrollLeft) {
-      autoScrollSpeed = 0;
+    scrollEl.scrollLeft += (autoScrollVelocity * elapsedMs) / 1_000;
+    const scrollDeltaPx = scrollEl.scrollLeft - previousScrollLeft;
+    if (scrollDeltaPx === 0) {
+      autoScrollVelocity = 0;
+      lastAutoScrollTime = null;
       return;
     }
     updateVisibleRange();
-    autoScrollUpdate?.();
-    if (autoScrollUpdate && autoScrollSpeed !== 0) {
+    autoScrollUpdate?.(scrollDeltaPx);
+    if (autoScrollUpdate && autoScrollVelocity !== 0) {
       autoScrollRaf = requestAnimationFrame(runAutoScroll);
     }
   };
-  const updateAutoScroll = (clientX: number, onScroll: (() => void) | null = null) => {
+  const updateAutoScroll = (clientX: number, onScroll: ((deltaPx: number) => void) | null = null) => {
     const scrollEl = tracksScrollRef.value;
     if (!scrollEl) return;
     const rect = scrollEl.getBoundingClientRect();
@@ -162,23 +196,25 @@ export function useTimelineViewport(
     const leftZone = rect.left + 50;
     if (clientX > rightZone) {
       const intensity = Math.min(1, (clientX - rightZone) / 50);
-      autoScrollSpeed = Math.round(4 + intensity * 10);
+      autoScrollVelocity = 60 + intensity * 300;
     } else if (clientX < leftZone) {
       const intensity = Math.min(1, (leftZone - clientX) / 50);
-      autoScrollSpeed = -Math.round(4 + intensity * 10);
+      autoScrollVelocity = -(60 + intensity * 300);
     } else {
-      autoScrollSpeed = 0;
+      autoScrollVelocity = 0;
+      lastAutoScrollTime = null;
     }
-    if (autoScrollSpeed === 0 && autoScrollRaf !== null) {
+    if (autoScrollVelocity === 0 && autoScrollRaf !== null) {
       cancelAnimationFrame(autoScrollRaf);
       autoScrollRaf = null;
     }
-    if (autoScrollSpeed !== 0 && autoScrollRaf === null) {
+    if (autoScrollVelocity !== 0 && autoScrollRaf === null) {
       autoScrollRaf = requestAnimationFrame(runAutoScroll);
     }
   };
   const stopAutoScroll = () => {
-    autoScrollSpeed = 0;
+    autoScrollVelocity = 0;
+    lastAutoScrollTime = null;
     autoScrollUpdate = null;
     if (autoScrollRaf !== null) {
       cancelAnimationFrame(autoScrollRaf);

--- a/src/components/video-editor/timeline/tests/EditorTimeline.test.ts
+++ b/src/components/video-editor/timeline/tests/EditorTimeline.test.ts
@@ -7,9 +7,9 @@ import type { TimelineClipboardItem } from '../composables/timeline-clipboard-ty
 const copiedItem = { descriptor: { kind: 'item', name: 'recording.mp4' } } as TimelineClipboardItem;
 
 const TimelineTracks = {
-  emits: ['update:currentTime', 'select:clip', 'clipboard:copied'],
+  emits: ['update:currentTime', 'select:clip', 'hold:clip', 'clipboard:copied'],
   template:
-    '<div class="timeline-tracks-stub"><button @click="$emit(\'update:currentTime\', 250)">Scrub</button><button @click="$emit(\'select:clip\', \'clip-1\')">Select</button><button class="copy-feedback" @click="$emit(\'clipboard:copied\', copiedItem)">Copy</button></div>',
+    '<div class="timeline-tracks-stub"><button @click="$emit(\'update:currentTime\', 250)">Scrub</button><button @click="$emit(\'select:clip\', \'clip-1\')">Select</button><button class="hold-feedback" @click="$emit(\'hold:clip\', { id: \'clip-1\', timeMs: 500 })">Hold</button><button class="copy-feedback" @click="$emit(\'clipboard:copied\', copiedItem)">Copy</button></div>',
   setup: () => ({ copiedItem }),
 };
 
@@ -60,6 +60,15 @@ describe('EditorTimeline', () => {
     await wrapper.get('.copy-feedback').trigger('click');
 
     expect(wrapper.emitted('clipboard:copied')).toEqual([[copiedItem]]);
+    wrapper.unmount();
+  });
+
+  it('forwards hold requests from the tracks to the editor timeline', async () => {
+    const wrapper = mount(EditorTimeline, { props, global: { stubs: { TimelineTracks } } });
+
+    await wrapper.get('.hold-feedback').trigger('click');
+
+    expect(wrapper.emitted('hold:clip')).toEqual([[{ id: 'clip-1', timeMs: 500 }]]);
     wrapper.unmount();
   });
 });

--- a/src/components/video-editor/timeline/tests/TimelineClip.test.ts
+++ b/src/components/video-editor/timeline/tests/TimelineClip.test.ts
@@ -133,7 +133,8 @@ describe('TimelineClip', () => {
     });
 
     expect(wrapper.get('.timeline-clip').classes()).toEqual(expect.arrayContaining(['selected', 'kind-video']));
-    expect(wrapper.get('.timeline-clip').attributes('style')).toContain('left: 10%');
+    expect(wrapper.get('.timeline-clip').attributes('style')).toContain('left: 0px');
+    expect(wrapper.get('.timeline-clip').attributes('style')).toContain('transform: translate3d(50%, 0, 0)');
     expect(wrapper.get('.timeline-clip').attributes('style')).toContain('width: 20%');
     expect(wrapper.get('.speed-badge').text()).toBe('1.25×');
     expect(wrapper.get('.trim-side-badge').text()).toBe('01.2s');
@@ -228,6 +229,18 @@ describe('TimelineClip', () => {
     await wrapper.setProps({ deferThumbnailRequests: false });
 
     expect(thumbnailState.requestVisibleFrames).toHaveBeenCalledWith([0, 1.25]);
+  });
+
+  it('uses translate3d positioning when the timeline width is provided', () => {
+    const wrapper = mount(TimelineClip, {
+      props: { ...baseProps, timelineWidthPx: 2_000 },
+      global: { stubs: { Skeleton, WaveformCanvas } },
+    });
+
+    const style = wrapper.get('.timeline-clip').attributes('style') ?? '';
+    expect(style).toMatch(/transform:\s*translate3d\(200px,\s*0(?:px)?,\s*0(?:px)?\)/);
+    expect(style).toMatch(/(?:^|;)\s*left:\s*0px/);
+    expect(style).not.toMatch(/left:\s*10%/);
   });
 
   it('renders audio waveforms, a dark loading state, and an explicit unavailable error', async () => {

--- a/src/components/video-editor/timeline/tests/TimelineTracks.test.ts
+++ b/src/components/video-editor/timeline/tests/TimelineTracks.test.ts
@@ -2,39 +2,51 @@ import { defineComponent } from 'vue';
 import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ZoomElement } from '../../zoom/zoom-types';
-import type { CaptionClip, ClipComposition, MediaAsset, VisualClip } from '~/media/shared/composition-types';
+import type { AudioClip, CaptionClip, ClipComposition, MediaAsset, VisualClip } from '~/media/shared/composition-types';
 import type { MediaError } from '~/media/shared/media-types';
 import TimelineTracks from '../TimelineTracks.vue';
 import { createDefaultCaptionStyle, createDefaultClipAppearance } from '~/media/shared/composition-defaults';
 import { DEFAULT_OUTPUT_CANVAS } from '../../canvas/output-canvas';
 import { useTimelineClipboard } from '../composables/useTimelineClipboard';
+import { clipTrimBounds } from '../../composition/engine/trim-clip';
+
+const waveformTestState = vi.hoisted(() => ({
+  viewport: null as null | (() => { startSeconds: number; endSeconds: number; pixelsPerSecond: number }),
+}));
 
 vi.mock('../composables/useCompositionAudioWaveforms', () => ({
-  useCompositionAudioWaveforms: () => ({
-    slices: {
-      'system-audio': { bars: [4, 12, 20], leftPercent: 0, widthPercent: 100 },
-      'microphone-audio': undefined,
-      'imported-audio': undefined,
-    },
-    status: {
-      'system-audio': 'ready',
-      'microphone-audio': 'loading',
-      'imported-audio': 'error',
-    },
-    errors: {
-      'imported-audio': {
-        kind: 'decode-failure',
-        sourceId: 'imported-asset',
-        message: 'The waveform could not be decoded.',
-      } satisfies MediaError,
-    },
-  }),
+  useCompositionAudioWaveforms: (
+    _composition: unknown,
+    viewport: () => { startSeconds: number; endSeconds: number; pixelsPerSecond: number },
+  ) => {
+    waveformTestState.viewport = viewport;
+    return {
+      slices: {
+        'system-audio': { bars: [4, 12, 20], leftPercent: 0, widthPercent: 100 },
+        'microphone-audio': undefined,
+        'imported-audio': undefined,
+      },
+      status: {
+        'system-audio': 'ready',
+        'microphone-audio': 'loading',
+        'imported-audio': 'error',
+      },
+      errors: {
+        'imported-audio': {
+          kind: 'decode-failure',
+          sourceId: 'imported-asset',
+          message: 'The waveform could not be decoded.',
+        } satisfies MediaError,
+      },
+    };
+  },
 }));
 
 const TimelineClipStub = defineComponent({
   name: 'TimelineClip',
   props: {
     clip: { type: Object, required: true },
+    duration: { type: Number, required: true },
     selected: { type: Boolean, default: false },
     trimState: { type: Object, default: null },
     thumbnailSlots: { type: Array, default: () => [] },
@@ -43,6 +55,7 @@ const TimelineClipStub = defineComponent({
     waveformWidthPercent: { type: Number, default: 100 },
     waveformStatus: { type: String, default: undefined },
     waveformError: { type: Object, default: undefined },
+    deferThumbnailRequests: { type: Boolean, default: false },
     pasteHighlight: { type: Boolean, default: false },
   },
   emits: ['select', 'move', 'trim', 'contextmenu'],
@@ -102,6 +115,23 @@ const visual = (overrides: Partial<VisualClip>): VisualClip => ({
   appearance: createDefaultClipAppearance('screen'),
   isMirrored: false,
   isMirroredY: false,
+  ...overrides,
+});
+
+const importedAudio = (overrides: Partial<AudioClip> = {}): AudioClip => ({
+  id: 'imported-audio-fragment',
+  kind: 'audio',
+  role: 'imported',
+  name: 'Imported audio',
+  assetId: 'imported-asset',
+  timelineStartMs: 0,
+  timelineDurationMs: 2_000,
+  sourceInMs: 0,
+  sourceDurationMs: 2_000,
+  playbackRate: 1,
+  enabled: true,
+  order: 6,
+  volume: 80,
   ...overrides,
 });
 
@@ -610,6 +640,47 @@ describe('TimelineTracks', () => {
     expect(mounted!.emitted('select:zoom')).toContainEqual(['zoom-1']);
   });
 
+  it('renders contiguous imported audio fragments from one asset in a single lane', async () => {
+    const base = composition();
+    const mounted = await mountTracks({
+      composition: {
+        ...base,
+        clips: [
+          ...base.clips.filter((clip) => clip.id !== 'imported-audio'),
+          importedAudio({ id: 'audio-left', timelineStartMs: 0, sourceDurationMs: 2_000 }),
+          importedAudio({ id: 'audio-right', timelineStartMs: 2_000, sourceInMs: 2_000, sourceDurationMs: 2_000 }),
+        ],
+      },
+    });
+
+    const importedRows = mounted!
+      .findAll('.tracks-stack > .audio-track')
+      .filter((row) => row.findAll('.timeline-clip').some((clip) => clip.text().includes('Imported audio')));
+    expect(importedRows).toHaveLength(1);
+    expect(importedRows[0]!.findAll('.timeline-clip')).toHaveLength(2);
+  });
+
+  it('keeps imported audio clips from different assets on separate lanes', async () => {
+    const base = composition();
+    const mounted = await mountTracks({
+      composition: {
+        ...base,
+        assets: [...base.assets, asset('imported-asset-2', 'audio')],
+        clips: [
+          ...base.clips.filter((clip) => clip.id !== 'imported-audio'),
+          importedAudio({ id: 'audio-one', assetId: 'imported-asset' }),
+          importedAudio({ id: 'audio-two', assetId: 'imported-asset-2' }),
+        ],
+      },
+    });
+
+    const importedRows = mounted!
+      .findAll('.tracks-stack > .audio-track')
+      .filter((row) => row.findAll('.timeline-clip').some((clip) => clip.text().includes('Imported audio')));
+    expect(importedRows).toHaveLength(2);
+    expect(importedRows.every((row) => row.findAll('.timeline-clip').length === 1)).toBe(true);
+  });
+
   it('only renders the Canvas transition track when at least one global transition exists', async () => {
     const mounted = await mountTracks();
     expect(mounted!.find('.canvas-sidebar-row').exists()).toBe(false);
@@ -858,8 +929,8 @@ describe('TimelineTracks', () => {
     await cursor.trigger('mousemove', { clientX: 700 });
 
     const ghost = mounted!.get('.cursor-zoom-indicator.preview-ghost');
-    expect(ghost.element.style.left).toBe('33%');
-    expect(ghost.element.style.width).toBe('50%');
+    expect((ghost.element as HTMLElement).style.left).toBe('33%');
+    expect((ghost.element as HTMLElement).style.width).toBe('50%');
   });
 
   it('uses the configured zoom duration when checking hover collisions', async () => {
@@ -950,6 +1021,314 @@ describe('TimelineTracks', () => {
     window.dispatchEvent(pointerEvent('pointerup', 900));
     expect(mounted!.emitted('preview:composition')?.at(-1)).toEqual([null]);
     expect(mounted!.emitted('trim:clip')).toContainEqual([expect.objectContaining({ id: 'screen-clip', edge: 'end' })]);
+  });
+
+  it('grows the timeline proportionally and keeps auto-scrolling while extending a hold at the edge', async () => {
+    const hold = visual({
+      id: 'hold-clip',
+      kind: 'video',
+      name: 'Hold segment',
+      trackId: 'hold-track',
+      timelineStartMs: 4_000,
+      timelineDurationMs: 1_000,
+      sourceInMs: 2_000,
+      sourceDurationMs: 1_000,
+      freezeFrameSourceMs: 2_000,
+      order: 0,
+    });
+    const following = visual({
+      id: 'following-clip',
+      kind: 'video',
+      name: 'Following segment',
+      trackId: 'hold-track',
+      timelineStartMs: 5_000,
+      timelineDurationMs: 1_000,
+      sourceInMs: 3_000,
+      sourceDurationMs: 1_000,
+      order: 0,
+    });
+    const holdComposition: ClipComposition = {
+      ...composition(),
+      clips: [hold, following],
+    };
+    const mounted = await mountTracks({
+      composition: holdComposition,
+      duration: 5,
+      selectedClipId: hold.id,
+      isSnappingEnabled: false,
+    });
+    const scroll = setScrubViewportGeometry(mounted!);
+    scroll.dispatchEvent(new Event('scroll'));
+    await flushPromises();
+    const { pendingFrames, flushNextFrame } = queueAnimationFrames();
+    const viewport = mounted!.get('.timeline-viewport').element as HTMLElement;
+    const initialWaveformViewport = waveformTestState.viewport?.();
+    if (!initialWaveformViewport) throw new Error('Expected the waveform viewport probe.');
+    expect(viewport.style.width).toBe('calc(120% + 230px)');
+    expect(viewport.style.minWidth).toBe('calc(100% + 230px)');
+
+    const holdClip = mounted!
+      .findAllComponents(TimelineClipStub)
+      .find((component) => (component.props('clip') as VisualClip).id === hold.id);
+    if (!holdClip) throw new Error('Expected the hold timeline clip stub.');
+    const initialThumbnailSlots = holdClip.props('thumbnailSlots');
+    expect(holdClip.props('deferThumbnailRequests')).toBe(false);
+
+    await holdClip.find('.trim-handle.end').trigger('pointerdown', { clientX: 220 });
+    window.dispatchEvent(pointerEvent('pointermove', 900));
+    flushNextFrame();
+    await flushPromises();
+
+    const preview = mounted!.emitted('preview:composition')?.at(-1)?.[0] as ClipComposition | undefined;
+    expect(preview?.clips.find((clip) => clip.id === hold.id)).toMatchObject({
+      timelineStartMs: 4_000,
+      timelineDurationMs: 2_000,
+      sourceInMs: 2_000,
+      freezeFrameSourceMs: 2_000,
+    });
+    expect(preview?.clips.find((clip) => clip.id === following.id)).toMatchObject({ timelineStartMs: 6_000 });
+    expect(holdClip.props('duration')).toBe(7);
+    expect(viewport.style.width).toBe('calc(168% + 230px)');
+    expect(viewport.style.minWidth).toBe('calc(140% + 230px)');
+    expect(viewport.classList).toContain('is-trimming');
+    expect(holdClip.props('thumbnailSlots')).toBe(initialThumbnailSlots);
+    expect(holdClip.props('deferThumbnailRequests')).toBe(true);
+    expect(waveformTestState.viewport?.()).toBe(initialWaveformViewport);
+    expect(pendingFrames).toHaveLength(1);
+
+    const firstScrollLeft = scroll.scrollLeft;
+    flushNextFrame();
+    await flushPromises();
+    const secondScrollLeft = scroll.scrollLeft;
+    const previewAfterFirstScroll = mounted!.emitted('preview:composition')?.at(-1)?.[0] as ClipComposition | undefined;
+    expect(previewAfterFirstScroll?.clips.find((clip) => clip.id === hold.id)?.timelineDurationMs).toBeGreaterThan(
+      2_000,
+    );
+    flushNextFrame();
+    await flushPromises();
+    const thirdScrollLeft = scroll.scrollLeft;
+
+    expect(secondScrollLeft).toBeGreaterThan(firstScrollLeft);
+    expect(thirdScrollLeft).toBeGreaterThan(secondScrollLeft);
+    expect(holdClip.props('thumbnailSlots')).toBe(initialThumbnailSlots);
+    expect(holdClip.props('deferThumbnailRequests')).toBe(true);
+    expect(waveformTestState.viewport?.()).toBe(initialWaveformViewport);
+    expect(pendingFrames).toHaveLength(1);
+    window.dispatchEvent(pointerEvent('pointerup', 900));
+    await flushPromises();
+
+    const stoppedScrollLeft = scroll.scrollLeft;
+    expect(viewport.classList).not.toContain('is-trimming');
+    expect(holdClip.props('deferThumbnailRequests')).toBe(false);
+    expect(waveformTestState.viewport?.()).not.toBe(initialWaveformViewport);
+    expect(pendingFrames).toHaveLength(0);
+    await flushPromises();
+    expect(scroll.scrollLeft).toBe(stoppedScrollLeft);
+  });
+
+  it('keeps the timeline scale stable so a shortening hold follows the pointer', async () => {
+    const hold = visual({
+      id: 'shorten-hold',
+      kind: 'video',
+      name: 'Hold segment',
+      trackId: 'shorten-hold-track',
+      timelineStartMs: 5_000,
+      timelineDurationMs: 3_000,
+      sourceInMs: 2_000,
+      sourceDurationMs: 3_000,
+      freezeFrameSourceMs: 2_000,
+      order: 0,
+    });
+    const mounted = await mountTracks({
+      composition: { ...composition(), clips: [hold] },
+      duration: 8,
+      selectedClipId: hold.id,
+      isSnappingEnabled: false,
+    });
+    const scroll = setScrubViewportGeometry(mounted!);
+    scroll.dispatchEvent(new Event('scroll'));
+    await flushPromises();
+    scroll.scrollLeft = 500;
+    const { pendingFrames, flushNextFrame } = queueAnimationFrames();
+    const viewport = mounted!.get('.timeline-viewport').element as HTMLElement;
+    expect(viewport.style.width).toBe('calc(120% + 230px)');
+    expect(viewport.style.minWidth).toBe('calc(100% + 230px)');
+    expect(mounted!.findAll('.marker-label').at(-1)?.text()).toBe('8s');
+
+    const holdClip = mounted!
+      .findAllComponents(TimelineClipStub)
+      .find((component) => (component.props('clip') as VisualClip).id === hold.id);
+    if (!holdClip) throw new Error('Expected the hold timeline clip stub.');
+
+    await holdClip.find('.trim-handle.end').trigger('pointerdown', { clientX: 620 });
+    window.dispatchEvent(pointerEvent('pointermove', 120));
+    flushNextFrame();
+    await flushPromises();
+
+    const preview = mounted!.emitted('preview:composition')?.at(-1)?.[0] as ClipComposition | undefined;
+    expect(preview?.clips.find((clip) => clip.id === hold.id)).toMatchObject({
+      timelineStartMs: 5_000,
+      timelineDurationMs: 1_000,
+      sourceInMs: 2_000,
+      freezeFrameSourceMs: 2_000,
+    });
+    expect(holdClip.props('duration')).toBe(8);
+    expect(viewport.style.width).toBe('calc(120% + 230px)');
+    expect(viewport.style.minWidth).toBe('calc(100% + 230px)');
+    expect(mounted!.findAll('.marker-label').at(-1)?.text()).toBe('8s');
+    expect(viewport.classList).toContain('is-trimming');
+    expect(pendingFrames).toHaveLength(1);
+
+    const firstScrollLeft = scroll.scrollLeft;
+    flushNextFrame();
+    await flushPromises();
+    expect(scroll.scrollLeft).toBeLessThan(firstScrollLeft);
+    expect(mounted!.emitted('preview:composition')?.at(-1)?.[0]).toMatchObject({
+      clips: expect.arrayContaining([expect.objectContaining({ id: hold.id, timelineDurationMs: expect.any(Number) })]),
+    });
+
+    window.dispatchEvent(pointerEvent('pointerup', 120));
+    await flushPromises();
+    const stoppedScrollLeft = scroll.scrollLeft;
+    expect(viewport.classList).not.toContain('is-trimming');
+    expect(pendingFrames).toHaveLength(0);
+    await flushPromises();
+    expect(scroll.scrollLeft).toBe(stoppedScrollLeft);
+  });
+
+  it('keeps the last hold trim preview bounded when viewport shrink clamps scrollLeft', async () => {
+    const hold = visual({
+      id: 'clamped-hold',
+      kind: 'video',
+      name: 'Last hold segment',
+      trackId: 'clamped-hold-track',
+      timelineStartMs: 5_000,
+      timelineDurationMs: 3_000,
+      sourceInMs: 2_000,
+      sourceDurationMs: 3_000,
+      freezeFrameSourceMs: 2_000,
+      order: 0,
+    });
+    const mounted = await mountTracks({
+      composition: { ...composition(), clips: [hold] },
+      duration: 8,
+      selectedClipId: hold.id,
+      isSnappingEnabled: false,
+    });
+    const scroll = setScrubViewportGeometry(mounted!);
+    scroll.dispatchEvent(new Event('scroll'));
+    await flushPromises();
+    let browserScrollLeft = 500;
+    Object.defineProperty(scroll, 'scrollLeft', {
+      configurable: true,
+      get: () => browserScrollLeft,
+      set: (value: number) => {
+        browserScrollLeft = Math.max(0, value);
+      },
+    });
+    scroll.scrollLeft = browserScrollLeft;
+    const { pendingFrames, flushNextFrame } = queueAnimationFrames();
+    const viewport = mounted!.get('.timeline-viewport').element as HTMLElement;
+    const holdClip = mounted!
+      .findAllComponents(TimelineClipStub)
+      .find((component) => (component.props('clip') as VisualClip).id === hold.id);
+    if (!holdClip) throw new Error('Expected the hold timeline clip stub.');
+
+    await holdClip.find('.trim-handle.end').trigger('pointerdown', { clientX: 620 });
+    window.dispatchEvent(pointerEvent('pointermove', 120));
+    flushNextFrame();
+    await flushPromises();
+
+    const previewBeforeClamp = mounted!.emitted('preview:composition')?.at(-1)?.[0] as ClipComposition | undefined;
+    const holdBeforeClamp = previewBeforeClamp?.clips.find((clip) => clip.id === hold.id);
+    if (!holdBeforeClamp) throw new Error('Expected the initial last-hold trim preview.');
+    const previewEventCount = mounted!.emitted('preview:composition')?.length ?? 0;
+    expect(holdBeforeClamp.timelineStartMs + holdBeforeClamp.timelineDurationMs).toBe(6_000);
+    expect(holdClip.props('duration')).toBe(8);
+
+    // Browser scroll containers clamp scrollLeft when the just-shortened viewport shrinks.
+    scroll.scrollLeft = 0;
+    scroll.dispatchEvent(new Event('scroll'));
+    while (pendingFrames.size > 0) {
+      flushNextFrame();
+      await flushPromises();
+    }
+
+    const previewAfterClamp = mounted!.emitted('preview:composition')?.at(-1)?.[0] as ClipComposition | undefined;
+    const holdAfterClamp = previewAfterClamp?.clips.find((clip) => clip.id === hold.id);
+    expect(holdAfterClamp).toMatchObject({ timelineStartMs: 5_000, timelineDurationMs: 1_000 });
+    expect(mounted!.emitted('preview:composition')).toHaveLength(previewEventCount);
+    expect(holdClip.props('duration')).toBe(8);
+    expect(viewport.style.width).toBe('calc(120% + 230px)');
+    expect(viewport.style.minWidth).toBe('calc(100% + 230px)');
+
+    window.dispatchEvent(pointerEvent('pointerup', 120));
+    await flushPromises();
+    expect(pendingFrames).toHaveLength(0);
+  });
+
+  it('clamps a grouped video trim preview to the shortest source bound without snapping back on pointerup', async () => {
+    const groupedComposition: ClipComposition = {
+      schemaVersion: 6,
+      keyboardCaptionSessions: [],
+      assets: [
+        { ...asset('long-video', 'video'), durationMs: 8_000 },
+        { ...asset('short-video', 'video'), durationMs: 3_000 },
+      ],
+      clips: [
+        visual({
+          id: 'grouped-video',
+          kind: 'video',
+          name: 'Grouped video',
+          assetId: 'long-video',
+          timelineDurationMs: 2_000,
+          sourceDurationMs: 2_000,
+          groupId: 'source-group',
+          trackId: 'video-track',
+        }),
+        visual({
+          id: 'grouped-short',
+          kind: 'webcam',
+          name: 'Grouped short source',
+          assetId: 'short-video',
+          timelineDurationMs: 2_000,
+          sourceDurationMs: 2_000,
+          groupId: 'source-group',
+          trackId: 'webcam-track',
+        }),
+      ],
+    };
+    const mounted = await mountTracks({
+      composition: groupedComposition,
+      selectedClipId: 'grouped-video',
+      isSnappingEnabled: false,
+    });
+    const bounds = clipTrimBounds(groupedComposition, 'grouped-video', 'end');
+    expect(bounds.maxMs).toBe(3_000);
+    const videoClip = mounted!
+      .findAllComponents(TimelineClipStub)
+      .find((component) => (component.props('clip') as VisualClip).id === 'grouped-video');
+    if (!videoClip) throw new Error('Expected the grouped video timeline clip stub.');
+
+    await videoClip.find('.trim-handle.end').trigger('pointerdown', { clientX: 200 });
+    window.dispatchEvent(pointerEvent('pointermove', 600));
+    await flushPromises();
+
+    const previews = mounted!.emitted('preview:composition') ?? [];
+    const preview = previews.at(-1)?.[0] as ClipComposition | undefined;
+    const previewClip = preview?.clips.find((clip) => clip.id === 'grouped-video');
+    if (!previewClip) throw new Error('Expected a grouped video trim preview.');
+    expect(previewClip.timelineStartMs + previewClip.timelineDurationMs).toBe(bounds.maxMs);
+    expect(preview?.clips.find((clip) => clip.id === 'grouped-short')).toMatchObject({
+      timelineStartMs: 0,
+      timelineDurationMs: bounds.maxMs,
+    });
+    expect(mounted!.emitted('trim:clip') ?? []).toHaveLength(0);
+
+    window.dispatchEvent(pointerEvent('pointerup', 600));
+
+    const trimEvents = mounted!.emitted('trim:clip') ?? [];
+    expect(trimEvents.at(-1)?.[0]).toEqual({ id: 'grouped-video', edge: 'end', timeMs: bounds.maxMs });
   });
 
   it('releases the zoom trim preview when the trim ends so later props control the indicator', async () => {

--- a/src/components/video-editor/timeline/timeline-clip-geometry.ts
+++ b/src/components/video-editor/timeline/timeline-clip-geometry.ts
@@ -1,0 +1,23 @@
+import type { Clip } from '~/media/shared/composition-types';
+
+export const timelineClipStyle = (clip: Clip, durationSeconds: number, timelineWidthPx = 0) => {
+  const durationMs = Math.max(1, durationSeconds * 1_000);
+  const translate =
+    timelineWidthPx > 0
+      ? `${(clip.timelineStartMs / durationMs) * timelineWidthPx}px`
+      : `${(clip.timelineStartMs / Math.max(1, clip.timelineDurationMs)) * 100}%`;
+  return {
+    left: '0',
+    width: `${(clip.timelineDurationMs / durationMs) * 100}%`,
+    transform: `translate3d(${translate}, 0, 0)`,
+  };
+};
+
+export const timelineFrameStyle = (clip: Clip, relativeMs: number, durationMs: number) => ({
+  left: `${(relativeMs / Math.max(1, clip.timelineDurationMs)) * 100}%`,
+  width: `${(durationMs / Math.max(1, clip.timelineDurationMs)) * 100}%`,
+});
+
+export const timelineTransitionStyle = (clip: Clip, edge: 'entry' | 'exit') => ({
+  width: `${((clip.transitions?.[edge]?.durationMs ?? 0) / Math.max(1, clip.timelineDurationMs)) * 100}%`,
+});

--- a/src/components/video-editor/timeline/timeline-tracks.css
+++ b/src/components/video-editor/timeline/timeline-tracks.css
@@ -101,6 +101,16 @@
   flex-direction: column;
   min-height: 100%;
   min-width: 100%;
+  transition:
+    width 180ms cubic-bezier(0.22, 1, 0.36, 1),
+    min-width 180ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+.timeline-viewport.is-trimming {
+  transition: none;
+}
+.timeline-viewport.is-trimming .timeline-clip {
+  will-change: transform, width;
+  transition: none;
 }
 .timeline-ruler {
   height: 28px;
@@ -483,6 +493,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .timeline-viewport,
   .timeline-clip,
   .sidebar-track-item .track-info,
   .track-row .track-content {

--- a/src/i18n/bg/core.json
+++ b/src/i18n/bg/core.json
@@ -446,6 +446,7 @@
   },
   "ScreenRegionOverlay": {
     "instruction": "Изберете област за запис",
+    "preset": "Шаблон",
     "reset": "Нулиране",
     "cancel": "Отказ",
     "useThisArea": "Използване на тази област"

--- a/src/i18n/de/core.json
+++ b/src/i18n/de/core.json
@@ -446,6 +446,7 @@
   },
   "ScreenRegionOverlay": {
     "instruction": "Wähle einen Bereich zur Aufnahme aus",
+    "preset": "Voreinstellung",
     "reset": "Zurücksetzen",
     "cancel": "Abbrechen",
     "useThisArea": "Diesen Bereich verwenden"

--- a/src/i18n/en/core.json
+++ b/src/i18n/en/core.json
@@ -473,6 +473,7 @@
   },
   "ScreenRegionOverlay": {
     "instruction": "Select an area to record",
+    "preset": "Preset",
     "reset": "Reset",
     "cancel": "Cancel",
     "useThisArea": "Use this area"

--- a/src/i18n/en/editor.json
+++ b/src/i18n/en/editor.json
@@ -180,7 +180,7 @@
     "waveformUnavailable": "Waveform unavailable",
     "trimStart": "Trim start",
     "trimEnd": "Trim end",
-    "holdSegment": "Hold segment",
+    "holdSegment": "Hold Segment at Playhead",
     "copy": "Copy",
     "paste": "Paste",
     "delete": "Delete",

--- a/src/i18n/es/core.json
+++ b/src/i18n/es/core.json
@@ -445,7 +445,8 @@
     "turnSystemAudioOn": "Activar audio del sistema"
   },
   "ScreenRegionOverlay": {
-    "instruction": "Selecciona un área para grabar",
+    "instruction": "Seleccione un área para grabar",
+    "preset": "Preajuste",
     "reset": "Restablecer",
     "cancel": "Cancelar",
     "useThisArea": "Usar esta área"

--- a/src/i18n/fr/core.json
+++ b/src/i18n/fr/core.json
@@ -473,6 +473,7 @@
   },
   "ScreenRegionOverlay": {
     "instruction": "Sélectionnez une zone à enregistrer",
+    "preset": "Préréglage",
     "reset": "Réinitialiser",
     "cancel": "Annuler",
     "useThisArea": "Utiliser cette zone"

--- a/src/i18n/fr/editor.json
+++ b/src/i18n/fr/editor.json
@@ -180,7 +180,7 @@
     "waveformUnavailable": "Forme d'onde indisponible",
     "trimStart": "Rogner le début",
     "trimEnd": "Rogner la fin",
-    "holdSegment": "Figer le segment",
+    "holdSegment": "Figer l’image à la tête de lecture",
     "copy": "Copier",
     "paste": "Coller",
     "delete": "Supprimer",

--- a/src/i18n/hi/core.json
+++ b/src/i18n/hi/core.json
@@ -446,6 +446,7 @@
   },
   "ScreenRegionOverlay": {
     "instruction": "रिकॉर्ड करने के लिए क्षेत्र चुनें",
+    "preset": "प्रीसेट",
     "reset": "रीसेट",
     "cancel": "रद्द करें",
     "useThisArea": "इस क्षेत्र का उपयोग करें"

--- a/src/i18n/it/core.json
+++ b/src/i18n/it/core.json
@@ -446,6 +446,7 @@
   },
   "ScreenRegionOverlay": {
     "instruction": "Seleziona un'area da registrare",
+    "preset": "Preimpostazione",
     "reset": "Reimposta",
     "cancel": "Annulla",
     "useThisArea": "Usa quest'area"

--- a/src/i18n/ja/core.json
+++ b/src/i18n/ja/core.json
@@ -446,6 +446,7 @@
   },
   "ScreenRegionOverlay": {
     "instruction": "録画する範囲を選択",
+    "preset": "プリセット",
     "reset": "リセット",
     "cancel": "キャンセル",
     "useThisArea": "この範囲を使用"

--- a/src/i18n/ko/core.json
+++ b/src/i18n/ko/core.json
@@ -446,6 +446,7 @@
   },
   "ScreenRegionOverlay": {
     "instruction": "녹화할 영역을 선택하세요",
+    "preset": "프리셋",
     "reset": "초기화",
     "cancel": "취소",
     "useThisArea": "이 영역 사용"

--- a/src/i18n/pl/core.json
+++ b/src/i18n/pl/core.json
@@ -446,6 +446,7 @@
   },
   "ScreenRegionOverlay": {
     "instruction": "Wybierz obszar do nagrania",
+    "preset": "Preset",
     "reset": "Resetuj",
     "cancel": "Anuluj",
     "useThisArea": "Użyj tego obszaru"

--- a/src/i18n/pt-BR/core.json
+++ b/src/i18n/pt-BR/core.json
@@ -446,6 +446,7 @@
   },
   "ScreenRegionOverlay": {
     "instruction": "Selecione uma área para gravar",
+    "preset": "Predefinição",
     "reset": "Redefinir",
     "cancel": "Cancelar",
     "useThisArea": "Usar esta área"

--- a/src/i18n/ru/core.json
+++ b/src/i18n/ru/core.json
@@ -446,6 +446,7 @@
   },
   "ScreenRegionOverlay": {
     "instruction": "Выберите область для записи",
+    "preset": "Пресет",
     "reset": "Сбросить",
     "cancel": "Отмена",
     "useThisArea": "Использовать эту область"

--- a/src/i18n/vi/core.json
+++ b/src/i18n/vi/core.json
@@ -445,6 +445,7 @@
   },
   "ScreenRegionOverlay": {
     "instruction": "Chọn một khu vực để ghi",
+    "preset": "Cài đặt trước",
     "reset": "Đặt lại",
     "cancel": "Hủy",
     "useThisArea": "Sử dụng khu vực này"

--- a/src/i18n/zh-CN/core.json
+++ b/src/i18n/zh-CN/core.json
@@ -446,6 +446,7 @@
   },
   "ScreenRegionOverlay": {
     "instruction": "选择要录制的区域",
+    "preset": "预设",
     "reset": "重置",
     "cancel": "取消",
     "useThisArea": "使用此区域"

--- a/src/i18n/zh-TW/core.json
+++ b/src/i18n/zh-TW/core.json
@@ -445,7 +445,8 @@
     "turnSystemAudioOn": "開啟系統音訊"
   },
   "ScreenRegionOverlay": {
-    "instruction": "選取要錄影的區域",
+    "instruction": "選擇要錄製的區域",
+    "preset": "預設",
     "reset": "重設",
     "cancel": "取消",
     "useThisArea": "使用此區域"

--- a/src/media/playback/media-playback-engine.ts
+++ b/src/media/playback/media-playback-engine.ts
@@ -12,6 +12,7 @@ import { FrameLruCache } from './frame-cache';
 import { isPlaybackWorkerResponse } from './playback-protocol';
 import { audioPlaybackTopology, videoPlaybackTopology } from './playback-composition-topology';
 import { videoPlaybackPlan } from './playback-composition-plan';
+import { previousContiguousVisualClipId } from './playback-frame-continuity';
 import { isPreviewQuality, type PreviewQuality } from './playback-preview';
 import type {
   PlaybackEventMap,
@@ -210,8 +211,11 @@ export class MediaPlaybackEngine {
         if (isVisualClip(clip) && clip.enabled) {
           const clipStartSec = clip.timelineStartMs / 1_000;
           const clipEndSec = (clip.timelineStartMs + clip.timelineDurationMs) / 1_000;
-          if (target >= clipStartSec && target <= clipEndSec) {
-            const srcSec = (clip.sourceInMs + (target - clipStartSec) * 1_000 * (clip.playbackRate ?? 1)) / 1_000;
+          if (target >= clipStartSec && target < clipEndSec) {
+            const srcSec =
+              clip.freezeFrameSourceMs !== undefined
+                ? clip.freezeFrameSourceMs / 1_000
+                : (clip.sourceInMs + (target - clipStartSec) * 1_000 * (clip.playbackRate ?? 1)) / 1_000;
             const cachedKey = this.cache.findMatchingKey(clip.id, srcSec, `${this.previewQuality}:`);
             if (cachedKey) {
               this.currentFrameKeys.set(clip.id, cachedKey);
@@ -232,8 +236,22 @@ export class MediaPlaybackEngine {
   }
 
   frameFor(clipId: string): MediaFrame | null {
+    const clip = this.composition?.clips.find((entry) => entry.id === clipId);
+    const timelineTimeMs = this.currentSeconds * 1_000;
+    if (
+      !clip ||
+      !clip.enabled ||
+      !isVisualClip(clip) ||
+      timelineTimeMs < clip.timelineStartMs ||
+      timelineTimeMs >= clip.timelineStartMs + clip.timelineDurationMs
+    ) {
+      return null;
+    }
     const key = this.currentFrameKeys.get(clipId);
-    return key ? (this.cache.get(key) ?? null) : null;
+    if (key) return this.cache.get(key) ?? null;
+    const previousClipId = previousContiguousVisualClipId(this.composition!, clipId, timelineTimeMs);
+    const previousKey = previousClipId ? this.currentFrameKeys.get(previousClipId) : null;
+    return previousKey ? (this.cache.get(previousKey) ?? null) : null;
   }
 
   on<K extends keyof PlaybackEventMap>(event: K, listener: Listener<K>): () => void {

--- a/src/media/playback/playback-composition-plan.ts
+++ b/src/media/playback/playback-composition-plan.ts
@@ -28,6 +28,9 @@ export function videoPlaybackPlan(composition: ClipComposition): {
         timelineDurationSeconds: clip.timelineDurationMs / 1_000,
         sourceInSeconds: clip.sourceInMs / 1_000,
         playbackRate: clip.playbackRate,
+        ...(clip.freezeFrameSourceMs !== undefined
+          ? { freezeFrameSourceSeconds: clip.freezeFrameSourceMs / 1_000 }
+          : {}),
       },
     ];
   });

--- a/src/media/playback/playback-frame-continuity.ts
+++ b/src/media/playback/playback-frame-continuity.ts
@@ -1,0 +1,21 @@
+import { clipEndMs, isVisualClip, type ClipComposition } from '../shared';
+
+export function previousContiguousVisualClipId(
+  composition: ClipComposition,
+  clipId: string,
+  timelineTimeMs: number,
+): string | null {
+  const clip = composition.clips.find((entry) => entry.id === clipId);
+  if (!clip || !isVisualClip(clip) || timelineTimeMs < clip.timelineStartMs || timelineTimeMs >= clipEndMs(clip)) {
+    return null;
+  }
+  const previous = composition.clips.find(
+    (entry) =>
+      entry.enabled &&
+      isVisualClip(entry) &&
+      entry.trackId === clip.trackId &&
+      entry.assetId === clip.assetId &&
+      clipEndMs(entry) === clip.timelineStartMs,
+  );
+  return previous?.id ?? null;
+}

--- a/src/media/playback/playback-protocol.ts
+++ b/src/media/playback/playback-protocol.ts
@@ -23,7 +23,9 @@ function isClip(value: unknown): value is PlaybackClipDescriptor {
     value.sourceInSeconds >= 0 &&
     finite(value.playbackRate) &&
     value.playbackRate >= 0.25 &&
-    value.playbackRate <= 4
+    value.playbackRate <= 4 &&
+    (value.freezeFrameSourceSeconds === undefined ||
+      (finite(value.freezeFrameSourceSeconds) && value.freezeFrameSourceSeconds >= 0))
   );
 }
 

--- a/src/media/playback/playback-types.ts
+++ b/src/media/playback/playback-types.ts
@@ -13,6 +13,7 @@ export interface PlaybackClipDescriptor {
   timelineDurationSeconds: number;
   sourceInSeconds: number;
   playbackRate: number;
+  freezeFrameSourceSeconds?: number;
 }
 
 export type PlaybackWorkerRequest =

--- a/src/media/playback/playback-worker-consumers.ts
+++ b/src/media/playback/playback-worker-consumers.ts
@@ -7,6 +7,7 @@ export const PLAYBACK_DECODER_OPTIONS = {
   hardwareAcceleration: 'prefer-hardware' as const,
   optimizeForLatency: true,
 };
+export const PLAYBACK_TICK_PRELOAD_SECONDS = 0.12;
 
 export type QueuedFrame = {
   bitmap: ImageBitmap;
@@ -69,4 +70,21 @@ export const activeAt = (clip: PlaybackClipDescriptor, timelineSeconds: number) 
   timelineSeconds < clip.timelineStartSeconds + clip.timelineDurationSeconds;
 
 export const sourceTime = (clip: PlaybackClipDescriptor, timelineSeconds: number) =>
+  clip.freezeFrameSourceSeconds ??
   clip.sourceInSeconds + (timelineSeconds - clip.timelineStartSeconds) * clip.playbackRate;
+
+export const shouldDecodeTickFrame = (consumer: ClipConsumer, targetSeconds: number) =>
+  consumer.lastTargetSeconds !== targetSeconds;
+
+export function activeConsumersForTick(consumers: Iterable<ClipConsumer>, timelineSeconds: number, preloadSeconds = 0) {
+  const active: ClipConsumer[] = [];
+  for (const consumer of consumers) {
+    const startsIn = consumer.clip.timelineStartSeconds - timelineSeconds;
+    if (activeAt(consumer.clip, timelineSeconds) || (startsIn > 0 && startsIn <= preloadSeconds)) {
+      active.push(consumer);
+    } else {
+      consumer.lastTargetSeconds = null;
+    }
+  }
+  return active;
+}

--- a/src/media/playback/playback.worker.ts
+++ b/src/media/playback/playback.worker.ts
@@ -11,15 +11,17 @@ import type {
 } from './playback-types';
 import {
   activeAt,
+  activeConsumersForTick,
   createPlaybackConsumer,
   createPlaybackSink,
   disposeLoadedAssets,
+  PLAYBACK_TICK_PRELOAD_SECONDS,
+  shouldDecodeTickFrame,
   sourceTime,
   type AssetDecoder,
   type ClipConsumer,
   type QueuedFrame,
 } from './playback-worker-consumers';
-
 const reportPlaybackWorkerError = (message: string, error?: unknown) =>
   console.error(`[Beam media:playback-worker] ${message}`, error ?? '');
 
@@ -266,7 +268,6 @@ async function sequentialFrame(consumer: ClipConsumer, targetSeconds: number): P
   await fillQueue(consumer);
   return frame;
 }
-
 async function processTicks() {
   if (processingTick || processingSeek) return;
   processingTick = true;
@@ -275,14 +276,22 @@ async function processTicks() {
       const request = pendingTick;
       pendingTick = null;
       if (request.generation !== generation) continue;
-      const activeConsumers = [...consumers.values()].filter((consumer) =>
-        activeAt(consumer.clip, request.timelineSeconds),
+      const activeConsumers = activeConsumersForTick(
+        consumers.values(),
+        request.timelineSeconds,
+        PLAYBACK_TICK_PRELOAD_SECONDS,
       );
       const decoded = await Promise.allSettled(
-        activeConsumers.map(async (consumer) => ({
-          consumer,
-          frame: await sequentialFrame(consumer, sourceTime(consumer.clip, request.timelineSeconds)),
-        })),
+        activeConsumers.map(async (consumer) => {
+          const sampleTimelineSeconds = Math.max(request.timelineSeconds, consumer.clip.timelineStartSeconds);
+          const targetSeconds = sourceTime(consumer.clip, sampleTimelineSeconds);
+          return {
+            consumer,
+            frame: shouldDecodeTickFrame(consumer, targetSeconds)
+              ? await sequentialFrame(consumer, targetSeconds)
+              : null,
+          };
+        }),
       );
       const failure = decoded.find((result): result is PromiseRejectedResult => result.status === 'rejected');
       if (failure) {
@@ -467,19 +476,15 @@ function waitForProcessingIdle() {
   if (!processingSeek && !processingTick) return Promise.resolve();
   return new Promise<void>((resolve) => processingIdleWaiters.add(resolve));
 }
-
 function resolveProcessingIdle() {
   if (processingSeek || processingTick) return;
   for (const resolve of processingIdleWaiters) resolve();
   processingIdleWaiters.clear();
 }
-
 async function shutdown() {
   await disposeAll();
   await waitForProcessingIdle();
   await Promise.allSettled([...loadTasks]);
-  // Let Mediabunny's iterator pumps observe disposal and synchronously close
-  // their WebCodecs decoders before the renderer terminates this worker.
   await new Promise<void>((resolve) => setTimeout(resolve, 0));
   post({ type: 'disposed', generation });
 }

--- a/src/media/playback/tests/media-playback-engine.test.ts
+++ b/src/media/playback/tests/media-playback-engine.test.ts
@@ -6,6 +6,7 @@ import type { AudioClip, ClipComposition } from '../../shared';
 import {
   cleanupPlaybackGlobals,
   composition,
+  asset,
   FakeAudio,
   FakeImageBitmap,
   FakeWorker,
@@ -57,6 +58,29 @@ const compositionWithAudio = (enabled: boolean): ClipComposition => {
     assets: [...value.assets, audioAsset],
     clips: [...value.clips, audioClip(enabled)],
   };
+};
+
+const loadAt = async (
+  engine: MediaPlaybackEngine,
+  worker: FakeWorker,
+  value: ClipComposition,
+  timelineSeconds: number,
+) => {
+  const pending = engine.loadComposition(value, timelineSeconds);
+  const loadRequest = worker.requests.find(
+    (request): request is Extract<PlaybackWorkerRequest, { type: 'load' }> => request.type === 'load',
+  );
+  worker.emit({ type: 'ready', generation: loadRequest!.generation });
+  for (let index = 0; index < 4; index += 1) await Promise.resolve();
+  const request = latestSeekRequest(worker)!;
+  worker.emit({
+    type: 'seek-result',
+    generation: request.generation,
+    requestId: request.requestId,
+    result: 'presented',
+    latencyMs: 1,
+  });
+  await pending;
 };
 
 describe('MediaPlaybackEngine', () => {
@@ -197,8 +221,9 @@ describe('MediaPlaybackEngine', () => {
     await Promise.resolve();
     const request = worker.requests.at(-1);
     expect(request?.type).toBe('retime');
+    if (!request || request.type !== 'retime') throw new Error('Expected a retime request.');
     expect(worker.requests.filter((entry) => entry.type === 'load')).toHaveLength(0);
-    worker.emit({ type: 'ready', generation: request!.generation });
+    worker.emit({ type: 'ready', generation: request.generation });
     for (let index = 0; index < 4; index += 1) await Promise.resolve();
     const seek = latestSeekRequest(worker)!;
     worker.emit({
@@ -233,8 +258,9 @@ describe('MediaPlaybackEngine', () => {
     await Promise.resolve();
     const request = worker.requests.at(-1);
     expect(request?.type).toBe('retime');
+    if (!request || request.type !== 'retime') throw new Error('Expected a retime request.');
     expect(worker.requests.filter((entry) => entry.type === 'load')).toHaveLength(0);
-    worker.emit({ type: 'ready', generation: request!.generation });
+    worker.emit({ type: 'ready', generation: request.generation });
     for (let index = 0; index < 4; index += 1) await Promise.resolve();
     const seek = latestSeekRequest(worker)!;
     worker.emit({
@@ -269,8 +295,9 @@ describe('MediaPlaybackEngine', () => {
     const pending = engine.setPreviewQuality('quarter');
     const configure = worker.requests.at(-1);
     expect(configure).toMatchObject({ type: 'configure-preview', previewQuality: 'quarter' });
+    if (!configure || configure.type !== 'configure-preview') throw new Error('Expected a preview request.');
     expect(engine.frameFor('clip-1')?.bitmap).toBe(previousFrame);
-    worker.emit({ type: 'ready', generation: configure!.generation });
+    worker.emit({ type: 'ready', generation: configure.generation });
     for (let index = 0; index < 4; index += 1) await Promise.resolve();
 
     const seek = [...worker.requests]
@@ -450,6 +477,197 @@ describe('MediaPlaybackEngine', () => {
     worker.emit({ type: 'disposed', generation: 3 });
     expect(worker.terminate).toHaveBeenCalledOnce();
     expect(engine.state).toBe('disposed');
+  });
+
+  it('reuses the previous frame for a contiguous fragment on the same track and asset', async () => {
+    const worker = new FakeWorker();
+    const audio = new FakeAudio();
+    const engine = new MediaPlaybackEngine({
+      workerFactory: () => worker,
+      audio: audio as unknown as AudioPlaybackScheduler,
+    });
+    const first = videoClip('first', 'asset-1', {
+      trackId: 'video-track',
+      timelineStartMs: 0,
+      timelineDurationMs: 1_000,
+      sourceDurationMs: 1_000,
+    });
+    const second = videoClip('second', 'asset-1', {
+      trackId: 'video-track',
+      timelineStartMs: 1_000,
+      timelineDurationMs: 1_000,
+      sourceDurationMs: 1_000,
+    });
+    const value = composition([first, second]);
+    await loadAt(engine, worker, value, 1.5);
+
+    const previous = new FakeImageBitmap();
+    worker.emit(frameResponse(latestSeekRequest(worker)!.generation, first.id, 0.5, previous));
+
+    expect(engine.frameFor(second.id)?.bitmap).toBe(previous);
+    engine.dispose();
+  });
+
+  it('provides continuity immediately at both VIDEO/HOLD boundaries', async () => {
+    const worker = new FakeWorker();
+    const audio = new FakeAudio();
+    const engine = new MediaPlaybackEngine({
+      workerFactory: () => worker,
+      audio: audio as unknown as AudioPlaybackScheduler,
+    });
+    const previous = videoClip('previous', 'asset-1', {
+      trackId: 'video-track',
+      timelineStartMs: 0,
+      timelineDurationMs: 1_000,
+      sourceDurationMs: 1_000,
+    });
+    const hold = videoClip('hold', 'asset-1', {
+      trackId: 'video-track',
+      timelineStartMs: 1_000,
+      timelineDurationMs: 1_000,
+      sourceInMs: 1_000,
+      sourceDurationMs: 1_000,
+      freezeFrameSourceMs: 1_000,
+    });
+    const following = videoClip('following', 'asset-1', {
+      trackId: 'video-track',
+      timelineStartMs: 2_000,
+      timelineDurationMs: 1_000,
+      sourceInMs: 2_000,
+      sourceDurationMs: 1_000,
+    });
+    await loadAt(engine, worker, composition([previous, hold, following]), 1.5);
+
+    const generation = latestSeekRequest(worker)!.generation;
+    const previousFrame = new FakeImageBitmap();
+    worker.emit(frameResponse(generation, previous.id, 0.99, previousFrame));
+    expect(engine.frameFor(hold.id)?.bitmap).toBe(previousFrame);
+
+    const holdFrame = new FakeImageBitmap();
+    worker.emit(frameResponse(generation, hold.id, 1, holdFrame));
+    const pending = engine.seek(2, 'seek');
+    await Promise.resolve();
+
+    // The following fragment can paint from the cached HOLD frame while its
+    // worker seek is still pending; no extra decode/presentation latency at
+    // either boundary is required.
+    expect(engine.frameFor(following.id)?.bitmap).toBe(holdFrame);
+
+    const request = latestSeekRequest(worker)!;
+    worker.emit({
+      type: 'seek-result',
+      generation: request.generation,
+      requestId: request.requestId,
+      result: 'presented',
+      latencyMs: 1,
+    });
+    await expect(pending).resolves.toBe('presented');
+    engine.dispose();
+  });
+
+  it('does not reuse a previous frame across a real timeline gap', async () => {
+    const worker = new FakeWorker();
+    const audio = new FakeAudio();
+    const engine = new MediaPlaybackEngine({
+      workerFactory: () => worker,
+      audio: audio as unknown as AudioPlaybackScheduler,
+    });
+    const first = videoClip('first', 'asset-1', {
+      trackId: 'video-track',
+      timelineStartMs: 0,
+      timelineDurationMs: 1_000,
+      sourceDurationMs: 1_000,
+    });
+    const second = videoClip('second', 'asset-1', {
+      trackId: 'video-track',
+      timelineStartMs: 1_500,
+      timelineDurationMs: 1_000,
+      sourceDurationMs: 1_000,
+    });
+    await loadAt(engine, worker, composition([first, second]), 1.75);
+
+    const previous = new FakeImageBitmap();
+    worker.emit(frameResponse(latestSeekRequest(worker)!.generation, first.id, 0.5, previous));
+
+    expect(engine.frameFor(second.id)).toBeNull();
+    engine.dispose();
+  });
+
+  it('does not reuse a previous frame when contiguous fragments reference different assets', async () => {
+    const worker = new FakeWorker();
+    const audio = new FakeAudio();
+    const engine = new MediaPlaybackEngine({
+      workerFactory: () => worker,
+      audio: audio as unknown as AudioPlaybackScheduler,
+    });
+    const first = videoClip('first', 'asset-1', {
+      trackId: 'video-track',
+      timelineStartMs: 0,
+      timelineDurationMs: 1_000,
+      sourceDurationMs: 1_000,
+    });
+    const second = videoClip('second', 'asset-2', {
+      trackId: 'video-track',
+      timelineStartMs: 1_000,
+      timelineDurationMs: 1_000,
+      sourceDurationMs: 1_000,
+    });
+    const value = composition([first, second]);
+    value.assets = [asset('asset-1'), asset('asset-2')];
+    await loadAt(engine, worker, value, 1.5);
+
+    const previous = new FakeImageBitmap();
+    worker.emit(frameResponse(latestSeekRequest(worker)!.generation, first.id, 0.5, previous));
+
+    expect(engine.frameFor(second.id)).toBeNull();
+    engine.dispose();
+  });
+
+  it('does not keep a HOLD frame after seeking slightly backward into the previous fragment', async () => {
+    const worker = new FakeWorker();
+    const audio = new FakeAudio();
+    const engine = new MediaPlaybackEngine({
+      workerFactory: () => worker,
+      audio: audio as unknown as AudioPlaybackScheduler,
+    });
+    const previous = videoClip('previous', 'asset-1', {
+      trackId: 'video-track',
+      timelineStartMs: 0,
+      timelineDurationMs: 1_000,
+      sourceInMs: 0,
+      sourceDurationMs: 1_000,
+    });
+    const hold = videoClip('hold', 'asset-1', {
+      trackId: 'video-track',
+      timelineStartMs: 1_000,
+      timelineDurationMs: 1_000,
+      sourceInMs: 1_000,
+      sourceDurationMs: 1_000,
+      freezeFrameSourceMs: 1_000,
+    });
+    await loadAt(engine, worker, composition([previous, hold]), 1.25);
+
+    const holdFrame = new FakeImageBitmap();
+    worker.emit(frameResponse(latestSeekRequest(worker)!.generation, hold.id, 1, holdFrame));
+    expect(engine.frameFor(hold.id)?.bitmap).toBe(holdFrame);
+
+    const backward = engine.seek(0.99, 'seek');
+    await Promise.resolve();
+    const request = latestSeekRequest(worker)!;
+    const previousFrame = new FakeImageBitmap();
+    worker.emit(frameResponse(request.generation, previous.id, 0.99, previousFrame));
+    worker.emit({
+      type: 'seek-result',
+      generation: request.generation,
+      requestId: request.requestId,
+      result: 'presented',
+      latencyMs: 1,
+    });
+    await expect(backward).resolves.toBe('presented');
+
+    expect(engine.frameFor(previous.id)?.bitmap).toBe(previousFrame);
+    expect(engine.frameFor(hold.id)).toBeNull();
+    engine.dispose();
   });
 
   it('waits for the worker disposed acknowledgement before terminating', async () => {

--- a/src/media/playback/tests/playback-protocol.test.ts
+++ b/src/media/playback/tests/playback-protocol.test.ts
@@ -108,6 +108,19 @@ describe('isPlaybackWorkerRequest', () => {
     expect(boundaryClip({ timelineStartSeconds: Number.MAX_VALUE, sourceInSeconds: Number.MAX_VALUE })).toBe(true);
   });
 
+  it('accepts a freeze-frame source timestamp on a playback clip descriptor', () => {
+    const request = {
+      type: 'load' as const,
+      generation: 1,
+      assets: [source()],
+      clips: [clip({ timelineStartSeconds: 3, timelineDurationSeconds: 1, freezeFrameSourceSeconds: 2.5 })],
+      previewQuality: 'full' as const,
+    };
+
+    expect(isPlaybackWorkerRequest(request)).toBe(true);
+    expect(() => assertPlaybackWorkerRequest(request)).not.toThrow();
+  });
+
   it('rejects unknown, null, and incomplete request objects', () => {
     expect(isPlaybackWorkerRequest(null)).toBe(false);
     expect(isPlaybackWorkerRequest({})).toBe(false);

--- a/src/media/playback/tests/playback-worker.test.ts
+++ b/src/media/playback/tests/playback-worker.test.ts
@@ -672,6 +672,209 @@ describe('playback worker', () => {
     });
   });
 
+  it('targets a freeze-frame clip at its source timestamp for both seeks and ticks', async () => {
+    const freezeFrameSourceSeconds = 4.25;
+    const freezeClip = { ...clip('clip-a'), freezeFrameSourceSeconds };
+    send({ type: 'load', generation: 17, assets: [source('asset-1')], clips: [freezeClip], previewQuality: 'full' });
+    await flush();
+
+    const sink = runtime.sinkInstances[0]!;
+    sink.getCanvas.mockResolvedValueOnce(wrapped(freezeFrameSourceSeconds));
+    send({ type: 'seek', generation: 17, requestId: 170, timelineSeconds: 6, mode: 'seek' });
+    await flush();
+
+    expect(sink.getCanvas).toHaveBeenCalledWith(freezeFrameSourceSeconds);
+    expect(messages()).toContainEqual(
+      expect.objectContaining({ type: 'frame', requestId: 170, timestampSeconds: freezeFrameSourceSeconds }),
+    );
+
+    const iterator = {
+      next: vi
+        .fn()
+        .mockResolvedValueOnce({ value: wrapped(freezeFrameSourceSeconds), done: false })
+        .mockResolvedValue({ value: undefined, done: true }),
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+    };
+    sink.canvases.mockReturnValueOnce(iterator);
+    send({ type: 'tick', generation: 17, timelineSeconds: 7 });
+    await flush();
+
+    expect(sink.canvases).toHaveBeenCalledWith(freezeFrameSourceSeconds);
+    expect(messages()).toContainEqual(
+      expect.objectContaining({ type: 'frame', timestampSeconds: freezeFrameSourceSeconds }),
+    );
+  });
+
+  it('does not consume or present advancing frames on repeated ticks during a hold', async () => {
+    const freezeFrameSourceSeconds = 4.5;
+    const frozenFrame = bitmap();
+    const advancingFrame = bitmap();
+    const firstIterator = {
+      next: vi
+        .fn()
+        .mockResolvedValueOnce({ value: wrapped(freezeFrameSourceSeconds, frozenFrame), done: false })
+        .mockResolvedValue({ value: undefined, done: true }),
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+    };
+    const repeatedTickIterator = {
+      next: vi
+        .fn()
+        .mockResolvedValueOnce({ value: wrapped(freezeFrameSourceSeconds + 0.04, advancingFrame), done: false })
+        .mockResolvedValue({ value: undefined, done: true }),
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+    };
+    send({
+      type: 'load',
+      generation: 18,
+      assets: [source('asset-1')],
+      clips: [{ ...clip('clip-a'), freezeFrameSourceSeconds }],
+      previewQuality: 'full',
+    });
+    await flush();
+
+    const sink = runtime.sinkInstances[0]!;
+    sink.canvases.mockReturnValueOnce(firstIterator).mockReturnValue(repeatedTickIterator);
+    send({ type: 'tick', generation: 18, timelineSeconds: 1 });
+    await flush();
+
+    const initialCanvasesCalls = sink.canvases.mock.calls.length;
+    const initialIteratorNextCalls = firstIterator.next.mock.calls.length;
+    const initialFrames = messages().filter((message) => message.type === 'frame');
+    expect(initialFrames).toHaveLength(1);
+    expect(initialFrames[0]).toMatchObject({ timestampSeconds: freezeFrameSourceSeconds });
+
+    send({ type: 'tick', generation: 18, timelineSeconds: 1.25 });
+    send({ type: 'tick', generation: 18, timelineSeconds: 1.75 });
+    await flush();
+
+    expect(sink.canvases).toHaveBeenCalledTimes(initialCanvasesCalls);
+    expect(firstIterator.next).toHaveBeenCalledTimes(initialIteratorNextCalls);
+    expect(repeatedTickIterator.next).not.toHaveBeenCalled();
+    expect(messages().filter((message) => message.type === 'frame')).toHaveLength(1);
+    expect(messages()).not.toContainEqual(
+      expect.objectContaining({ type: 'frame', timestampSeconds: freezeFrameSourceSeconds + 0.04 }),
+    );
+  });
+
+  it('preloads HOLD and following VIDEO frames before their playback boundaries', async () => {
+    const freezeFrameSourceSeconds = 1;
+    send({
+      type: 'load',
+      generation: 20,
+      assets: [source('asset-1')],
+      clips: [
+        { ...clip('previous'), timelineDurationSeconds: 1 },
+        {
+          ...clip('hold'),
+          timelineStartSeconds: 1,
+          timelineDurationSeconds: 1,
+          sourceInSeconds: 1,
+          freezeFrameSourceSeconds,
+        },
+        {
+          ...clip('following'),
+          timelineStartSeconds: 2,
+          timelineDurationSeconds: 1,
+          sourceInSeconds: 2,
+        },
+      ],
+      previewQuality: 'full',
+    });
+    await flush();
+
+    const oneFrame = (timestampSeconds: number) => ({
+      next: vi
+        .fn()
+        .mockResolvedValueOnce({ value: wrapped(timestampSeconds), done: false })
+        .mockResolvedValue({ value: undefined, done: true }),
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+    });
+    const [previousSink, holdSink, followingSink] = runtime.sinkInstances;
+    previousSink!.canvases.mockReturnValueOnce(oneFrame(0.9));
+    holdSink!.canvases.mockReturnValueOnce(oneFrame(freezeFrameSourceSeconds));
+    followingSink!.canvases.mockReturnValueOnce(oneFrame(2));
+
+    send({ type: 'tick', generation: 20, timelineSeconds: 0.9 });
+    await flush();
+
+    expect(previousSink!.canvases).toHaveBeenCalledWith(0.9);
+    expect(holdSink!.canvases).toHaveBeenCalledWith(freezeFrameSourceSeconds);
+    expect(followingSink!.canvases).not.toHaveBeenCalled();
+
+    send({ type: 'tick', generation: 20, timelineSeconds: 1.9 });
+    await flush();
+
+    expect(holdSink!.canvases).toHaveBeenCalledTimes(1);
+    expect(followingSink!.canvases).toHaveBeenCalledWith(2);
+    expect(messages()).toContainEqual(expect.objectContaining({ type: 'frame', clipId: 'hold' }));
+    expect(messages()).toContainEqual(expect.objectContaining({ type: 'frame', clipId: 'following' }));
+  });
+
+  it('presents the frozen frame again after leaving and re-entering the hold range', async () => {
+    const freezeFrameSourceSeconds = 4.5;
+    const firstFrame = bitmap();
+    const secondFrame = bitmap();
+    const firstIterator = {
+      next: vi
+        .fn()
+        .mockResolvedValueOnce({ value: wrapped(freezeFrameSourceSeconds, firstFrame), done: false })
+        .mockResolvedValue({ value: undefined, done: true }),
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+    };
+    const reentryIterator = {
+      next: vi
+        .fn()
+        .mockResolvedValueOnce({ value: wrapped(freezeFrameSourceSeconds, secondFrame), done: false })
+        .mockResolvedValue({ value: undefined, done: true }),
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+    };
+    send({
+      type: 'load',
+      generation: 19,
+      assets: [source('asset-1')],
+      clips: [
+        {
+          ...clip('clip-a'),
+          timelineStartSeconds: 2,
+          timelineDurationSeconds: 1,
+          freezeFrameSourceSeconds,
+        },
+      ],
+      previewQuality: 'full',
+    });
+    await flush();
+
+    const sink = runtime.sinkInstances[0]!;
+    sink.canvases.mockReturnValueOnce(firstIterator).mockReturnValueOnce(reentryIterator);
+    send({ type: 'tick', generation: 19, timelineSeconds: 2.25 });
+    await flush();
+    send({ type: 'tick', generation: 19, timelineSeconds: 3 });
+    await flush();
+    send({ type: 'tick', generation: 19, timelineSeconds: 2.75 });
+    await flush();
+
+    expect(sink.canvases).toHaveBeenCalledTimes(2);
+    expect(reentryIterator.next).toHaveBeenCalled();
+    const frames = messages().filter((message) => message.type === 'frame');
+    expect(frames).toHaveLength(2);
+    expect(frames).toEqual([
+      expect.objectContaining({ timestampSeconds: freezeFrameSourceSeconds }),
+      expect.objectContaining({ timestampSeconds: freezeFrameSourceSeconds }),
+    ]);
+  });
+
   it('presents a frame decoded by a slow tick instead of starving while a newer tick is pending', async () => {
     const next = deferred<IteratorResult<Wrapped>>();
     const stale = bitmap();

--- a/src/media/shared/composition-types.ts
+++ b/src/media/shared/composition-types.ts
@@ -1,6 +1,6 @@
 import type { CameraFramingPreset, CameraLayoutPreset } from './camera-layout-types';
 
-export const COMPOSITION_SCHEMA_VERSION = 8 as const;
+export const COMPOSITION_SCHEMA_VERSION = 9 as const;
 export const SCREEN_CLIP_ID = 'screen';
 
 export type MediaKind = 'video' | 'image' | 'audio';
@@ -176,6 +176,8 @@ export interface VisualClip extends ClipBase {
   appearance: ClipAppearance;
   isMirrored: boolean;
   isMirroredY: boolean;
+  /** Holds one decoded video frame for the whole clip duration when present. */
+  freezeFrameSourceMs?: number;
   /** Persisted layout preset for visual clips; legacy clips default to custom. */
   cameraLayoutPreset?: CameraLayoutPreset;
   /** Persisted framing preset for visual clips; legacy clips default to custom. */

--- a/src/media/shared/tests/timeline-mapping.test.ts
+++ b/src/media/shared/tests/timeline-mapping.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import type { VisualClip } from '../composition-types';
+import { createDefaultClipAppearance } from '../composition-defaults';
+import { sourceTimeAt } from '../timeline-mapping';
+
+const frozenVideo = (): VisualClip => ({
+  id: 'hold',
+  kind: 'video',
+  name: 'Hold',
+  assetId: 'video-asset',
+  timelineStartMs: 500,
+  timelineDurationMs: 1_000,
+  sourceInMs: 200,
+  sourceDurationMs: 2_000,
+  playbackRate: 2,
+  transitions: { entry: null, exit: null },
+  enabled: true,
+  order: 0,
+  trackId: 'video-track',
+  transform: { x: 0, y: 0, width: 1, height: 1 },
+  appearance: createDefaultClipAppearance('video'),
+  isMirrored: false,
+  isMirroredY: false,
+  freezeFrameSourceMs: 1_234,
+});
+
+describe('timeline mapping', () => {
+  it('maps every instant of a freeze-frame segment to its captured source timestamp', () => {
+    const clip = frozenVideo();
+
+    expect(sourceTimeAt(clip, 499)).toBeNull();
+    expect(sourceTimeAt(clip, 500)).toBe(1_234);
+    expect(sourceTimeAt(clip, 999)).toBe(1_234);
+    expect(sourceTimeAt(clip, 1_499)).toBe(1_234);
+    expect(sourceTimeAt(clip, 1_500)).toBeNull();
+  });
+});

--- a/src/media/shared/timeline-mapping.ts
+++ b/src/media/shared/timeline-mapping.ts
@@ -12,6 +12,7 @@ export function sourceTimeAt(clip: Clip, timelineTimeMs: number): number | null 
   if (!Number.isFinite(timelineTimeMs) || timelineTimeMs < clip.timelineStartMs || timelineTimeMs >= clipEndMs(clip)) {
     return null;
   }
+  if ('freezeFrameSourceMs' in clip && clip.freezeFrameSourceMs !== undefined) return clip.freezeFrameSourceMs;
   return Math.round(clip.sourceInMs + (timelineTimeMs - clip.timelineStartMs) * clip.playbackRate);
 }
 

--- a/test/clip-composition.test.cjs
+++ b/test/clip-composition.test.cjs
@@ -200,7 +200,7 @@ test('normalizes canonical clip timing, linked groups and appearance', () => {
   };
   const groupId = 'recording';
   const normalized = normalizeComposition({
-    schemaVersion: 8,
+    schemaVersion: 9,
     assets: [asset],
     keyboardCaptionSessions: [],
     clips: [
@@ -255,7 +255,7 @@ test('normalizes canonical clip timing, linked groups and appearance', () => {
 
 test('round-trips text and keyboard captions in the canonical composition schema', () => {
   const normalized = normalizeComposition({
-    schemaVersion: 8,
+    schemaVersion: 9,
     assets: [],
     keyboardCaptionSessions: ['session-keyboard', 'session-keyboard'],
     clips: [
@@ -264,7 +264,7 @@ test('round-trips text and keyboard captions in the canonical composition schema
     ],
   });
 
-  assert.equal(normalized.schemaVersion, 8);
+  assert.equal(normalized.schemaVersion, 9);
   assert.deepEqual(normalized.keyboardCaptionSessions, ['session-keyboard']);
   assert.equal(normalized.clips[0].caption.type, 'text');
   assert.deepEqual(normalized.clips[1].caption, keyboardCaption({ style: canonicalCaptionStyle() }));
@@ -272,7 +272,7 @@ test('round-trips text and keyboard captions in the canonical composition schema
 
 test('round-trips an assetless blur overlay with its effect settings', () => {
   const normalized = normalizeComposition({
-    schemaVersion: 8,
+    schemaVersion: 9,
     assets: [],
     keyboardCaptionSessions: [],
     clips: [
@@ -343,7 +343,7 @@ test('rejects malformed keyboard captions and invalid keyboard session markers',
     assert.throws(
       () =>
         normalizeComposition({
-          schemaVersion: 8,
+          schemaVersion: 9,
           assets: [],
           keyboardCaptionSessions: [],
           clips: [captionClip(caption)],
@@ -352,7 +352,7 @@ test('rejects malformed keyboard captions and invalid keyboard session markers',
     );
 
   assert.throws(
-    () => normalizeComposition({ schemaVersion: 8, assets: [], keyboardCaptionSessions: [null], clips: [] }),
+    () => normalizeComposition({ schemaVersion: 9, assets: [], keyboardCaptionSessions: [null], clips: [] }),
     /session|caption/i,
   );
 });
@@ -453,7 +453,7 @@ test('migrates legacy composition fields and atomically persists the canonical e
 
   const migrated = store.editorState(project.id);
   assert.equal(migrated.schemaVersion, 3);
-  assert.equal(migrated.composition.schemaVersion, 8);
+  assert.equal(migrated.composition.schemaVersion, 9);
   assert.deepEqual(migrated.composition.keyboardCaptionSessions, []);
   assert.deepEqual(migrated.presentation.canvas, {
     preset: '21:9',
@@ -483,13 +483,13 @@ test('migrates legacy composition fields and atomically persists the canonical e
 
   const rewritten = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
   assert.equal(rewritten.editor.schemaVersion, 3);
-  assert.equal(rewritten.editor.composition.schemaVersion, 8);
+  assert.equal(rewritten.editor.composition.schemaVersion, 9);
   assert.deepEqual(rewritten.editor.composition.keyboardCaptionSessions, []);
   assert.equal(rewritten.editor.composition.clips[0].isMirroredY, false);
   assert.equal(fs.existsSync(`${manifestPath}.tmp`), false);
 });
 
-test('migrates v2 composition to v8 and records historical project sessions once', () => {
+test('migrates v2 composition to v9 and records historical project sessions once', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'demo-editor-v2-migration-'));
   const store = createProjectStore(root);
   const project = store.create({ name: 'V2 migration' });
@@ -511,13 +511,13 @@ test('migrates v2 composition to v8 and records historical project sessions once
   fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
 
   const migrated = store.editorState(project.id);
-  assert.equal(migrated.composition.schemaVersion, 8);
+  assert.equal(migrated.composition.schemaVersion, 9);
   assert.deepEqual(migrated.composition.keyboardCaptionSessions, ['session-old', 'session-new']);
   assert.equal(migrated.composition.clips[0].caption.type, 'text');
 
   const rewritten = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
   assert.equal(rewritten.editor.schemaVersion, 3);
-  assert.equal(rewritten.editor.composition.schemaVersion, 8);
+  assert.equal(rewritten.editor.composition.schemaVersion, 9);
   assert.deepEqual(rewritten.editor.composition.keyboardCaptionSessions, ['session-old', 'session-new']);
   assert.deepEqual(store.editorState(project.id).composition.keyboardCaptionSessions, ['session-old', 'session-new']);
 
@@ -526,11 +526,11 @@ test('migrates v2 composition to v8 and records historical project sessions once
     true,
     ['session-old'],
   );
-  assert.equal(direct.schemaVersion, 8);
+  assert.equal(direct.schemaVersion, 9);
   assert.deepEqual(direct.keyboardCaptionSessions, ['session-old']);
 });
 
-test('migrates v5 captions to v8 with the historical typography defaults', () => {
+test('migrates v5 captions to v9 with the historical typography defaults', () => {
   const migrated = migrateComposition(
     {
       schemaVersion: 5,
@@ -542,7 +542,7 @@ test('migrates v5 captions to v8 with the historical typography defaults', () =>
     [],
   );
 
-  assert.equal(migrated.schemaVersion, 8);
+  assert.equal(migrated.schemaVersion, 9);
   assert.deepEqual(migrated.clips[0].caption.style, {
     fontFamily: 'sans-serif',
     fontWeight: 800,
@@ -564,7 +564,7 @@ test('migrates v5 captions to v8 with the historical typography defaults', () =>
   });
 });
 
-test('migrates v6 compositions by adding empty transitions before writing v8', () => {
+test('migrates v6 compositions by adding empty transitions before writing v9', () => {
   const asset = {
     id: 'asset-video',
     kind: 'video',
@@ -578,11 +578,11 @@ test('migrates v6 compositions by adding empty transitions before writing v8', (
   const legacyClip = visualClip(asset.id);
   delete legacyClip.transitions;
   const migrated = migrateComposition({ schemaVersion: 6, assets: [asset], clips: [legacyClip] }, true, []);
-  assert.equal(migrated.schemaVersion, 8);
+  assert.equal(migrated.schemaVersion, 9);
   assert.deepEqual(migrated.clips[0].transitions, { entry: null, exit: null });
 });
 
-test('migrates v7 webcam clips to v8 custom presets without changing their render fields', () => {
+test('migrates v7 webcam clips to v9 custom presets without changing their render fields', () => {
   const asset = {
     id: 'asset-camera',
     kind: 'video',
@@ -627,7 +627,7 @@ test('migrates v7 webcam clips to v8 custom presets without changing their rende
   );
   const migratedCamera = migrated.clips.find((clip) => clip.kind === 'webcam');
 
-  assert.equal(migrated.schemaVersion, 8);
+  assert.equal(migrated.schemaVersion, 9);
   assert.equal(migratedCamera.cameraLayoutPreset, 'custom');
   assert.equal(migratedCamera.cameraFramingPreset, 'custom');
   assert.equal(migratedCamera.cameraSplitRatio, 0.5);
@@ -641,7 +641,36 @@ test('migrates v7 webcam clips to v8 custom presets without changing their rende
   assert.deepEqual(migrated.clips.find((clip) => clip.id === 'screen').transform, screen.transform);
 });
 
-test('normalizes a v8 webcam with omitted presets to custom while rejecting explicit invalid values', () => {
+test('migrates v8 compositions to v9 while preserving freeze-frame source times', () => {
+  const asset = {
+    id: 'asset-video',
+    kind: 'video',
+    name: 'Video',
+    fileName: 'video.mp4',
+    durationMs: 2_000,
+    width: 1_920,
+    height: 1_080,
+    origin: 'project',
+  };
+  const source = visualClip(asset.id, {
+    id: 'held-video',
+    sourceInMs: 500,
+    sourceDurationMs: 1_000,
+    freezeFrameSourceMs: 500,
+  });
+  const migrated = migrateComposition(
+    { schemaVersion: 8, assets: [asset], keyboardCaptionSessions: [], clips: [source] },
+    true,
+    [],
+  );
+
+  assert.equal(migrated.schemaVersion, 9);
+  assert.equal(migrated.clips[0].freezeFrameSourceMs, 500);
+  assert.equal(migrated.clips[0].trackId, source.trackId);
+  assert.deepEqual(migrated.clips[0].transitions, source.transitions);
+});
+
+test('normalizes a v9 webcam with omitted presets to custom while rejecting explicit invalid values', () => {
   const asset = {
     id: 'asset-camera',
     kind: 'video',
@@ -653,7 +682,7 @@ test('normalizes a v8 webcam with omitted presets to custom while rejecting expl
     origin: 'project',
   };
   const normalized = normalizeComposition({
-    schemaVersion: 8,
+    schemaVersion: 9,
     assets: [asset],
     keyboardCaptionSessions: [],
     clips: [webcamClip(asset.id)],
@@ -670,7 +699,7 @@ test('normalizes a v8 webcam with omitted presets to custom while rejecting expl
   assert.throws(
     () =>
       normalizeComposition({
-        schemaVersion: 8,
+        schemaVersion: 9,
         assets: [asset],
         keyboardCaptionSessions: [],
         clips: [webcamClip(asset.id, { cameraLayoutPreset: 'invalid', cameraFramingPreset: 'fill' })],
@@ -680,7 +709,7 @@ test('normalizes a v8 webcam with omitted presets to custom while rejecting expl
   assert.throws(
     () =>
       normalizeComposition({
-        schemaVersion: 8,
+        schemaVersion: 9,
         assets: [asset],
         keyboardCaptionSessions: [],
         clips: [
@@ -692,7 +721,7 @@ test('normalizes a v8 webcam with omitted presets to custom while rejecting expl
   assert.throws(
     () =>
       normalizeComposition({
-        schemaVersion: 8,
+        schemaVersion: 9,
         assets: [asset],
         keyboardCaptionSessions: [],
         clips: [
@@ -708,7 +737,7 @@ test('normalizes a v8 webcam with omitted presets to custom while rejecting expl
   assert.throws(
     () =>
       normalizeComposition({
-        schemaVersion: 8,
+        schemaVersion: 9,
         assets: [asset],
         keyboardCaptionSessions: [],
         clips: [webcamClip(asset.id, { cameraLayoutPreset: 'fullscreen', cameraFramingPreset: 'invalid' })],
@@ -717,10 +746,79 @@ test('normalizes a v8 webcam with omitted presets to custom while rejecting expl
   );
 });
 
-test('repairs and persists omitted camera presets when opening an already-v8 project', () => {
+test('normalizes valid freeze-frame source times and rejects invalid or image freeze values', () => {
+  const asset = {
+    id: 'asset-video',
+    kind: 'video',
+    name: 'Video',
+    fileName: 'video.mp4',
+    durationMs: 2_000,
+    width: 1_920,
+    height: 1_080,
+    origin: 'project',
+  };
+  const normalized = normalizeComposition({
+    schemaVersion: 9,
+    assets: [asset],
+    keyboardCaptionSessions: [],
+    clips: [
+      visualClip(asset.id, {
+        id: 'held-video',
+        sourceInMs: 500,
+        sourceDurationMs: 1_000,
+        freezeFrameSourceMs: 500,
+      }),
+      webcamClip(asset.id, {
+        id: 'held-webcam',
+        timelineStartMs: 1_000,
+        sourceInMs: 250,
+        sourceDurationMs: 1_000,
+        freezeFrameSourceMs: 250,
+      }),
+    ],
+  });
+
+  assert.equal(normalized.clips.find((clip) => clip.id === 'held-video').freezeFrameSourceMs, 500);
+  assert.equal(normalized.clips.find((clip) => clip.id === 'held-webcam').freezeFrameSourceMs, 250);
+
+  const invalid = [
+    visualClip(asset.id, {
+      id: 'before-source',
+      sourceInMs: 500,
+      sourceDurationMs: 1_000,
+      freezeFrameSourceMs: 499,
+    }),
+    visualClip(asset.id, {
+      id: 'after-source',
+      sourceInMs: 500,
+      sourceDurationMs: 1_000,
+      freezeFrameSourceMs: 1_501,
+    }),
+    visualClip(asset.id, { id: 'not-a-time', freezeFrameSourceMs: Number.NaN }),
+  ];
+  for (const clip of invalid)
+    assert.throws(
+      () => normalizeComposition({ schemaVersion: 9, assets: [asset], keyboardCaptionSessions: [], clips: [clip] }),
+      /figée|freeze|image/i,
+    );
+
+  const imageAsset = { ...asset, id: 'asset-image', kind: 'image', fileName: 'image.png' };
+  assert.throws(
+    () =>
+      normalizeComposition({
+        schemaVersion: 9,
+        assets: [imageAsset],
+        keyboardCaptionSessions: [],
+        clips: [visualClip(imageAsset.id, { id: 'image-hold', kind: 'image', freezeFrameSourceMs: 100 })],
+      }),
+    /figée|freeze|image/i,
+  );
+});
+
+test('repairs and persists omitted camera presets when opening an already-v9 project', () => {
   const { directory: root } = setup();
   const store = createProjectStore(root);
-  const project = store.create({ name: 'Incomplete v8 camera presets' });
+  const project = store.create({ name: 'Incomplete v9 camera presets' });
   const source = path.join(root, 'camera.mp4');
   fs.writeFileSync(source, 'camera');
   const imported = store.importEditorMedia(project.id, { kind: 'video', source });
@@ -729,7 +827,7 @@ test('repairs and persists omitted camera presets when opening an already-v8 pro
   const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
   const asset = { ...imported, durationMs: 1_000, width: 1_280, height: 720 };
   manifest.editor.composition = {
-    schemaVersion: 8,
+    schemaVersion: 9,
     assets: [asset],
     keyboardCaptionSessions: [],
     clips: [webcamClip(asset.id)],
@@ -747,7 +845,7 @@ test('repairs and persists omitted camera presets when opening an already-v8 pro
   assert.equal(persistedCamera.cameraFramingPreset, 'custom');
 });
 
-test('rejects unknown camera presets in a canonical v8 webcam clip', () => {
+test('rejects unknown camera presets in a canonical v9 webcam clip', () => {
   const asset = {
     id: 'asset-camera',
     kind: 'video',
@@ -761,7 +859,7 @@ test('rejects unknown camera presets in a canonical v8 webcam clip', () => {
   assert.throws(
     () =>
       normalizeComposition({
-        schemaVersion: 8,
+        schemaVersion: 9,
         assets: [asset],
         keyboardCaptionSessions: [],
         clips: [webcamClip(asset.id, { cameraLayoutPreset: 'invalid', cameraFramingPreset: 'fill' })],
@@ -782,7 +880,7 @@ test('validates canonical transition presets, durations, domains, and edge budge
     origin: 'project',
   };
   const canonical = (clip) =>
-    normalizeComposition({ schemaVersion: 8, assets: [asset], clips: [clip], keyboardCaptionSessions: [] });
+    normalizeComposition({ schemaVersion: 9, assets: [asset], clips: [clip], keyboardCaptionSessions: [] });
   const valid = visualClip(asset.id, {
     transitions: {
       entry: { preset: { kind: 'slide', direction: 'left' }, durationMs: 250 },
@@ -820,7 +918,7 @@ test('validates canonical transition presets, durations, domains, and edge budge
   assert.throws(
     () =>
       normalizeComposition({
-        schemaVersion: 8,
+        schemaVersion: 9,
         assets: [
           asset,
           { ...asset, id: 'asset-audio', kind: 'audio', fileName: 'audio.wav', width: null, height: null },
@@ -947,7 +1045,7 @@ test('materializes project and recording assets without persisting runtime URLs'
   fs.mkdirSync(path.join(directory, 'media'));
   fs.writeFileSync(path.join(directory, 'media', 'video.mp4'), 'video');
   const composition = normalizeComposition({
-    schemaVersion: 8,
+    schemaVersion: 9,
     keyboardCaptionSessions: [],
     assets: [
       {
@@ -978,7 +1076,7 @@ test('prunes only project media that is no longer referenced', () => {
   fs.mkdirSync(path.join(directory, 'media'));
   fs.writeFileSync(path.join(directory, 'media', 'unused.mp4'), 'video');
   const previous = {
-    schemaVersion: 8,
+    schemaVersion: 9,
     keyboardCaptionSessions: [],
     assets: [
       {
@@ -1006,7 +1104,7 @@ test('persists and reads one atomic editor state', () => {
   fs.writeFileSync(source, 'video');
   const asset = store.importEditorMedia(project.id, { kind: 'video', source });
   const composition = {
-    schemaVersion: 8,
+    schemaVersion: 9,
     keyboardCaptionSessions: [],
     assets: [{ ...asset, durationMs: 1_000 }],
     clips: [visualClip(asset.id)],
@@ -1134,7 +1232,7 @@ test('normalizes the v7 visual track identity and preserves it through editor-st
   const trackId = 'visual-track-1';
   const state = store.editorState(project.id);
   state.composition = {
-    schemaVersion: 8,
+    schemaVersion: 9,
     keyboardCaptionSessions: [],
     assets: [{ ...asset, durationMs: 2_000 }],
     clips: [
@@ -1152,7 +1250,7 @@ test('normalizes the v7 visual track identity and preserves it through editor-st
   };
 
   const saved = store.saveEditorState(project.id, state);
-  assert.equal(saved.composition.schemaVersion, 8);
+  assert.equal(saved.composition.schemaVersion, 9);
   assert.deepEqual(
     saved.composition.clips.map((clip) => clip.trackId),
     [trackId, trackId],
@@ -1200,7 +1298,7 @@ test('migrates only certain contiguous v3 visual fragments into one track', () =
     [],
   );
 
-  assert.equal(migrated.schemaVersion, 8);
+  assert.equal(migrated.schemaVersion, 9);
   const certain = migrated.clips.filter((clip) => clip.id.startsWith('certain-'));
   assert.equal(certain.length, 2);
   assert.ok(certain[0].trackId);
@@ -1219,7 +1317,7 @@ test('rejects invalid visual track identities and overlapping clips assigned to 
     height: 1080,
     origin: 'project',
   };
-  const base = { schemaVersion: 8, assets: [asset], keyboardCaptionSessions: [] };
+  const base = { schemaVersion: 9, assets: [asset], keyboardCaptionSessions: [] };
   assert.throws(
     () => normalizeComposition({ ...base, clips: [visualClip(asset.id, { trackId: '' })] }),
     /track|piste|identit/i,
@@ -1299,7 +1397,7 @@ test('migration groups a mixed-order chain of certain v3 split fragments and kee
   assert.notEqual(migrated.clips.find((clip) => clip.id === 'other-track').trackId, chain[0].trackId);
 });
 
-test('migrates Golden Canvas 2 v4 screen fragments to v8 without losing visual properties', () => {
+test('migrates Golden Canvas 2 v4 screen fragments to v9 without losing visual properties', () => {
   const asset = {
     id: 'session:golden-canvas:screen:segment-0001.mp4',
     kind: 'video',
@@ -1357,7 +1455,7 @@ test('migrates Golden Canvas 2 v4 screen fragments to v8 without losing visual p
   const migrated = store.editorState(project.id);
 
   assert.equal(migrated.schemaVersion, 3);
-  assert.equal(migrated.composition.schemaVersion, 8);
+  assert.equal(migrated.composition.schemaVersion, 9);
   const migratedFirst = migrated.composition.clips.find((clip) => clip.id === first.id);
   const migratedSecond = migrated.composition.clips.find((clip) => clip.id === second.id);
   const migratedThird = migrated.composition.clips.find((clip) => clip.id === third.id);
@@ -1369,7 +1467,7 @@ test('migrates Golden Canvas 2 v4 screen fragments to v8 without losing visual p
   assert.equal(migratedSecond.appearance.shadowSize, 'custom');
 
   const persisted = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
-  assert.equal(persisted.editor.composition.schemaVersion, 8);
+  assert.equal(persisted.editor.composition.schemaVersion, 9);
   assert.deepEqual(
     persisted.editor.composition.clips.map((clip) => clip.trackId),
     migrated.composition.clips.map((clip) => clip.trackId),
@@ -1391,7 +1489,7 @@ test('project store reports hasScreen, hasCamera, and hasCaption only when actua
   const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
 
   manifest.editor.composition = {
-    schemaVersion: 8,
+    schemaVersion: 9,
     assets: [
       { id: 'screen-asset', kind: 'video', name: 'Screen', fileName: 'screen.mp4', origin: 'project' },
       { id: 'webcam-asset', kind: 'video', name: 'Webcam', fileName: 'webcam.mp4', origin: 'project' },


### PR DESCRIPTION
## Summary

- add Hold Segment at Playhead for video and webcam clips with a one-second freeze segment
- preserve seamless playback and preload VIDEO/HOLD/VIDEO boundaries
- make hold resizing non-destructive, ripple following grouped content, and keep trim handles synced with smooth auto-scroll
- keep split imported audio fragments on one lane and delete linked video/audio fragments together
- recompute timeline duration after destructive edits and keep previews responsive during trims
- include persistence, export, localization, HUD region preset, and focused regression coverage

## Root cause

Split visual clips had persistent track identities, while imported audio fragments were rendered as one row per clip. Playback also decoded only the currently active consumer, and grouped deletion did not consistently include linked companions from every UI path.

## Validation

- focused editor, engine, timeline, and playback Vitest coverage
- 95 focused playback/editor tests passed
- imported-audio lane regression tests passed
- Prettier checks passed
- git diff --check passed
- repository typecheck still reports pre-existing unrelated UI/performance test errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Add a Hold Segment action to freeze video for one second at the playhead.
  - Choose and save screen-capture region presets for common resolutions.
  - Group imported audio clips by source for a clearer timeline.

- **Bug Fixes**
  - Improve trimming, splitting, deletion, and duration updates for linked clips.
  - Keep freeze frames consistent during editing, preview, and playback.
  - Synchronize exported cursor movement with screen footage timing.
  - Improve timeline responsiveness, thumbnail behavior, and frame continuity.

- **Compatibility**
  - Existing projects continue to migrate correctly to the latest composition format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->