### PR TITLE
Fix Linux input helper upgrades

### DIFF
--- a/build/linux/after-install.sh
+++ b/build/linux/after-install.sh
@@ -10,13 +10,15 @@ fi
 
 for directory in /opt/Beam/resources/input-helper /opt/beam/resources/input-helper
 do
-  for helper in "$directory"/beam-input-helper-*
-  do
-    if [ -x "$helper" ]; then
-      "$helper" install >/dev/null
-      exit 0
-    fi
-  done
+  helper=$(
+    find "$directory" -maxdepth 1 -type f -name 'beam-input-helper-*' -perm /111 -print 2>/dev/null \
+      | sort -V \
+      | tail -n 1
+  )
+  if [ -n "$helper" ]; then
+    "$helper" install >/dev/null
+    exit 0
+  fi
 done
 
 echo "Beam input helper was not found in the installed application" >&2

--- a/test/linux-postinst.test.cjs
+++ b/test/linux-postinst.test.cjs
@@ -7,12 +7,12 @@ const test = require('node:test');
 
 const AFTER_INSTALL = path.join(__dirname, '..', 'build', 'linux', 'after-install.sh');
 
-function runAfterInstall(directory, withHelper) {
+function runAfterInstall(directory, helperVersions) {
   const helperDirectory = path.join(directory, '/opt/Beam/resources/input-helper');
   fs.mkdirSync(helperDirectory, { recursive: true });
-  if (withHelper) {
-    const helper = path.join(helperDirectory, 'beam-input-helper-1.2.3');
-    fs.writeFileSync(helper, '#!/bin/sh\nprintf "%s" "$1" > "$MARKER"\n');
+  for (const version of helperVersions) {
+    const helper = path.join(helperDirectory, `beam-input-helper-${version}`);
+    fs.writeFileSync(helper, '#!/bin/sh\nprintf "%s %s" "${0##*/}" "$1" > "$MARKER"\n');
     fs.chmodSync(helper, 0o755);
   }
   const script = path.join(directory, 'after-install.sh');
@@ -40,16 +40,29 @@ function withTempDirectory(callback) {
 
 test('after-install runs the versioned input helper install', { skip: process.platform === 'win32' }, () => {
   withTempDirectory((directory) => {
-    const result = runAfterInstall(directory, true);
+    const result = runAfterInstall(directory, ['1.2.3']);
 
     assert.equal(result.status, 0, result.stderr);
-    assert.equal(fs.readFileSync(path.join(directory, 'called'), 'utf8'), 'install');
+    assert.equal(fs.readFileSync(path.join(directory, 'called'), 'utf8'), 'beam-input-helper-1.2.3 install');
   });
 });
 
+test(
+  'after-install selects the newest helper while RPM versions coexist',
+  { skip: process.platform === 'win32' },
+  () => {
+    withTempDirectory((directory) => {
+      const result = runAfterInstall(directory, ['1.2.3', '1.2.4', '1.10.0']);
+
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(fs.readFileSync(path.join(directory, 'called'), 'utf8'), 'beam-input-helper-1.10.0 install');
+    });
+  },
+);
+
 test('after-install fails when no input helper is packaged', { skip: process.platform === 'win32' }, () => {
   withTempDirectory((directory) => {
-    const result = runAfterInstall(directory, false);
+    const result = runAfterInstall(directory, []);
 
     assert.equal(result.status, 1);
     assert.match(result.stderr, /Beam input helper was not found/);


### PR DESCRIPTION
## Summary

- select the newest packaged Linux input helper during package installation
- avoid reinstalling a stale helper while old and new RPM versions temporarily coexist
- add a focused post-install regression test covering semantic version ordering

## Root cause

During an RPM upgrade, resources from the previous and incoming Beam packages can coexist while the new package post-install script runs. The script stopped after the first beam-input-helper glob match, which could be the old helper. Beam then detected a helper/policy revision mismatch, retried installation through Polkit, and kept interaction recording blocked when that authorization did not complete.

## User impact

A subsequent package update now installs the newest bundled helper and repairs systems left with a stale system input helper, allowing keyboard-shortcut and click recording to be enabled again.

## Validation

- node --test test/linux-postinst.test.cjs test/linux-package-icon.test.cjs
- npx oxfmt --check test/linux-postinst.test.cjs test/linux-package-icon.test.cjs
- sh -n build/linux/after-install.sh
- git diff --check