### PR TITLE
Stop recordings when screen sharing ends

### DIFF
--- a/electron/capture/capture-ipc.cjs
+++ b/electron/capture/capture-ipc.cjs
@@ -148,7 +148,15 @@ function registerCaptureIpc({
     if (command === 'stop-native-recording') {
       if (deferredStoppedSession)
         throw new Error('A native recording is already waiting for its sidecar tracks to finish.');
-      deferredStoppedSession = await requestEngine('stop');
+      try {
+        deferredStoppedSession = await requestEngine('stop');
+      } catch (error) {
+        // A source can disappear before native finalization. The engine still
+        // writes the completed manifest, so keep that partial recording usable.
+        const status = await requestEngine('status').catch(() => null);
+        if (status?.state !== 'completed' || !status.manifestPath) throw error;
+        deferredStoppedSession = status;
+      }
       return withProjectId(deferredStoppedSession);
     }
     if (command === 'complete-native-recording') {

--- a/packages/capture/src/bin/capture-engine.rs
+++ b/packages/capture/src/bin/capture-engine.rs
@@ -196,6 +196,7 @@ fn handle(request: RequestEnvelope, engine: &mut Engine) -> ResponseEnvelope {
             "sessionId": engine.session.as_ref().map(RecordingSession::session_id),
             "manifestPath": engine.session.as_ref().map(RecordingSession::manifest_path),
             "systemAudioLevel": engine.session.as_ref().and_then(RecordingSession::system_audio_level),
+            "screenAvailable": engine.session.as_ref().map_or(true, RecordingSession::screen_available),
         })),
         Command::StartSystemAudioPreview => {
             if !matches!(

--- a/packages/capture/src/bin/capture_engine_tests/mod.rs
+++ b/packages/capture/src/bin/capture_engine_tests/mod.rs
@@ -1,9 +1,32 @@
 use capture::{
     catalog::CatalogSnapshot,
     model::{CaptureCapabilities, PermissionSnapshot},
+    protocol::{Command, RequestEnvelope},
 };
 
-use super::{Engine, prepare_snapshot};
+use super::{Engine, handle, prepare_snapshot};
+
+#[test]
+fn idle_status_reports_screen_available() {
+    let mut engine = Engine::default();
+    let response = handle(
+        RequestEnvelope {
+            id: "status-idle".into(),
+            command: Command::Status,
+        },
+        &mut engine,
+    );
+
+    assert!(response.ok);
+    assert_eq!(
+        response
+            .result
+            .as_ref()
+            .and_then(|result| result.get("screenAvailable"))
+            .and_then(serde_json::Value::as_bool),
+        Some(true)
+    );
+}
 
 #[cfg(target_os = "linux")]
 #[test]

--- a/packages/capture/src/screen/linux/pipewire/thread.rs
+++ b/packages/capture/src/screen/linux/pipewire/thread.rs
@@ -19,9 +19,9 @@ use crate::{
 
 use super::{
     CursorMessage, CursorState, ProcessState, SinkMessage, TimestampMapper, backpressure_event,
-    flush_pending_cursor, format_error, format_parameter, join, parse_format, pipewire_error,
-    process_buffer, send_ready_error, send_ready_ok, set_fatal, sink_error, sink_worker,
-    stream_error, take_fatal, update_buffer_params,
+    flush_pending_cursor, format_error, format_parameter, has_fatal, join, parse_format,
+    pipewire_error, process_buffer, send_ready_error, send_ready_ok, set_fatal, sink_error,
+    sink_worker, stream_error, take_fatal, update_buffer_params,
 };
 
 const PIPEWIRE_READY_TIMEOUT: Duration = Duration::from_secs(10);
@@ -215,6 +215,14 @@ impl PipewireCapture {
         worker_result?;
         sink_result?;
         take_fatal(&self.fatal)
+    }
+
+    pub(crate) fn is_available(&self) -> bool {
+        !has_fatal(&self.fatal)
+            && self
+                .thread
+                .as_ref()
+                .is_none_or(|thread| !thread.is_finished())
     }
 
     fn send(&self, command: PipewireCommand) -> Result<(), CaptureError> {

--- a/packages/capture/src/screen/linux/portal.rs
+++ b/packages/capture/src/screen/linux/portal.rs
@@ -39,6 +39,10 @@ impl PreparedPortal {
     pub(super) fn close(&mut self) -> Result<(), CaptureError> {
         self.control.close()
     }
+
+    pub(super) fn is_available(&self) -> bool {
+        self.control.is_available()
+    }
 }
 
 enum PortalCommand {
@@ -70,6 +74,12 @@ impl PortalControl {
                 )
             })?
         })
+    }
+
+    fn is_available(&self) -> bool {
+        self.thread
+            .as_ref()
+            .is_none_or(|thread| !thread.is_finished())
     }
 }
 

--- a/packages/capture/src/screen/linux/recording.rs
+++ b/packages/capture/src/screen/linux/recording.rs
@@ -154,6 +154,16 @@ impl LinuxRecording {
         pipewire_result.and(portal_result)
     }
 
+    pub fn is_available(&self) -> bool {
+        self.portal
+            .as_ref()
+            .is_none_or(PreparedPortal::is_available)
+            && self
+                .pipewire
+                .as_ref()
+                .is_none_or(PipewireCapture::is_available)
+    }
+
     #[must_use]
     pub fn metrics(&self) -> Arc<ScreenCaptureMetrics> {
         self.metrics.clone()

--- a/packages/capture/src/screen/mac/capture.rs
+++ b/packages/capture/src/screen/mac/capture.rs
@@ -1,4 +1,10 @@
-use std::{path::Path, sync::Arc};
+use std::{
+    path::Path,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+};
 
 use screencapturekit::{
     cm::CMTime,
@@ -8,8 +14,8 @@ use screencapturekit::{
     },
     shareable_content::SCShareableContent,
     stream::{
-        SCStream, configuration::SCStreamConfiguration, content_filter::SCContentFilter,
-        output_type::SCStreamOutputType,
+        SCStream, StreamCallbacks, configuration::SCStreamConfiguration,
+        content_filter::SCContentFilter, output_type::SCStreamOutputType,
     },
 };
 
@@ -26,6 +32,7 @@ pub struct MacRecording {
     output: std::path::PathBuf,
     frame_handler: usize,
     metrics: Arc<ScreenCaptureMetrics>,
+    unavailable: Arc<AtomicBool>,
 }
 
 impl MacRecording {
@@ -89,9 +96,15 @@ impl MacRecording {
             )
         })?;
         let metrics = Arc::new(ScreenCaptureMetrics::default());
+        let unavailable = Arc::new(AtomicBool::new(false));
         let callback_metrics = metrics.clone();
         let callback_gate = start_gate;
-        let mut stream = SCStream::new(&filter, &configuration);
+        let error_unavailable = unavailable.clone();
+        let inactive_unavailable = unavailable.clone();
+        let delegate = StreamCallbacks::new()
+            .on_error(move |_| error_unavailable.store(true, Ordering::Release))
+            .on_inactive(move || inactive_unavailable.store(true, Ordering::Release));
+        let mut stream = SCStream::new_with_delegate(&filter, &configuration, delegate);
         let frame_handler = stream
             .add_output_handler(
                 move |_, _| {
@@ -116,6 +129,7 @@ impl MacRecording {
             output: output.to_owned(),
             frame_handler,
             metrics,
+            unavailable,
         })
     }
 
@@ -126,6 +140,11 @@ impl MacRecording {
     #[must_use]
     pub fn recorded_file_size(&self) -> i64 {
         self.recording.recorded_file_size()
+    }
+
+    #[must_use]
+    pub fn is_available(&self) -> bool {
+        !self.unavailable.load(Ordering::Acquire)
     }
 
     #[must_use]

--- a/packages/capture/src/screen/recording.rs
+++ b/packages/capture/src/screen/recording.rs
@@ -253,4 +253,16 @@ impl ScreenRecording {
             PlatformScreenRecording::Linux(recording) => recording.stop(),
         }
     }
+
+    #[must_use]
+    pub fn is_available(&self) -> bool {
+        match &self.backend {
+            #[cfg(windows)]
+            PlatformScreenRecording::Windows(recording) => recording.is_available(),
+            #[cfg(target_os = "macos")]
+            PlatformScreenRecording::Mac(recording) => recording.is_available(),
+            #[cfg(target_os = "linux")]
+            PlatformScreenRecording::Linux(recording) => recording.is_available(),
+        }
+    }
 }

--- a/packages/capture/src/screen/win/capture.rs
+++ b/packages/capture/src/screen/win/capture.rs
@@ -1,7 +1,10 @@
 use std::{
     ffi::c_void,
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
 };
 
 use parking_lot::Mutex;
@@ -39,6 +42,7 @@ struct HandlerFlags {
     metrics: Arc<ScreenCaptureMetrics>,
     start_gate: Arc<StartGate>,
     crop: Option<PixelCrop>,
+    unavailable: Arc<AtomicBool>,
 }
 
 struct CaptureHandler {
@@ -46,6 +50,7 @@ struct CaptureHandler {
     metrics: Arc<ScreenCaptureMetrics>,
     start_gate: Arc<StartGate>,
     crop: Option<PixelCrop>,
+    unavailable: Arc<AtomicBool>,
 }
 
 impl CaptureHandler {
@@ -81,6 +86,7 @@ impl GraphicsCaptureApiHandler for CaptureHandler {
             metrics: flags.metrics,
             start_gate: flags.start_gate,
             crop: flags.crop,
+            unavailable: flags.unavailable,
         })
     }
 
@@ -127,6 +133,7 @@ impl GraphicsCaptureApiHandler for CaptureHandler {
     }
 
     fn on_closed(&mut self) -> Result<(), Self::Error> {
+        self.unavailable.store(true, Ordering::Release);
         self.finish().map_err(|error| error.to_string())
     }
 }
@@ -149,6 +156,7 @@ pub struct WindowsRecording {
     callback: Arc<Mutex<CaptureHandler>>,
     metrics: Arc<ScreenCaptureMetrics>,
     output: PathBuf,
+    unavailable: Arc<AtomicBool>,
 }
 
 impl WindowsRecording {
@@ -272,6 +280,10 @@ impl WindowsRecording {
         result
     }
 
+    pub fn is_available(&self) -> bool {
+        !self.unavailable.load(Ordering::Acquire)
+    }
+
     #[must_use]
     pub fn metrics(&self) -> Arc<ScreenCaptureMetrics> {
         self.metrics.clone()
@@ -311,6 +323,7 @@ where
         start_gate,
     } = config;
     let metrics = Arc::new(ScreenCaptureMetrics::default());
+    let unavailable = Arc::new(AtomicBool::new(false));
     let crop = region
         .map(|region| normalize_crop(region, size.0, size.1))
         .transpose()?;
@@ -331,6 +344,7 @@ where
         metrics: metrics.clone(),
         start_gate,
         crop,
+        unavailable: unavailable.clone(),
     };
     let compatibility = compatible_settings(exclude_cursor, fps);
     let settings = Settings::new(
@@ -350,6 +364,7 @@ where
         callback,
         metrics,
         output: output.to_owned(),
+        unavailable,
     })
 }
 

--- a/packages/capture/src/session/recording.rs
+++ b/packages/capture/src/session/recording.rs
@@ -134,6 +134,11 @@ impl RecordingSession {
         self.active.system_audio_level()
     }
 
+    #[must_use]
+    pub fn screen_available(&self) -> bool {
+        self.active.screen_available()
+    }
+
     pub fn start(&mut self) -> Result<(), CaptureError> {
         if self.state != super::SessionState::Armed {
             return Err(invalid_transition(self.state, "Recording"));

--- a/packages/capture/src/session/recording_active.rs
+++ b/packages/capture/src/session/recording_active.rs
@@ -42,6 +42,12 @@ impl ActiveRecordings {
         self.screen.is_some()
     }
 
+    pub(super) fn screen_available(&self) -> bool {
+        self.screen
+            .as_ref()
+            .is_none_or(crate::screen::ScreenRecording::is_available)
+    }
+
     pub(super) fn system_audio_level(&self) -> Option<f32> {
         self.system_audio
             .as_ref()

--- a/src/api/types/capture-session.ts
+++ b/src/api/types/capture-session.ts
@@ -19,6 +19,7 @@ export interface CaptureSession {
   manifestPath?: string | null;
   videoSrc?: string | null;
   systemAudioLevel?: number | null;
+  screenAvailable?: boolean;
 }
 
 export interface CaptureProject {

--- a/src/components/hud/recorder/useDeviceToggles.ts
+++ b/src/components/hud/recorder/useDeviceToggles.ts
@@ -143,14 +143,15 @@ export function useDeviceToggles(ctx: DeviceToggleContext) {
     }
     try {
       const nextSystemAudio = await BrowserSystemAudioRecorder.request();
+      ctx.setSystemAudio(nextSystemAudio);
       ctx.registerSystemAudioRecorder(nextSystemAudio);
       try {
         await nextSystemAudio.start(sessionId);
       } catch (reason) {
+        ctx.setSystemAudio(null);
         await stopRecorder(nextSystemAudio);
         throw reason;
       }
-      ctx.setSystemAudio(nextSystemAudio);
       ctx.setSystemAudioEnabled(true);
     } catch (reason) {
       setToggleError(reason);

--- a/src/components/hud/recorder/useDeviceToggles.ts
+++ b/src/components/hud/recorder/useDeviceToggles.ts
@@ -26,6 +26,7 @@ export interface DeviceToggleContext {
   setMicrophone(recorder: BrowserMicrophoneRecorder | null): void;
   getSystemAudio(): BrowserSystemAudioRecorder | null;
   setSystemAudio(recorder: BrowserSystemAudioRecorder | null): void;
+  registerSystemAudioRecorder(recorder: BrowserSystemAudioRecorder): void;
   setCameraEnabled(enabled: boolean): void;
   setMicrophoneEnabled(enabled: boolean): void;
   setSystemAudioEnabled(enabled: boolean): void;
@@ -142,6 +143,7 @@ export function useDeviceToggles(ctx: DeviceToggleContext) {
     }
     try {
       const nextSystemAudio = await BrowserSystemAudioRecorder.request();
+      ctx.registerSystemAudioRecorder(nextSystemAudio);
       try {
         await nextSystemAudio.start(sessionId);
       } catch (reason) {

--- a/src/components/hud/recorder/useRecordingController.test.ts
+++ b/src/components/hud/recorder/useRecordingController.test.ts
@@ -3,6 +3,7 @@ import type { RecordingConfiguration } from './recording-types';
 
 const mocks = vi.hoisted(() => {
   const makeRecorder = () => ({
+    onFatal: vi.fn(),
     start: vi.fn(async () => undefined),
     stop: vi.fn(async () => undefined),
     pause: vi.fn(async () => undefined),
@@ -27,6 +28,7 @@ const mocks = vi.hoisted(() => {
       stop: vi.fn(async () => ({ sessionId: 'session-1' })),
       stopNativeRecording: vi.fn(async () => ({ sessionId: 'session-1' })),
       completeNativeRecording: vi.fn(async () => ({ sessionId: 'session-1', videoSrc: 'file:///v.mp4' })),
+      status: vi.fn(async () => ({ state: 'recording', screenAvailable: true })),
       pause: vi.fn(async () => ({ sessionId: 'session-1' })),
       resume: vi.fn(async () => ({ sessionId: 'session-1' })),
       setTeleprompterSession: vi.fn(),

--- a/src/components/hud/recorder/useRecordingController.ts
+++ b/src/components/hud/recorder/useRecordingController.ts
@@ -4,6 +4,7 @@ import { BrowserCameraRecorder, isCameraUnavailableError } from '../../../api/ca
 import { BrowserMicrophoneRecorder } from '../../../api/microphone-recorder';
 import { BrowserSystemAudioRecorder } from '../../../api/system-audio-recorder';
 import { useDeviceToggles } from './useDeviceToggles';
+import { useRecordingHealth } from './useRecordingHealth';
 import { useNativeSystemAudioLevel } from './useNativeSystemAudioLevel';
 import { recordingCameraMetadata } from './recording-camera-metadata';
 import { formatRecordingTime, isRecordingActivePhase } from './recording-types';
@@ -18,6 +19,7 @@ import type {
 
 type Recorder = BrowserCameraRecorder | BrowserMicrophoneRecorder | BrowserSystemAudioRecorder;
 type SidecarKind = 'camera' | 'microphone' | 'systemAudio';
+type SidecarStates = Record<SidecarKind, StartupSidecarState>;
 const inactiveCamera = 'off';
 const inactiveMicrophone = 'no-audio';
 export function useRecordingController(
@@ -54,12 +56,8 @@ export function useRecordingController(
   let nativeStarted = false;
   let cancelling = false;
   let nativeCleanupBlocked = false;
-  const sidecarStates: Record<SidecarKind, StartupSidecarState> = {
-    camera: 'disabled',
-    microphone: 'disabled',
-    systemAudio: 'disabled',
-  };
-
+  const sidecarStates = { camera: 'disabled', microphone: 'disabled', systemAudio: 'disabled' } as SidecarStates;
+  const recordingHealth = useRecordingHealth(phase, error, () => systemAudio, cancel, stop);
   const deviceToggles = useDeviceToggles({
     getConfiguration: () => configuration,
     setConfigurationCameraId: (id) => {
@@ -82,6 +80,7 @@ export function useRecordingController(
     setSystemAudio: (recorder) => {
       systemAudio = recorder;
     },
+    registerSystemAudioRecorder: recordingHealth.registerSystemAudioRecorder,
     setCameraEnabled: (enabled) => {
       cameraEnabled.value = enabled;
     },
@@ -97,7 +96,6 @@ export function useRecordingController(
     },
     cameraMetadata: recordingCameraMetadata,
   });
-
   const isActive = computed(() => isRecordingActivePhase(phase.value));
   const cleanupStaleNativeStart = async (session: { sessionId?: string | null }) => {
     try {
@@ -132,7 +130,6 @@ export function useRecordingController(
   const stopRecorderStrict = async (recorder: Recorder | null, endNs?: number) => {
     await recorder?.stop(endNs);
   };
-
   const prepareSources = async () => {
     if (!configuration) return;
     if (configuration.cameraId !== inactiveCamera) {
@@ -159,6 +156,7 @@ export function useRecordingController(
     if (configuration.systemAudio && !nativeSystemAudio) {
       try {
         systemAudio = await BrowserSystemAudioRecorder.request();
+        recordingHealth.registerSystemAudioRecorder(systemAudio);
         sidecarStates.systemAudio = 'prepared';
       } catch (reason) {
         sidecarStates.systemAudio = 'failed';
@@ -331,6 +329,7 @@ export function useRecordingController(
         capture.showScreenRegionOverlay({ ...next.regionOverlay, region: next.region });
       secondsRemaining.value = Math.max(0, next.countdownSeconds);
       phase.value = 'countdown';
+      recordingHealth.start();
       stage = 'prepare-native';
       const preparation = prewarmNativeRecording(generation);
       prewarm = preparation;
@@ -370,6 +369,7 @@ export function useRecordingController(
     await capture.setCountdown(null);
     capture.hideScreenRegionOverlay();
     clearTimer();
+    recordingHealth.reset();
     if (!sidecarsAlreadyStopped)
       await Promise.all([stopRecorder(camera), stopRecorder(microphone), stopRecorder(systemAudio)]);
     camera = null;
@@ -395,7 +395,7 @@ export function useRecordingController(
     phase.value = 'idle';
   };
 
-  const cancel = async () => {
+  async function cancel() {
     if (cancelling) return;
     cancelling = true;
     const nativeRecording = sessionId !== null;
@@ -417,9 +417,9 @@ export function useRecordingController(
     } finally {
       cancelling = false;
     }
-  };
+  }
 
-  const stop = async () => {
+  async function stop() {
     if (phase.value === 'countdown' || phase.value === 'starting') return cancel();
     if (phase.value !== 'recording' && phase.value !== 'paused') return;
     const wasRecording = phase.value === 'recording';
@@ -449,7 +449,7 @@ export function useRecordingController(
         startTimer();
       }
     }
-  };
+  }
 
   const togglePause = async () => {
     if (!sessionId) return;

--- a/src/components/hud/recorder/useRecordingHealth.ts
+++ b/src/components/hud/recorder/useRecordingHealth.ts
@@ -1,0 +1,63 @@
+import type { Ref } from 'vue';
+import { capture } from '../../../api/capture';
+import { BrowserSystemAudioRecorder } from '../../../api/system-audio-recorder';
+import { isRecordingActivePhase, type RecordingPhase } from './recording-types';
+
+export function useRecordingHealth(
+  phase: Ref<RecordingPhase>,
+  error: Ref<string>,
+  getRecorder: () => BrowserSystemAudioRecorder | null,
+  cancel: () => Promise<void>,
+  stop: () => Promise<void>,
+) {
+  let timer: number | null = null;
+  let polling = false;
+  let generation = 0;
+  let failureHandled = false;
+
+  const handleFailure = (message: string) => {
+    if (failureHandled || phase.value === 'idle' || phase.value === 'finalizing') return;
+    failureHandled = true;
+    error.value = message;
+    if (phase.value === 'countdown' || phase.value === 'starting') void cancel();
+    else if (phase.value === 'recording' || phase.value === 'paused') void stop();
+  };
+
+  const registerSystemAudioRecorder = (recorder: BrowserSystemAudioRecorder) => {
+    recorder.onFatal((reason) => {
+      if (getRecorder() === recorder) handleFailure(reason.message);
+    });
+  };
+
+  const check = async () => {
+    if (polling || !isRecordingActivePhase(phase.value)) return;
+    const currentGeneration = generation;
+    polling = true;
+    try {
+      const status = await capture.status();
+      if (currentGeneration !== generation) return;
+      if (status.screenAvailable === false) handleFailure('Screen sharing ended.');
+    } catch {
+      // A transient status failure must not interrupt an otherwise healthy recording.
+    } finally {
+      polling = false;
+    }
+  };
+
+  const start = () => {
+    if (timer !== null) return;
+    generation += 1;
+    failureHandled = false;
+    timer = window.setInterval(() => void check(), 250);
+    void check();
+  };
+
+  const reset = () => {
+    generation += 1;
+    if (timer !== null) window.clearInterval(timer);
+    timer = null;
+    failureHandled = false;
+  };
+
+  return { registerSystemAudioRecorder, start, reset };
+}

--- a/src/components/hud/tests/useRecordingControllerBranches.test.ts
+++ b/src/components/hud/tests/useRecordingControllerBranches.test.ts
@@ -16,6 +16,7 @@ const { capture, cameraApi, microphoneApi, systemApi } = vi.hoisted(() => ({
     cancelPreparedRecording: vi.fn(),
     discardRecording: vi.fn(),
     stop: vi.fn(),
+    status: vi.fn(),
     pause: vi.fn(),
     resume: vi.fn(),
     setTeleprompterSession: vi.fn(),
@@ -53,6 +54,7 @@ const configuration = (overrides: Partial<RecordingConfiguration> = {}): Recordi
 });
 
 const recorder = () => ({
+  onFatal: vi.fn(),
   start: vi.fn().mockResolvedValue(undefined),
   stop: vi.fn().mockResolvedValue(undefined),
   pause: vi.fn().mockResolvedValue(undefined),
@@ -86,6 +88,7 @@ beforeEach(() => {
   microphone = recorder();
   systemAudio = recorder();
   vi.clearAllMocks();
+  capture.status.mockReset();
   capture.getCameraOverlayState.mockResolvedValue({
     shadowSize: 'md',
     cornerRadius: 'lg',
@@ -143,6 +146,28 @@ describe('useRecordingController branch behavior', () => {
     await controller.toggleSystemAudio();
     expect(systemApi.request).not.toHaveBeenCalled();
     expect(controller.error.value).toBe('System audio on Linux must be selected before recording starts.');
+  });
+
+  it('stops and completes when native screen sharing becomes unavailable', async () => {
+    capture.platform = 'linux';
+    const complete = vi.fn();
+    const controller = useRecordingController(complete);
+
+    await controller.start(configuration({ systemAudio: true }));
+    await waitForRecording(controller);
+    capture.status.mockResolvedValue({
+      state: 'recording',
+      screenAvailable: false,
+    });
+
+    await vi.advanceTimersByTimeAsync(300);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(capture.stopNativeRecording).toHaveBeenCalledOnce();
+    expect(capture.completeNativeRecording).toHaveBeenCalledOnce();
+    expect(complete).toHaveBeenCalledWith(expect.objectContaining({ sessionId: 'session-1' }));
+    expect(controller.phase.value).toBe('idle');
   });
 
   it('starts sidecars, tracks elapsed time, pauses/resumes, and completes', async () => {

--- a/test/capture-ipc.test.cjs
+++ b/test/capture-ipc.test.cjs
@@ -54,6 +54,61 @@ test('stops native capture before completing sidecar tracks', async () => {
   fs.rmSync(root, { recursive: true, force: true });
 });
 
+test('recovers a completed partial native session after stop rejects', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'beam-capture-ipc-'));
+  const manifestPath = path.join(root, 'manifest.json');
+  fs.mkdirSync(path.join(root, 'screen'));
+  fs.writeFileSync(manifestPath, JSON.stringify({ projectId: 'project-partial' }));
+  fs.writeFileSync(path.join(root, 'screen', 'primary.mp4'), Buffer.from([1]));
+
+  try {
+    const handlers = new Map();
+    const requests = [];
+    let completeCalls = 0;
+    const session = { state: 'completed', sessionId: 'session-partial', manifestPath };
+    const ipcMain = { handle: (channel, handler) => handlers.set(channel, handler) };
+    const captureEngine = {
+      request: async (command) => {
+        requests.push(command);
+        if (command === 'stop') throw new Error('native source disappeared');
+        if (command === 'status') return session;
+        throw new Error(`unexpected capture command: ${command}`);
+      },
+    };
+    const storage = {
+      registerSession: () => undefined,
+      complete: (value) => {
+        completeCalls += 1;
+        return value;
+      },
+    };
+
+    registerCaptureIpc({
+      ipcMain,
+      desktopCapturer: {},
+      screen: {},
+      captureEngine,
+      app: {},
+      userPaths: { projects: root },
+      trackStorages: [storage],
+    });
+    const request = handlers.get('capture:request');
+
+    const stopped = await request({}, 'stop-native-recording');
+    assert.equal(stopped.state, 'completed');
+    assert.equal(stopped.sessionId, 'session-partial');
+    assert.equal(stopped.manifestPath, manifestPath);
+    assert.equal(stopped.projectId, 'project-partial');
+    assert.deepEqual(requests, ['stop', 'status']);
+
+    const completed = await request({}, 'complete-native-recording');
+    assert.equal(completeCalls, 1);
+    assert.match(completed.videoSrc, /primary\.mp4$/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test('resolves display bounds by native display id without relying on desktop previews', async () => {
   const handlers = new Map();
   let previewCalls = 0;


### PR DESCRIPTION
Stops and finalizes recordings when desktop screen sharing ends or is canceled on Linux, Windows, and macOS. Preserves partial recordings and handles toolbar system-audio sharing loss.

Fixes: #48 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added monitoring for screen-sharing availability during active recordings.
  * Capture status now reports whether screen sharing remains available.
  * Recordings now respond appropriately when screen capture or system audio becomes unavailable.

* **Bug Fixes**
  * Improved recording completion when native capture stops unexpectedly.
  * Completed recordings can now be recovered when stopping encounters an error.
  * Added safeguards for transient capture-status failures and confirmed session completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->