### PR TITLE
Fix AppImage interaction permission helper

### DIFF
--- a/packages/capture/src/bin/beam-input-helper.rs
+++ b/packages/capture/src/bin/beam-input-helper.rs
@@ -3,13 +3,16 @@
 mod input_motion;
 
 #[cfg(target_os = "linux")]
+#[path = "beam_input_helper/install.rs"]
+mod input_install;
+
+#[cfg(target_os = "linux")]
 mod linux {
     use std::{
         collections::{HashMap, HashSet},
         fs,
         io::{self, BufWriter, Write},
-        os::unix::fs::PermissionsExt,
-        path::{Path, PathBuf},
+        path::PathBuf,
         thread,
         time::Duration,
     };
@@ -18,13 +21,13 @@ mod linux {
     use evdev::{Device, EventSummary, KeyCode, SynchronizationCode};
     use serde::Serialize;
 
-    use super::input_motion::MotionAccumulator;
+    use super::{
+        input_install::{INSTALLED_HELPER, INSTALLED_POLICY, install_assets},
+        input_motion::MotionAccumulator,
+    };
 
     const POLL_INTERVAL: Duration = Duration::from_millis(4);
-    const INSTALLED_HELPER: &str = "/usr/libexec/beam-input-helper";
-    const INSTALLED_POLICY: &str = "/usr/share/polkit-1/actions/com.beam.input-monitor.policy";
     const POLICY_VERSION: u32 = 5;
-    const POLICY: &str = include_str!("beam-input-helper.policy");
 
     #[derive(Serialize)]
     #[serde(rename_all = "camelCase")]
@@ -194,13 +197,6 @@ mod linux {
         stream()
     }
 
-    fn install_assets() -> Result<(), Box<dyn std::error::Error>> {
-        let source = std::env::current_exe()?;
-        install_file(&source, Path::new(INSTALLED_HELPER), 0o755)?;
-        install_bytes(POLICY.as_bytes(), Path::new(INSTALLED_POLICY), 0o644)?;
-        Ok(())
-    }
-
     fn uninstall() -> Result<(), Box<dyn std::error::Error>> {
         require_privileged()?;
         for path in [INSTALLED_POLICY, INSTALLED_HELPER] {
@@ -211,38 +207,6 @@ mod linux {
             }
         }
         write_json(&serde_json::json!({ "installed": false }))
-    }
-
-    fn install_file(
-        source: &Path,
-        destination: &Path,
-        mode: u32,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        let bytes = fs::read(source)?;
-        install_bytes(&bytes, destination, mode)
-    }
-
-    fn install_bytes(
-        bytes: &[u8],
-        destination: &Path,
-        mode: u32,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        let parent = destination
-            .parent()
-            .ok_or("system helper destination has no parent directory")?;
-        fs::create_dir_all(parent)?;
-        let temporary = parent.join(format!(
-            ".{}.{}.tmp",
-            destination
-                .file_name()
-                .and_then(|name| name.to_str())
-                .unwrap_or("beam-input-helper"),
-            std::process::id()
-        ));
-        fs::write(&temporary, bytes)?;
-        fs::set_permissions(&temporary, fs::Permissions::from_mode(mode))?;
-        fs::rename(temporary, destination)?;
-        Ok(())
     }
 
     fn require_privileged() -> Result<(), Box<dyn std::error::Error>> {

--- a/packages/capture/src/bin/beam_input_helper/install.rs
+++ b/packages/capture/src/bin/beam_input_helper/install.rs
@@ -1,0 +1,49 @@
+use std::{fs, os::unix::fs::PermissionsExt, path::Path};
+
+pub(super) const INSTALLED_HELPER: &str = "/usr/libexec/beam-input-helper";
+pub(super) const INSTALLED_POLICY: &str =
+    "/usr/share/polkit-1/actions/com.beam.input-monitor.policy";
+const POLICY: &str = include_str!("../beam-input-helper.policy");
+
+pub(super) fn install_assets() -> Result<(), Box<dyn std::error::Error>> {
+    // `/proc/self/exe` remains readable when this process was started from a
+    // sealed memfd; `current_exe()` resolves to a non-openable
+    // `/memfd:... (deleted)` target in that case.
+    install_file(
+        Path::new("/proc/self/exe"),
+        Path::new(INSTALLED_HELPER),
+        0o755,
+    )?;
+    install_bytes(POLICY.as_bytes(), Path::new(INSTALLED_POLICY), 0o644)
+}
+
+fn install_file(
+    source: &Path,
+    destination: &Path,
+    mode: u32,
+) -> Result<(), Box<dyn std::error::Error>> {
+    install_bytes(&fs::read(source)?, destination, mode)
+}
+
+fn install_bytes(
+    bytes: &[u8],
+    destination: &Path,
+    mode: u32,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let parent = destination
+        .parent()
+        .ok_or("system helper destination has no parent directory")?;
+    fs::create_dir_all(parent)?;
+    let temporary = parent.join(format!(
+        ".{}.{}.tmp",
+        destination
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("beam-input-helper"),
+        std::process::id()
+    ));
+    fs::write(&temporary, bytes)?;
+    fs::set_permissions(&temporary, fs::Permissions::from_mode(mode))?;
+    fs::rename(temporary, destination)?;
+    Ok(())
+}

--- a/packages/capture/src/screen/linux/input_monitor.rs
+++ b/packages/capture/src/screen/linux/input_monitor.rs
@@ -1,6 +1,11 @@
 use std::{
     collections::VecDeque,
+    fs::{self, File, OpenOptions},
     io::{BufRead, BufReader},
+    os::{
+        fd::{AsRawFd, FromRawFd},
+        unix::fs::{OpenOptionsExt, PermissionsExt},
+    },
     path::{Path, PathBuf},
     process::{Child, Command, Stdio},
     sync::{
@@ -19,6 +24,11 @@ use super::owned_child;
 
 const INSTALLED_HELPER: &str = "/usr/libexec/beam-input-helper";
 pub(super) const INPUT_QUEUE_CAPACITY: usize = 4_096;
+
+pub(super) struct ElevatedHelperExecutable {
+    path: PathBuf,
+    _sealed_file: Option<File>,
+}
 
 pub(super) struct InputEventQueue {
     pub(super) events: VecDeque<NativeInputEvent>,
@@ -149,7 +159,7 @@ pub fn request_linux_input_access() -> Result<InputAccessStatus, CaptureError> {
 
     let mut command = Command::new("pkexec");
     command
-        .arg(helper)
+        .arg(helper.path())
         .arg(helper_command)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
@@ -182,6 +192,9 @@ pub fn request_linux_input_access() -> Result<InputAccessStatus, CaptureError> {
         }
         Ok(_) => {}
     }
+    // The sealed memfd must outlive Polkit authentication and the helper's
+    // exec. A readiness line proves the privileged process has started.
+    drop(helper);
     let ready: serde_json::Value = match serde_json::from_str(&ready_line) {
         Ok(ready) => ready,
         Err(error) => {
@@ -337,17 +350,100 @@ fn bundled_input_helper_path() -> Option<PathBuf> {
         .filter(|path| executable_file(path))
 }
 
-fn helper_launch() -> Result<(PathBuf, &'static str), CaptureError> {
+fn helper_launch() -> Result<(ElevatedHelperExecutable, &'static str), CaptureError> {
     let installed = PathBuf::from(INSTALLED_HELPER);
     if let Some(bundled) = bundled_input_helper_path()
         && bundled != installed
         && (!executable_file(&installed) || helper_version(&bundled) != helper_version(&installed))
     {
-        return Ok((bundled, "install-stream"));
+        // AppImage resources live on a user-mounted FUSE filesystem that the
+        // privileged pkexec child cannot traverse. Copy it into an immutable,
+        // sealed memory file that remains open until pkexec starts the helper.
+        return Ok((
+            ElevatedHelperExecutable::from_bundled(&bundled)?,
+            "install-stream",
+        ));
     }
     executable_file(&installed)
-        .then_some((installed, "stream"))
+        .then_some((ElevatedHelperExecutable::installed(installed), "stream"))
         .ok_or_else(|| CaptureError::Unsupported("Beam input helper is not installed".into()))
+}
+
+impl ElevatedHelperExecutable {
+    fn installed(path: PathBuf) -> Self {
+        Self {
+            path,
+            _sealed_file: None,
+        }
+    }
+
+    pub(super) fn from_bundled(source: &Path) -> Result<Self, CaptureError> {
+        let mut input = OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_NOFOLLOW)
+            .open(source)
+            .map_err(|error| CaptureError::storage(source, error))?;
+        if !input
+            .metadata()
+            .map_err(|error| CaptureError::storage(source, error))?
+            .is_file()
+        {
+            return Err(CaptureError::InvalidConfiguration(format!(
+                "input helper is not a regular file: {}",
+                source.display()
+            )));
+        }
+
+        // SAFETY: the C string is static and valid; memfd_create returns a new
+        // owned descriptor or -1 without aliasing any Rust-managed resource.
+        let descriptor = unsafe {
+            libc::memfd_create(
+                c"beam-input-helper".as_ptr(),
+                libc::MFD_CLOEXEC | libc::MFD_ALLOW_SEALING,
+            )
+        };
+        if descriptor < 0 {
+            return Err(CaptureError::Backend(format!(
+                "input helper memory file could not be created: {}",
+                std::io::Error::last_os_error()
+            )));
+        }
+        // SAFETY: descriptor was freshly returned by memfd_create and ownership
+        // is transferred exactly once to File, which closes it on every exit.
+        let mut sealed_file = unsafe { File::from_raw_fd(descriptor) };
+        std::io::copy(&mut input, &mut sealed_file)
+            .and_then(|_| sealed_file.sync_all())
+            .map_err(|error| CaptureError::storage(source, error))?;
+        // SAFETY: fchmod only mutates the mode of this owned descriptor.
+        if unsafe { libc::fchmod(sealed_file.as_raw_fd(), 0o500) } != 0 {
+            return Err(CaptureError::Backend(format!(
+                "input helper memory permissions could not be set: {}",
+                std::io::Error::last_os_error()
+            )));
+        }
+        let seals =
+            libc::F_SEAL_SEAL | libc::F_SEAL_SHRINK | libc::F_SEAL_GROW | libc::F_SEAL_WRITE;
+        // SAFETY: fcntl applies immutable seals to this owned memfd descriptor.
+        if unsafe { libc::fcntl(sealed_file.as_raw_fd(), libc::F_ADD_SEALS, seals) } != 0 {
+            return Err(CaptureError::Backend(format!(
+                "input helper memory file could not be sealed: {}",
+                std::io::Error::last_os_error()
+            )));
+        }
+        let path = PathBuf::from(format!(
+            "/proc/{}/fd/{}",
+            std::process::id(),
+            sealed_file.as_raw_fd()
+        ));
+        Ok(Self {
+            path,
+            _sealed_file: Some(sealed_file),
+        })
+    }
+
+    pub(super) fn path(&self) -> &Path {
+        &self.path
+    }
 }
 
 fn helper_version(path: &Path) -> Option<(String, u64)> {
@@ -370,9 +466,7 @@ pub(super) fn parse_helper_version(output: &[u8]) -> Option<(String, u64)> {
 }
 
 fn executable_file(path: &Path) -> bool {
-    use std::os::unix::fs::PermissionsExt;
-
-    std::fs::metadata(path)
+    fs::metadata(path)
         .is_ok_and(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
 }
 

--- a/packages/capture/src/screen/linux/input_monitor_tests.rs
+++ b/packages/capture/src/screen/linux/input_monitor_tests.rs
@@ -1,8 +1,128 @@
 #![allow(clippy::expect_used)]
 
+use std::{
+    fs,
+    os::unix::fs::{PermissionsExt, symlink},
+    path::Path,
+    process::Command,
+};
+
 use crate::input::{InputKey, NativeInputEvent};
 
-use super::input_monitor::{INPUT_QUEUE_CAPACITY, InputEventQueue, parse_helper_version};
+use super::input_monitor::{
+    ElevatedHelperExecutable, INPUT_QUEUE_CAPACITY, InputEventQueue, parse_helper_version,
+};
+
+fn write_executable(path: &Path, contents: &[u8]) {
+    fs::write(path, contents).expect("write helper fixture");
+    let mut permissions = fs::metadata(path)
+        .expect("helper fixture metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).expect("make helper fixture executable");
+}
+
+#[test]
+fn from_bundled_preserves_exact_bytes_through_a_proc_fd_path() {
+    let _lock = super::owned_child::test_lock();
+    let temporary = tempfile::tempdir().expect("temporary helper directory");
+    let source = temporary.path().join("beam-input-helper-from-appimage");
+    let contents = b"appimage helper bytes\0with a non-text suffix";
+    write_executable(&source, contents);
+
+    let helper = ElevatedHelperExecutable::from_bundled(&source).expect("create helper");
+
+    assert_ne!(helper.path(), source.as_path());
+    assert!(helper.path().starts_with("/proc/"));
+    assert!(helper.path().to_string_lossy().contains("/fd/"));
+    assert_eq!(
+        fs::read(helper.path()).expect("read helper through proc fd"),
+        contents
+    );
+}
+
+#[test]
+fn from_bundled_rejects_a_symlink_source() {
+    let _lock = super::owned_child::test_lock();
+    let temporary = tempfile::tempdir().expect("temporary helper directory");
+    let target = temporary.path().join("real-helper");
+    write_executable(&target, b"real helper");
+    let source_link = temporary.path().join("beam-input-helper-link");
+    symlink(&target, &source_link).expect("create source symlink");
+
+    assert!(ElevatedHelperExecutable::from_bundled(&source_link).is_err());
+    assert!(
+        fs::symlink_metadata(&source_link)
+            .expect("source symlink metadata")
+            .file_type()
+            .is_symlink()
+    );
+}
+
+#[test]
+fn from_bundled_rejects_missing_and_non_regular_sources() {
+    let _lock = super::owned_child::test_lock();
+    let temporary = tempfile::tempdir().expect("temporary helper directory");
+    let missing_source = temporary.path().join("missing-helper");
+    assert!(ElevatedHelperExecutable::from_bundled(&missing_source).is_err());
+
+    let source_directory = temporary.path().join("source-directory");
+    fs::create_dir(&source_directory).expect("create source directory");
+    assert!(ElevatedHelperExecutable::from_bundled(&source_directory).is_err());
+}
+
+#[test]
+fn from_bundled_memfd_is_sealed_against_writes() {
+    let _lock = super::owned_child::test_lock();
+    let temporary = tempfile::tempdir().expect("temporary helper directory");
+    let source = temporary.path().join("beam-input-helper-from-appimage");
+    let contents = b"immutable helper payload";
+    write_executable(&source, contents);
+
+    let helper = ElevatedHelperExecutable::from_bundled(&source).expect("create helper");
+
+    assert!(
+        fs::OpenOptions::new()
+            .write(true)
+            .open(helper.path())
+            .is_err()
+    );
+    assert_eq!(
+        fs::read(helper.path()).expect("read sealed helper"),
+        contents
+    );
+}
+
+#[test]
+fn from_bundled_memfd_remains_executable_through_its_proc_path() {
+    let _lock = super::owned_child::test_lock();
+    let temporary = tempfile::tempdir().expect("temporary helper directory");
+    let source = temporary.path().join("beam-input-helper-from-appimage");
+    write_executable(&source, b"#!/bin/sh\nexit 0\n");
+
+    let helper = ElevatedHelperExecutable::from_bundled(&source).expect("create helper");
+    let status = Command::new(helper.path())
+        .status()
+        .expect("execute helper through proc fd");
+
+    assert!(status.success());
+}
+
+#[test]
+fn from_bundled_path_becomes_invalid_after_owner_is_dropped() {
+    let _lock = super::owned_child::test_lock();
+    let temporary = tempfile::tempdir().expect("temporary helper directory");
+    let source = temporary.path().join("beam-input-helper-from-appimage");
+    write_executable(&source, b"helper that expires with its owner");
+    let path = {
+        let helper = ElevatedHelperExecutable::from_bundled(&source).expect("create helper");
+        assert!(helper.path().starts_with("/proc/"));
+        helper.path().to_owned()
+    };
+
+    assert!(!path.exists());
+    assert!(fs::read(path).is_err());
+}
 
 #[test]
 fn parses_current_helper_version_and_policy_revision() {


### PR DESCRIPTION
## Summary
- stage the AppImage input helper in a sealed executable memory file before invoking Polkit
- keep the immutable helper alive through authorization and install it from /proc/self/exe
- preserve the installed DEB/RPM helper path and split installation code below the source-size limit
- cover byte integrity, sealing, execution, symlink rejection, and descriptor lifetime

## Verification
- cargo test -p capture --lib screen::linux::input_monitor_tests --all-features
- cargo test -p capture --test input_helper_policy --all-features
- cargo clippy -p capture --lib --all-features -- -D warnings
- cargo build -p capture --bin capture-engine --bin beam-input-helper
- node --test test/input-access.test.cjs test/native-artifacts.test.cjs
- cargo fmt --all --check
- git diff --check

## Manual follow-up
- verify the real Polkit dialog from a rebuilt AppImage on Ubuntu Wayland

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Linux input helper installation and launching.
  * Bundled helpers are securely prepared and protected from modification before startup.
  * Added reliable installation of the helper and its authorization policy.

* **Bug Fixes**
  * Improved handling of invalid, missing, symlinked, or non-executable helper files.
  * Ensured helper files remain available during authorization and startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->