### PR TITLE
Fix transition directions: slide and zoom entry/exit motion

### DIFF
--- a/src/components/video-editor/composition/transitions/render-transition.test.ts
+++ b/src/components/video-editor/composition/transitions/render-transition.test.ts
@@ -45,7 +45,7 @@ describe('drawWithClipTransition', () => {
     drawWithClipTransition(ctx, clipWithEntry({ kind: 'zoom', direction: 'in' }), 250, frame, draw);
 
     expect(ctx.translate).toHaveBeenCalledWith(500, 250);
-    expect(ctx.scale).toHaveBeenCalledWith(0.995, 0.995);
+    expect(ctx.scale).toHaveBeenCalledWith(0.9875, 0.9875);
     expect(ctx.translate).toHaveBeenCalledWith(-500, -250);
     expect(draw).toHaveBeenCalledOnce();
   });
@@ -62,7 +62,7 @@ describe('drawWithClipTransition', () => {
     );
 
     expect(ctx.translate).toHaveBeenCalledOnce();
-    expect(ctx.translate).toHaveBeenCalledWith(-8, 0);
+    expect(ctx.translate).toHaveBeenCalledWith(8, 0);
     expect(ctx.scale).not.toHaveBeenCalled();
   });
 
@@ -72,8 +72,8 @@ describe('drawWithClipTransition', () => {
 
     const mapped = transitionPointWithClip(clipWithEntry({ kind: 'slide', direction: 'left' }, 2), 250, frame, point);
 
-    // Entry progress is 1 - (1 - .5)^2 = .75, leaving a -2% frame offset.
-    expect(mapped).toEqual({ x: 484, y: 250 });
+    // Entry progress is 1 - (1 - .5)^2 = .75, leaving a +2% frame offset.
+    expect(mapped).toEqual({ x: 516, y: 250 });
   });
 
   it('maps a point through an exit transition using its easing power and centered scale', () => {
@@ -85,8 +85,8 @@ describe('drawWithClipTransition', () => {
 
     const mapped = transitionPointWithClip(clip, 750, frame, { x: 700, y: 350 });
 
-    // Exit progress is .5^2 = .25, leaving 75% of the preset's 4% scale offset.
-    expect(mapped.x).toBeCloseTo(694);
-    expect(mapped.y).toBeCloseTo(347);
+    // Exit progress is .5^2 = .25, leaving 75% of the preset's 10% scale overshoot.
+    expect(mapped.x).toBeCloseTo(715);
+    expect(mapped.y).toBeCloseTo(357.5);
   });
 });

--- a/src/i18n/en/core.json
+++ b/src/i18n/en/core.json
@@ -72,9 +72,9 @@
     "slideDown": "Slide down",
     "slideDownDetail": "From above",
     "zoomIn": "Zoom in",
-    "zoomInDetail": "Scale from 96%",
+    "zoomInDetail": "Scale from 90%",
     "zoomOut": "Zoom out",
-    "zoomOutDetail": "Scale from 104%",
+    "zoomOutDetail": "Scale from 110%",
     "blur": "Blur",
     "blurDetail": "Soft focus"
   },

--- a/src/i18n/fr/core.json
+++ b/src/i18n/fr/core.json
@@ -72,9 +72,9 @@
     "slideDown": "Glissement vers le bas",
     "slideDownDetail": "Depuis le haut",
     "zoomIn": "Zoom avant",
-    "zoomInDetail": "Échelle depuis 96 %",
+    "zoomInDetail": "Échelle depuis 90 %",
     "zoomOut": "Zoom arrière",
-    "zoomOutDetail": "Échelle depuis 104 %",
+    "zoomOutDetail": "Échelle depuis 110 %",
     "blur": "Flou",
     "blurDetail": "Mise au point douce"
   },

--- a/src/media/shared/clip-transitions.ts
+++ b/src/media/shared/clip-transitions.ts
@@ -86,17 +86,18 @@ export function normalizeCanvasTransitions(transitions: ClipTransitions, timelin
 
 const identity = (): ClipTransitionState => ({ opacity: 1, translateX: 0, translateY: 0, scale: 1, blur: 0 });
 
-function evaluatePreset(preset: TransitionPreset, progress: number): ClipTransitionState {
+function evaluatePreset(preset: TransitionPreset, progress: number, edge: 'entry' | 'exit'): ClipTransitionState {
   const state = identity();
   state.opacity = progress;
   const remaining = 1 - progress;
+  const arrival = edge === 'entry' ? 1 : -1;
   if (preset.kind === 'slide') {
-    if (preset.direction === 'left') state.translateX = -0.08 * remaining;
-    if (preset.direction === 'right') state.translateX = 0.08 * remaining;
-    if (preset.direction === 'up') state.translateY = -0.08 * remaining;
-    if (preset.direction === 'down') state.translateY = 0.08 * remaining;
+    if (preset.direction === 'left') state.translateX = arrival * 0.08 * remaining;
+    if (preset.direction === 'right') state.translateX = -arrival * 0.08 * remaining;
+    if (preset.direction === 'up') state.translateY = arrival * 0.08 * remaining;
+    if (preset.direction === 'down') state.translateY = -arrival * 0.08 * remaining;
   } else if (preset.kind === 'zoom') {
-    state.scale = 1 + (preset.direction === 'in' ? -0.04 : 0.04) * remaining;
+    state.scale = 1 + (preset.direction === 'in' ? -arrival : arrival) * 0.1 * remaining;
   } else if (preset.kind === 'blur') state.blur = 12 * remaining;
   return state;
 }
@@ -124,13 +125,13 @@ export function resolveTransitionState(
   if (transitions.entry && timeMs < transitions.entry.durationMs) {
     const linear = clamp01(timeMs / transitions.entry.durationMs);
     const power = transitions.entry.easingPower ?? DEFAULT_TRANSITION_EASING_POWER;
-    return evaluatePreset(transitions.entry.preset, 1 - (1 - linear) ** power);
+    return evaluatePreset(transitions.entry.preset, 1 - (1 - linear) ** power, 'entry');
   }
   const remaining = timelineDurationMs - timeMs;
   if (transitions.exit && remaining < transitions.exit.durationMs) {
     const linear = clamp01(remaining / transitions.exit.durationMs);
     const power = transitions.exit.easingPower ?? DEFAULT_TRANSITION_EASING_POWER;
-    return evaluatePreset(transitions.exit.preset, linear ** power);
+    return evaluatePreset(transitions.exit.preset, linear ** power, 'exit');
   }
   return identity();
 }

--- a/src/media/shared/tests/clip-transitions.test.ts
+++ b/src/media/shared/tests/clip-transitions.test.ts
@@ -71,8 +71,8 @@ describe('clip transition evaluator', () => {
     const zoom = timedClip({ entry: { preset: { kind: 'zoom', direction: 'in' }, durationMs: 500 }, exit: null });
     const blur = timedClip({ entry: { preset: { kind: 'blur' }, durationMs: 500 }, exit: null });
 
-    expect(resolveClipTransitionState(slide, 100)).toMatchObject({ opacity: 0, translateX: -0.08 });
-    expect(resolveClipTransitionState(zoom, 100)).toMatchObject({ opacity: 0, scale: 0.96 });
+    expect(resolveClipTransitionState(slide, 100)).toMatchObject({ opacity: 0, translateX: 0.08 });
+    expect(resolveClipTransitionState(zoom, 100)).toMatchObject({ opacity: 0, scale: 0.9 });
     expect(resolveClipTransitionState(blur, 100)).toMatchObject({ opacity: 0, blur: 12 });
     expect(resolveClipTransitionState(slide, 600)).toMatchObject({ opacity: 1, translateX: 0 });
   });
@@ -267,25 +267,25 @@ describe('clip transition evaluator', () => {
         timedClip({ entry: { preset: { kind: 'slide', direction: 'right' }, durationMs: 500 }, exit: null }),
         100,
       ).translateX,
-    ).toBe(0.08);
+    ).toBe(-0.08);
     expect(
       resolveClipTransitionState(
         timedClip({ entry: { preset: { kind: 'slide', direction: 'up' }, durationMs: 500 }, exit: null }),
         100,
       ).translateY,
-    ).toBe(-0.08);
+    ).toBe(0.08);
     expect(
       resolveClipTransitionState(
         timedClip({ entry: { preset: { kind: 'slide', direction: 'down' }, durationMs: 500 }, exit: null }),
         100,
       ).translateY,
-    ).toBe(0.08);
+    ).toBe(-0.08);
     expect(
       resolveClipTransitionState(
         timedClip({ entry: { preset: { kind: 'zoom', direction: 'out' }, durationMs: 500 }, exit: null }),
         100,
       ).scale,
-    ).toBe(1.04);
+    ).toBe(1.1);
     expect(
       normalizeClipTransitions({ entry: null, exit: { preset: { kind: 'fade' }, durationMs: 500 } }, 40, 'audio'),
     ).toEqual({ entry: null, exit: { preset: { kind: 'fade' }, durationMs: 40 } });


### PR DESCRIPTION
Fixes two transition bugs in the clip/canvas transition evaluator:
- Slide direction was inverted: "Slide up" entered from above and slid down; "Slide left/right/down" were likewise reversed. Entry transitions now arrive from the side named in the UI ("Slide up" comes from below), while exits still depart toward the named side.
- Zoom start size was too subtle: zoom-in started at 96% / zoom-out at 104%. Now 90% / 110% so the effect is clearly visible on text and images.
- Zoom exit was inverted (found while auditing): exit "Zoom in" shrank instead of growing. Both zoom and slide now share the same edge-aware sign logic, so entries settle into the frame and exits continue in the same motion direction.
Updated the i18n detail strings (en/fr) and the affected unit tests — all focused transition tests and typecheck pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Refined video transition animations for smoother zoom effects and more consistent slide directions during entry and exit.
  - Updated zoom transitions to use a more noticeable scale change, improving visual impact.
- **Documentation**
  - Updated English and French transition descriptions to accurately reflect the revised zoom levels.
- **Tests**
  - Updated transition coverage to verify the revised zoom scaling and slide positioning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->