### PR TITLE
feat(capture): add Linux screen region cropping

### DIFF
--- a/electron/capture/capture-config.cjs
+++ b/electron/capture/capture-config.cjs
@@ -108,8 +108,7 @@ function buildDefaultCaptureConfig(catalog, options, environment) {
     selectSource(sources, screenKind, options.screenId, environment.platform);
   if (!screen) throw new Error('Aucun écran ou fenêtre capturable n’est disponible');
   const portalSelection = screen.selectionMode === 'portal';
-  if (portalSelection && options.region != null)
-    throw new Error('La sélection de zone n’est pas disponible avec le picker système Linux');
+  const region = screenRegion(options.region, screenKind);
   return {
     projectId: options.projectId || randomUUID(),
     screen: portalSelection
@@ -140,7 +139,7 @@ function buildDefaultCaptureConfig(catalog, options, environment) {
       minimumFreeBytes: options.minimumFreeBytes ?? 536_870_912,
     },
     failurePolicy: options.failurePolicy || 'continue-without-optional-tracks',
-    region: portalSelection ? null : screenRegion(options.region, screenKind),
+    region,
     excludedProcessId: environment.excludedProcessId,
   };
 }

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -371,7 +371,11 @@ function initializeApplication() {
       platform: process.platform,
     });
     const countdownOverlay = createCountdownWindow(lifecycleOptions);
-    const screenRegionOverlay = createScreenRegionOverlayWindow(lifecycleOptions);
+    const screenRegionOverlay = createScreenRegionOverlayWindow({
+      ...lifecycleOptions,
+      platform: process.platform,
+      screen,
+    });
     applicationIpc.on('camera-overlay:configure', (_event, state) => cameraOverlay.configure(state));
     applicationIpc.on('camera-overlay:set-active', (_event, active) => cameraOverlay.setActive(active));
     applicationIpc.on('camera-overlay:reset-placement', () => cameraOverlay.resetPlacement());
@@ -385,7 +389,9 @@ function initializeApplication() {
       // the native start gate admits the first recorded frame.
       await new Promise((resolve) => setTimeout(resolve, 100));
     });
-    applicationIpc.handle('screen-region:select', (_event, options) => screenRegionOverlay.select(options));
+    applicationIpc.handle('screen-region:select', (event, options) =>
+      screenRegionOverlay.select(options, BrowserWindow.fromWebContents(event.sender)),
+    );
     applicationIpc.on('screen-region:show', (_event, options) => screenRegionOverlay.show(options));
     applicationIpc.on('screen-region:hide', () => screenRegionOverlay.hide());
     applicationIpc.on('screen-region:confirm', (_event, region) => screenRegionOverlay.confirm(region));

--- a/electron/screen-region-overlay.cjs
+++ b/electron/screen-region-overlay.cjs
@@ -13,7 +13,24 @@ function finiteBounds(value) {
   };
 }
 
-function createScreenRegionOverlayWindow({ applicationRoot, isPackaged, canAcceptWork = () => true }) {
+function resolveSelectionBounds(options, platform, screen, parentWindow) {
+  if (options?.bounds) return finiteBounds(options.bounds);
+  if (platform !== 'linux') throw new Error('Screen overlay bounds are required');
+  const parentBounds = parentWindow && !parentWindow.isDestroyed() ? parentWindow.getBounds() : null;
+  const display =
+    (parentBounds && typeof screen?.getDisplayMatching === 'function' && screen.getDisplayMatching(parentBounds)) ||
+    screen?.getPrimaryDisplay?.();
+  if (!display?.bounds) throw new Error('No display is available for Linux region selection');
+  return finiteBounds(display.bounds);
+}
+
+function createScreenRegionOverlayWindow({
+  applicationRoot,
+  isPackaged,
+  canAcceptWork = () => true,
+  platform = process.platform,
+  screen,
+}) {
   let window = null;
   let ready = false;
   let pending = null;
@@ -63,9 +80,10 @@ function createScreenRegionOverlayWindow({ applicationRoot, isPackaged, canAccep
     return window;
   };
 
-  const configure = (options, interactive) => {
+  const configure = (options, interactive, parentWindow = null) => {
     const target = ensureWindow();
     current = { ...options, bounds: finiteBounds(options.bounds), mode: interactive ? 'select' : 'record' };
+    target.setParentWindow(interactive && platform === 'linux' ? parentWindow : null);
     target.setBounds(current.bounds);
     target.setIgnoreMouseEvents(!interactive);
     send(current);
@@ -79,7 +97,7 @@ function createScreenRegionOverlayWindow({ applicationRoot, isPackaged, canAccep
   };
 
   return {
-    select(options) {
+    select(options, parentWindow = null) {
       if (pending) {
         pending.resolve(null);
         pending = null;
@@ -88,11 +106,18 @@ function createScreenRegionOverlayWindow({ applicationRoot, isPackaged, canAccep
         pending = { resolve };
       });
       try {
-        configure(options, true);
+        configure(
+          { ...options, bounds: resolveSelectionBounds(options, platform, screen, parentWindow) },
+          true,
+          parentWindow,
+        );
       } catch (error) {
         pending = null;
         current = null;
-        if (window && !window.isDestroyed()) window.hide();
+        if (window && !window.isDestroyed()) {
+          window.hide();
+          window.setParentWindow(null);
+        }
         throw error;
       }
       return result;
@@ -107,10 +132,12 @@ function createScreenRegionOverlayWindow({ applicationRoot, isPackaged, canAccep
     confirm(region) {
       if (!pending) return;
       const resolve = pending.resolve;
+      const bounds = current?.bounds;
       pending = null;
       current = null;
       window?.hide();
-      resolve(region);
+      window?.setParentWindow(null);
+      resolve(bounds ? { bounds: { ...bounds }, region } : null);
     },
     cancel() {
       if (!pending) return;
@@ -118,6 +145,7 @@ function createScreenRegionOverlayWindow({ applicationRoot, isPackaged, canAccep
       pending = null;
       current = null;
       window?.hide();
+      window?.setParentWindow(null);
       resolve(null);
     },
     destroy() {
@@ -131,4 +159,4 @@ function createScreenRegionOverlayWindow({ applicationRoot, isPackaged, canAccep
   };
 }
 
-module.exports = { createScreenRegionOverlayWindow };
+module.exports = { createScreenRegionOverlayWindow, resolveSelectionBounds };

--- a/packages/capture/src/model/config.rs
+++ b/packages/capture/src/model/config.rs
@@ -167,9 +167,16 @@ impl CaptureRequest {
         }
         if let Some(region) = self.region {
             region.validate()?;
-            if !matches!(self.screen, Some(ScreenSelection::Source { .. })) {
+            if !matches!(
+                self.screen,
+                Some(ScreenSelection::Source { .. })
+                    | Some(ScreenSelection::Portal {
+                        kind: PortalSourceKind::Monitor,
+                        ..
+                    })
+            ) {
                 return Err(crate::CaptureError::InvalidConfiguration(
-                    "screen region requires a direct screen source".into(),
+                    "screen region requires a display source".into(),
                 ));
             }
         }

--- a/packages/capture/src/screen/linux/pipewire/geometry.rs
+++ b/packages/capture/src/screen/linux/pipewire/geometry.rs
@@ -1,0 +1,185 @@
+use std::sync::Arc;
+
+use crate::{
+    CaptureError,
+    model::ScreenRegion,
+    screen::{OwnedVideoFrame, PixelCrop, PixelFormat, normalize_crop},
+};
+
+use super::{
+    CropRect, CursorMetadata, NegotiatedFormat, VideoTransform, map_cursor_metadata,
+    output_dimensions,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct FrameGeometry {
+    pub(super) frame_crop: Option<CropRect>,
+    pub(super) cursor_crop: Option<CropRect>,
+    pub(super) transform: VideoTransform,
+    region_crop: Option<PixelCrop>,
+    uncropped_width: u32,
+    uncropped_height: u32,
+    width: u32,
+    height: u32,
+}
+
+impl FrameGeometry {
+    pub(super) fn from_frame(
+        format: NegotiatedFormat,
+        frame_crop: Option<CropRect>,
+        cursor_crop: Option<CropRect>,
+        transform: VideoTransform,
+        region_crop: Option<PixelCrop>,
+        frame: &OwnedVideoFrame,
+    ) -> Self {
+        let (uncropped_width, uncropped_height) =
+            output_dimensions(format, frame_crop, transform).unwrap_or((frame.width, frame.height));
+        debug_assert_eq!(
+            region_crop.map_or((uncropped_width, uncropped_height), |crop| {
+                (crop.width(), crop.height())
+            }),
+            (frame.width, frame.height)
+        );
+        Self {
+            frame_crop,
+            cursor_crop,
+            transform,
+            region_crop,
+            uncropped_width,
+            uncropped_height,
+            width: frame.width,
+            height: frame.height,
+        }
+    }
+
+    pub(super) fn map_cursor(
+        self,
+        cursor: Option<CursorMetadata>,
+        format: NegotiatedFormat,
+    ) -> Option<CursorMetadata> {
+        let mut cursor = map_cursor_metadata(
+            cursor,
+            format.width,
+            format.height,
+            self.cursor_crop,
+            self.transform,
+        )?;
+        let (cursor_width, cursor_height) =
+            output_dimensions(format, self.cursor_crop, self.transform).ok()?;
+        cursor.x = scale_coordinate(cursor.x, cursor_width, self.uncropped_width);
+        cursor.y = scale_coordinate(cursor.y, cursor_height, self.uncropped_height);
+        if let Some(crop) = self.region_crop {
+            cursor.x = subtract_offset(cursor.x, crop.start_x);
+            cursor.y = subtract_offset(cursor.y, crop.start_y);
+        }
+        Some(cursor)
+    }
+
+    pub(super) const fn width(self) -> u32 {
+        self.width
+    }
+
+    pub(super) const fn height(self) -> u32 {
+        self.height
+    }
+}
+
+pub(super) fn crop_frame(
+    frame: OwnedVideoFrame,
+    region: Option<ScreenRegion>,
+) -> Result<(OwnedVideoFrame, Option<PixelCrop>), CaptureError> {
+    let Some(region) = region else {
+        return Ok((frame, None));
+    };
+    if frame.pixel_format != PixelFormat::Bgra8 {
+        return Err(CaptureError::InvalidConfiguration(
+            "Linux screen crop requires BGRA frames".into(),
+        ));
+    }
+    let crop = normalize_crop(region, frame.width, frame.height)?;
+    let output_stride = usize::try_from(crop.width())
+        .ok()
+        .and_then(|width| width.checked_mul(4))
+        .ok_or_else(|| {
+            CaptureError::InvalidConfiguration("screen crop row size overflows".into())
+        })?;
+    let output_len = output_stride
+        .checked_mul(usize::try_from(crop.height()).map_err(|_| {
+            CaptureError::InvalidConfiguration("screen crop height is not representable".into())
+        })?)
+        .ok_or_else(|| CaptureError::InvalidConfiguration("screen crop size overflows".into()))?;
+    let mut pixels = vec![0; output_len];
+    let source_x = usize::try_from(crop.start_x)
+        .ok()
+        .and_then(|x| x.checked_mul(4))
+        .ok_or_else(|| CaptureError::InvalidConfiguration("screen crop offset overflows".into()))?;
+    for row in 0..crop.height() {
+        let source = usize::try_from(crop.start_y + row)
+            .ok()
+            .and_then(|y| y.checked_mul(frame.stride))
+            .and_then(|offset| offset.checked_add(source_x))
+            .ok_or_else(|| {
+                CaptureError::InvalidConfiguration("screen crop offset overflows".into())
+            })?;
+        let destination = usize::try_from(row)
+            .ok()
+            .and_then(|row| row.checked_mul(output_stride))
+            .ok_or_else(|| {
+                CaptureError::InvalidConfiguration("screen crop offset overflows".into())
+            })?;
+        let source_end = source.checked_add(output_stride).ok_or_else(|| {
+            CaptureError::InvalidConfiguration("screen crop row range overflows".into())
+        })?;
+        let destination_end = destination.checked_add(output_stride).ok_or_else(|| {
+            CaptureError::InvalidConfiguration("screen crop row range overflows".into())
+        })?;
+        let source_row = frame.pixels.get(source..source_end).ok_or_else(|| {
+            CaptureError::InvalidConfiguration("screen crop exceeds the frame".into())
+        })?;
+        pixels[destination..destination_end].copy_from_slice(source_row);
+    }
+    Ok((
+        OwnedVideoFrame {
+            width: crop.width(),
+            height: crop.height(),
+            stride: output_stride,
+            pixel_format: frame.pixel_format,
+            pixels: Arc::from(pixels),
+        },
+        Some(crop),
+    ))
+}
+
+fn scale_coordinate(value: i32, source: u32, destination: u32) -> i32 {
+    if source == destination || source == 0 {
+        return value;
+    }
+    let scaled = i64::from(value)
+        .saturating_mul(i64::from(destination))
+        .checked_div(i64::from(source))
+        .unwrap_or_default();
+    i32::try_from(scaled).unwrap_or(if scaled < 0 { i32::MIN } else { i32::MAX })
+}
+
+fn subtract_offset(value: i32, offset: u32) -> i32 {
+    let adjusted = i64::from(value).saturating_sub(i64::from(offset));
+    i32::try_from(adjusted).unwrap_or(if adjusted < 0 { i32::MIN } else { i32::MAX })
+}
+
+pub(super) fn repaired_window_crop(
+    reported: Option<CropRect>,
+    content: Option<CropRect>,
+) -> Option<CropRect> {
+    let (Some(reported), Some(content)) = (reported, content) else {
+        return reported;
+    };
+    let width_scale = f64::from(content.width) / f64::from(reported.width.max(1));
+    let height_scale = f64::from(content.height) / f64::from(reported.height.max(1));
+    let uniform_scale = (width_scale - height_scale).abs() <= 0.05;
+    let materially_larger = width_scale >= 1.1 && height_scale >= 1.1;
+    if uniform_scale && materially_larger {
+        Some(content)
+    } else {
+        Some(reported)
+    }
+}

--- a/packages/capture/src/screen/linux/pipewire/mod.rs
+++ b/packages/capture/src/screen/linux/pipewire/mod.rs
@@ -1,6 +1,7 @@
 mod cursor_classifier;
 mod cursor_state;
 mod format;
+mod geometry;
 mod metadata;
 mod params;
 mod process;
@@ -14,6 +15,7 @@ mod tests;
 use cursor_classifier::*;
 pub(crate) use cursor_state::*;
 pub(crate) use format::*;
+use geometry::*;
 use params::*;
 use process::*;
 use support::*;

--- a/packages/capture/src/screen/linux/pipewire/process.rs
+++ b/packages/capture/src/screen/linux/pipewire/process.rs
@@ -14,6 +14,7 @@ use pipewire::{
 
 use crate::{
     CaptureError, NativeCaptureErrorCode,
+    model::ScreenRegion,
     screen::{
         CursorSampleState, OwnedScreenSample, ScreenCaptureMetrics, ScreenDiscontinuity,
         ScreenSegment, VideoFormat,
@@ -22,8 +23,8 @@ use crate::{
 };
 
 use super::{
-    BufferLayout, CropRect, CursorState, NegotiatedFormat, TimestampMapper, VideoTransform,
-    copy_frame, expand_crop_to_content, has_fatal, map_cursor_metadata, metadata, set_fatal,
+    BufferLayout, CursorState, FrameGeometry, NegotiatedFormat, TimestampMapper, copy_frame,
+    crop_frame, expand_crop_to_content, has_fatal, metadata, repaired_window_crop, set_fatal,
     sink_error, video_format,
 };
 
@@ -58,56 +59,7 @@ pub(super) struct ProcessState {
     pub pending_drops: u64,
     pub last_frame_geometry: Option<FrameGeometry>,
     pub repair_window_crop: bool,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) struct FrameGeometry {
-    frame_crop: Option<CropRect>,
-    cursor_crop: Option<CropRect>,
-    transform: VideoTransform,
-    width: u32,
-    height: u32,
-}
-
-impl FrameGeometry {
-    pub(super) fn from_frame(
-        format: NegotiatedFormat,
-        frame_crop: Option<CropRect>,
-        cursor_crop: Option<CropRect>,
-        transform: VideoTransform,
-        frame: &crate::screen::OwnedVideoFrame,
-    ) -> Self {
-        debug_assert_eq!(
-            super::output_dimensions(format, frame_crop, transform).ok(),
-            Some((frame.width, frame.height))
-        );
-        Self {
-            frame_crop,
-            cursor_crop,
-            transform,
-            width: frame.width,
-            height: frame.height,
-        }
-    }
-
-    pub(super) fn map_cursor(
-        self,
-        cursor: Option<super::CursorMetadata>,
-        format: NegotiatedFormat,
-    ) -> Option<super::CursorMetadata> {
-        let mut cursor = map_cursor_metadata(
-            cursor,
-            format.width,
-            format.height,
-            self.cursor_crop,
-            self.transform,
-        )?;
-        let (cursor_width, cursor_height) =
-            super::output_dimensions(format, self.cursor_crop, self.transform).ok()?;
-        cursor.x = scale_coordinate(cursor.x, cursor_width, self.width);
-        cursor.y = scale_coordinate(cursor.y, cursor_height, self.height);
-        Some(cursor)
-    }
+    pub region: Option<ScreenRegion>,
 }
 
 pub(super) fn should_defer_timestamp_origin(
@@ -116,35 +68,6 @@ pub(super) fn should_defer_timestamp_origin(
     chunk_size: u32,
 ) -> bool {
     !has_frame_geometry && (corrupted || chunk_size == 0)
-}
-
-fn scale_coordinate(value: i32, source: u32, destination: u32) -> i32 {
-    if source == destination || source == 0 {
-        return value;
-    }
-    let scaled = i64::from(value)
-        .saturating_mul(i64::from(destination))
-        .checked_div(i64::from(source))
-        .unwrap_or_default();
-    i32::try_from(scaled).unwrap_or(if scaled < 0 { i32::MIN } else { i32::MAX })
-}
-
-pub(super) fn repaired_window_crop(
-    reported: Option<CropRect>,
-    content: Option<CropRect>,
-) -> Option<CropRect> {
-    let (Some(reported), Some(content)) = (reported, content) else {
-        return reported;
-    };
-    let width_scale = f64::from(content.width) / f64::from(reported.width.max(1));
-    let height_scale = f64::from(content.height) / f64::from(reported.height.max(1));
-    let uniform_scale = (width_scale - height_scale).abs() <= 0.05;
-    let materially_larger = width_scale >= 1.1 && height_scale >= 1.1;
-    if uniform_scale && materially_larger {
-        Some(content)
-    } else {
-        Some(reported)
-    }
 }
 
 pub(super) fn process_buffer(stream: &pw::stream::Stream, state: &Rc<RefCell<ProcessState>>) {
@@ -224,7 +147,7 @@ pub(super) fn process_buffer(stream: &pw::stream::Stream, state: &Rc<RefCell<Pro
         let cursor = geometry.map_cursor(cursor, format);
         let sample_cursor = state
             .cursor
-            .resolve(cursor, geometry.width, geometry.height);
+            .resolve(cursor, geometry.width(), geometry.height());
         if has_cursor_metadata && matches!(sample_cursor, CursorSampleState::Known { .. }) {
             try_cursor_sample(&mut state, timestamp.session_ns, sample_cursor);
         } else {
@@ -289,15 +212,28 @@ pub(super) fn process_buffer(stream: &pw::stream::Stream, state: &Rc<RefCell<Pro
         transform: frame_transform,
         ..layout
     };
-    let frame = match copy_frame(memory, format, layout) {
+    let uncropped_frame = match copy_frame(memory, format, layout) {
         Ok(frame) => frame,
         Err(error) => {
             invalid_buffer(&mut state, timestamp.session_ns, &error.to_string());
             return;
         }
     };
-    let geometry =
-        FrameGeometry::from_frame(format, frame_crop, cursor_crop, frame_transform, &frame);
+    let (frame, region_crop) = match crop_frame(uncropped_frame, state.region) {
+        Ok(result) => result,
+        Err(error) => {
+            set_fatal(&state.fatal, error);
+            return;
+        }
+    };
+    let geometry = FrameGeometry::from_frame(
+        format,
+        frame_crop,
+        cursor_crop,
+        frame_transform,
+        region_crop,
+        &frame,
+    );
     let cursor = geometry.map_cursor(cursor, format);
     let sample_cursor = state.cursor.resolve(cursor, frame.width, frame.height);
     state.last_frame_geometry = Some(geometry);

--- a/packages/capture/src/screen/linux/pipewire/tests.rs
+++ b/packages/capture/src/screen/linux/pipewire/tests.rs
@@ -39,5 +39,6 @@ fn copy_pixel(format: NativePixelFormat, bytes: &[u8]) -> Vec<u8> {
 
 mod cursor_tests;
 mod format_tests;
+mod region_tests;
 mod sink_tests;
 mod timestamp_tests;

--- a/packages/capture/src/screen/linux/pipewire/tests/cursor_tests.rs
+++ b/packages/capture/src/screen/linux/pipewire/tests/cursor_tests.rs
@@ -398,6 +398,7 @@ fn frame_geometry_scales_cursor_crop_to_frame_and_ignores_later_cursor_crop_chan
         None,
         Some(cursor_crop),
         VideoTransform::None,
+        None,
         &frame,
     );
     let cursor = CursorMetadata {

--- a/packages/capture/src/screen/linux/pipewire/tests/region_tests.rs
+++ b/packages/capture/src/screen/linux/pipewire/tests/region_tests.rs
@@ -1,0 +1,223 @@
+use std::sync::Arc;
+
+use crate::{
+    model::ScreenRegion,
+    screen::{CursorSampleState, OwnedVideoFrame, PixelCrop, PixelFormat},
+};
+
+use super::super::geometry::{FrameGeometry, crop_frame};
+use super::super::{
+    BufferLayout, CursorMetadata, CursorState, NativePixelFormat, VideoTransform, copy_frame,
+};
+use super::negotiated;
+
+fn frame_with_stride(width: u32, height: u32, stride_pixels: usize) -> OwnedVideoFrame {
+    let stride = stride_pixels * 4;
+    let mut pixels = vec![0xee; stride * height as usize];
+    for y in 0..height as usize {
+        for x in 0..width as usize {
+            let offset = y * stride + x * 4;
+            pixels[offset..offset + 4].copy_from_slice(&[
+                (y * width as usize + x + 1) as u8,
+                0,
+                0,
+                255,
+            ]);
+        }
+    }
+    OwnedVideoFrame {
+        width,
+        height,
+        stride,
+        pixel_format: PixelFormat::Bgra8,
+        pixels: Arc::from(pixels),
+    }
+}
+
+fn blue_values(frame: &OwnedVideoFrame) -> Vec<u8> {
+    frame
+        .pixels
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .map(|pixel| pixel[0])
+        .collect()
+}
+
+#[test]
+fn crop_preserves_selected_pixels_and_rounds_dimensions_to_h264_pairs() {
+    let frame = frame_with_stride(8, 6, 8);
+    let region = ScreenRegion {
+        x: 0.125,
+        y: 1.0 / 6.0,
+        width: 0.375,
+        height: 0.5,
+    };
+
+    let (cropped, pixel_crop) = crop_frame(frame, Some(region)).expect("valid screen crop");
+
+    assert_eq!((cropped.width, cropped.height), (2, 2));
+    assert_eq!(cropped.stride, 2 * 4);
+    assert_eq!(blue_values(&cropped), [10, 11, 18, 19]);
+    assert_eq!(
+        pixel_crop,
+        Some(PixelCrop {
+            start_x: 1,
+            start_y: 1,
+            end_x: 3,
+            end_y: 3,
+        })
+    );
+}
+
+#[test]
+fn crop_after_frame_copy_uses_source_stride_and_discards_padding() {
+    let frame = frame_with_stride(4, 4, 6);
+    let region = ScreenRegion {
+        x: 0.25,
+        y: 0.25,
+        width: 0.5,
+        height: 0.5,
+    };
+
+    let (cropped, _) = crop_frame(frame, Some(region)).expect("valid screen crop");
+
+    assert_eq!((cropped.width, cropped.height, cropped.stride), (2, 2, 8));
+    assert_eq!(blue_values(&cropped), [6, 7, 10, 11]);
+    assert!(cropped.pixels.iter().all(|byte| *byte != 0xee));
+}
+
+#[test]
+fn crop_uses_coordinates_after_pipewire_rotation() {
+    let memory = [
+        1, 0, 0, 255, 2, 0, 0, 255, 3, 0, 0, 255, 4, 0, 0, 255, 5, 0, 0, 255, 6, 0, 0, 255, 7, 0,
+        0, 255, 8, 0, 0, 255,
+    ];
+    let transformed = copy_frame(
+        &memory,
+        negotiated(NativePixelFormat::Bgra, 4, 2),
+        BufferLayout {
+            offset: 0,
+            size: memory.len(),
+            stride: 16,
+            crop: None,
+            transform: VideoTransform::Rotated90,
+        },
+    )
+    .expect("valid rotated frame");
+    let region = ScreenRegion {
+        x: 0.0,
+        y: 0.0,
+        width: 1.0,
+        height: 0.5,
+    };
+
+    let (cropped, _) = crop_frame(transformed, Some(region)).expect("valid rotated crop");
+
+    assert_eq!((cropped.width, cropped.height), (2, 2));
+    assert_eq!(blue_values(&cropped), [4, 8, 3, 7]);
+}
+
+#[test]
+fn one_pixel_edge_selection_expands_inward_to_an_even_crop() {
+    let frame = frame_with_stride(6, 4, 6);
+    let region = ScreenRegion {
+        x: 5.0 / 6.0,
+        y: 3.0 / 4.0,
+        width: 1.0 / 6.0,
+        height: 1.0 / 4.0,
+    };
+
+    let (cropped, pixel_crop) = crop_frame(frame, Some(region)).expect("valid edge crop");
+
+    assert_eq!((cropped.width, cropped.height), (2, 2));
+    assert_eq!(blue_values(&cropped), [17, 18, 23, 24]);
+    assert_eq!(
+        pixel_crop,
+        Some(PixelCrop {
+            start_x: 4,
+            start_y: 2,
+            end_x: 6,
+            end_y: 4,
+        })
+    );
+}
+
+#[test]
+fn frame_geometry_rebases_cursor_and_marks_positions_outside_region_invisible() {
+    let format = negotiated(NativePixelFormat::Bgra, 8, 6);
+    let frame = OwnedVideoFrame {
+        width: 4,
+        height: 4,
+        stride: 4 * 4,
+        pixel_format: PixelFormat::Bgra8,
+        pixels: Arc::from(vec![0_u8; 4 * 4 * 4]),
+    };
+    let region_crop = PixelCrop {
+        start_x: 2,
+        start_y: 2,
+        end_x: 6,
+        end_y: 6,
+    };
+    let geometry = FrameGeometry::from_frame(
+        format,
+        None,
+        None,
+        VideoTransform::Rotated90,
+        Some(region_crop),
+        &frame,
+    );
+
+    let mut state = CursorState::new("scope");
+    let visible = state.resolve(
+        geometry.map_cursor(
+            Some(CursorMetadata {
+                id: 17,
+                shape_id: None,
+                cursor_kind: None,
+                x: 3,
+                y: 4,
+                hotspot: None,
+            }),
+            format,
+        ),
+        frame.width,
+        frame.height,
+    );
+    assert!(matches!(
+        visible,
+        CursorSampleState::Known {
+            pixel_x: 2,
+            pixel_y: 2,
+            normalized_x,
+            normalized_y,
+            visible: true,
+            ..
+        } if normalized_x == 0.5 && normalized_y == 0.5
+    ));
+
+    let outside = state.resolve(
+        geometry.map_cursor(
+            Some(CursorMetadata {
+                id: 17,
+                shape_id: None,
+                cursor_kind: None,
+                x: 3,
+                y: 1,
+                hotspot: None,
+            }),
+            format,
+        ),
+        frame.width,
+        frame.height,
+    );
+    assert!(matches!(
+        outside,
+        CursorSampleState::Known {
+            pixel_x: -1,
+            pixel_y: 2,
+            visible: false,
+            ..
+        }
+    ));
+}

--- a/packages/capture/src/screen/linux/pipewire/thread.rs
+++ b/packages/capture/src/screen/linux/pipewire/thread.rs
@@ -13,6 +13,7 @@ use spa::{param::ParamType, pod::Pod};
 
 use crate::{
     CaptureError, NativeCaptureErrorCode,
+    model::ScreenRegion,
     screen::{ScreenCaptureMetrics, ScreenSampleSink, ScreenSegment, VideoFormat},
     session::StartGate,
 };
@@ -61,6 +62,7 @@ pub(crate) struct PipewireCaptureRequest {
     pub(crate) start_gate: Arc<StartGate>,
     pub(crate) metrics: Arc<ScreenCaptureMetrics>,
     pub(crate) repair_window_crop: bool,
+    pub(crate) region: Option<ScreenRegion>,
 }
 
 impl PipewireCapture {
@@ -75,6 +77,7 @@ impl PipewireCapture {
             start_gate,
             metrics,
             repair_window_crop,
+            region,
         } = request;
         if queue_capacity == 0 {
             return Err(CaptureError::InvalidConfiguration(
@@ -113,6 +116,7 @@ impl PipewireCapture {
                     worker_gate,
                     ready_sender,
                     repair_window_crop,
+                    region,
                 );
                 let _ = finish_sender.send(SinkMessage::Finish);
                 result
@@ -278,6 +282,7 @@ fn pipewire_worker(
     start_gate: Arc<StartGate>,
     ready: mpsc::SyncSender<Result<VideoFormat, CaptureError>>,
     repair_window_crop: bool,
+    region: Option<ScreenRegion>,
 ) -> Result<(), CaptureError> {
     pw::init();
     let mainloop = pw::main_loop::MainLoopRc::new(None).map_err(pipewire_error)?;
@@ -312,6 +317,7 @@ fn pipewire_worker(
         pending_drops: 0,
         last_frame_geometry: None,
         repair_window_crop,
+        region,
     }));
     let ready = Rc::new(RefCell::new(Some(ready)));
     let negotiation_stopped = Rc::new(Cell::new(false));

--- a/packages/capture/src/screen/linux/recording.rs
+++ b/packages/capture/src/screen/linux/recording.rs
@@ -36,9 +36,9 @@ impl LinuxRecording {
                 "Linux Portal restore tokens are not supported in non-persistent mode".into(),
             ));
         }
-        if request.region.is_some() {
+        if request.region.is_some() && !matches!(kind, crate::model::PortalSourceKind::Monitor) {
             return Err(CaptureError::InvalidConfiguration(
-                "a normalized screen region is not supported by the Portal picker".into(),
+                "screen region requires a Portal monitor source".into(),
             ));
         }
         let (sink, encoded_output, encoded_codec): (
@@ -97,6 +97,7 @@ impl LinuxRecording {
             start_gate: request.start_gate,
             metrics: metrics.clone(),
             repair_window_crop,
+            region: request.region,
         })?;
         Ok(Self {
             portal: Some(portal),

--- a/packages/capture/src/screen/mod.rs
+++ b/packages/capture/src/screen/mod.rs
@@ -3,7 +3,9 @@ mod frame;
 mod recording;
 
 #[cfg(windows)]
-pub(crate) use crop::{PixelCrop, even_dimension, normalize_crop};
+pub(crate) use crop::even_dimension;
+#[cfg(any(windows, target_os = "linux"))]
+pub(crate) use crop::{PixelCrop, normalize_crop};
 pub use frame::*;
 pub use recording::*;
 

--- a/packages/capture/tests/model.rs
+++ b/packages/capture/tests/model.rs
@@ -60,6 +60,35 @@ fn cursor_without_screen_is_rejected() {
 }
 
 #[test]
+fn portal_monitor_accepts_a_region_but_portal_window_kinds_reject_it() {
+    fn request(kind: PortalSourceKind) -> CaptureRequest {
+        CaptureRequest {
+            project_id: ProjectId::new(),
+            screen: Some(ScreenSelection::Portal {
+                kind,
+                restore_token: None,
+            }),
+            system_audio: None,
+            cursor: CursorSelection::Disabled,
+            recording: RecordingSettings::default(),
+            failure_policy: FailurePolicy::FailFast,
+            region: Some(ScreenRegion {
+                x: 0.1,
+                y: 0.2,
+                width: 0.5,
+                height: 0.4,
+            }),
+            excluded_process_id: None,
+        }
+    }
+
+    assert!(request(PortalSourceKind::Monitor).validate_basic().is_ok());
+    for kind in [PortalSourceKind::Window, PortalSourceKind::MonitorOrWindow] {
+        assert!(request(kind).validate_basic().is_err());
+    }
+}
+
+#[test]
 fn excluded_process_id_roundtrips_when_present() {
     let request: CaptureRequest = serde_json::from_value(serde_json::json!({
         "projectId": ProjectId::new(),

--- a/src/api/types/capture-api.ts
+++ b/src/api/types/capture-api.ts
@@ -1,5 +1,11 @@
 import type { CaptureConfig, CreateProjectOptions, StartRecordingOptions } from './capture-config';
-import type { ScreenRegion, ScreenRegionBounds, ScreenRegionOverlayOptions } from './screen-region';
+import type {
+  ScreenRegion,
+  ScreenRegionBounds,
+  ScreenRegionOverlayOptions,
+  ScreenRegionSelectionOptions,
+  ScreenRegionSelectionResult,
+} from './screen-region';
 import type { CaptureProject, CaptureSession, ProjectEditorData, ProjectZoomState } from './capture-session';
 import type { ClipComposition, MediaAsset } from '~/media/shared/composition-types';
 import type {
@@ -93,7 +99,7 @@ export interface DesktopCaptureApi extends CaptureApi {
   onCountdown(listener: (seconds: number | null) => void): () => void;
   getSources(types?: string[]): Promise<CapturePreview[]>;
   getDisplayBounds(displayId: string): Promise<ScreenRegionBounds | null>;
-  selectScreenRegion(options: ScreenRegionOverlayOptions): Promise<ScreenRegion | null>;
+  selectScreenRegion(options: ScreenRegionSelectionOptions): Promise<ScreenRegionSelectionResult | null>;
   showScreenRegionOverlay(options: ScreenRegionOverlayOptions): void;
   hideScreenRegionOverlay(): void;
   onScreenRegionConfigure(

--- a/src/api/types/screen-region.ts
+++ b/src/api/types/screen-region.ts
@@ -16,3 +16,13 @@ export interface ScreenRegionOverlayOptions {
   bounds: ScreenRegionBounds;
   region?: ScreenRegion | null;
 }
+
+export interface ScreenRegionSelectionOptions {
+  bounds?: ScreenRegionBounds;
+  region?: ScreenRegion | null;
+}
+
+export interface ScreenRegionSelectionResult {
+  bounds: ScreenRegionBounds;
+  region: ScreenRegion;
+}

--- a/src/components/hud/HUD.vue
+++ b/src/components/hud/HUD.vue
@@ -376,25 +376,37 @@ const snapshotScreenBounds = (bounds: ScreenRegionBounds): ScreenRegionBounds =>
 
 const selectScreenRegion = async () => {
   if (props.embedded) return;
-  if (isBusy.value || isRecording.value || isRegionSelectionLeaving.value || !selectedScreenBounds.value) return;
-  const resolvedBounds = (await refreshSelectedScreenBounds()) ?? selectedScreenBounds.value;
-  if (!resolvedBounds || isBusy.value || isRecording.value || isRegionSelectionLeaving.value) return;
+  const linuxPortalSelection = desktopPlatform === 'linux';
+  if (
+    isBusy.value ||
+    isRecording.value ||
+    isRegionSelectionLeaving.value ||
+    (!linuxPortalSelection && !selectedScreenBounds.value)
+  )
+    return;
+  const resolvedBounds = linuxPortalSelection
+    ? null
+    : ((await refreshSelectedScreenBounds()) ?? selectedScreenBounds.value);
+  if ((!linuxPortalSelection && !resolvedBounds) || isBusy.value || isRecording.value || isRegionSelectionLeaving.value)
+    return;
   // Values read from Vue refs/computed values can be reactive proxies. Electron
   // IPC cannot structured-clone those proxies, so always send a plain snapshot.
-  const bounds = snapshotScreenBounds(resolvedBounds);
+  const bounds = resolvedBounds ? snapshotScreenBounds(resolvedBounds) : null;
   errorMessage.value = '';
   isRegionSelectionLeaving.value = true;
   await wait(180);
-  capture.setWindowVisible(false);
+  if (!linuxPortalSelection) capture.setWindowVisible(false);
   try {
     // The saved region is only a starting point for the next selection. It
     // must not activate crop mode just because the HUD was opened.
     const currentRegion = selectedScreenRegion.value ?? savedScreenRegion.value;
-    const region = await capture.selectScreenRegion({
-      bounds,
+    const selection = await capture.selectScreenRegion({
+      ...(bounds ? { bounds } : {}),
       region: currentRegion ? { ...currentRegion } : null,
     });
-    if (!region) return;
+    if (!selection) return;
+    const region = selection.region;
+    const selectionBounds = snapshotScreenBounds(selection.bounds);
     const isFullScreen = region.x <= 0.01 && region.y <= 0.01 && region.width >= 0.98 && region.height >= 0.98;
     if (isFullScreen) {
       selectedScreenRegion.value = null;
@@ -404,7 +416,7 @@ const selectScreenRegion = async () => {
     } else {
       const plainRegion = { ...region };
       selectedScreenRegion.value = plainRegion;
-      selectedScreenOverlay.value = { bounds, region: plainRegion };
+      selectedScreenOverlay.value = { bounds: selectionBounds, region: plainRegion };
       savedScreenRegion.value = plainRegion;
       void capture.updatePreferences({ extras: { screenRegion: plainRegion } });
     }
@@ -1111,9 +1123,9 @@ const openProject = (project: CaptureProject) => {
         <div class="form-inputs-area">
           <Transition name="fade-slide" mode="out-in">
             <div :key="activeTab" class="tab-content-container">
-              <!-- Capture source (macOS / Windows only, on Linux PipeWire portal handles source selection on record) -->
-              <template v-if="desktopPlatform !== 'linux'">
-                <template v-if="activeTab === 'window'">
+              <!-- Linux uses the system Portal picker at recording start, but region selection remains available here. -->
+              <template v-if="activeTab === 'window'">
+                <template v-if="desktopPlatform !== 'linux'">
                   <div class="device-row">
                     <Layout class="device-icon" />
                     <SourceSelect
@@ -1130,42 +1142,48 @@ const openProject = (project: CaptureProject) => {
                     />
                   </div>
                 </template>
-
-                <div v-else class="device-row">
-                  <Monitor class="device-icon" />
-                  <div class="screen-select-controls">
-                    <SourceSelect
-                      v-model="selectedScreenId"
-                      kind="screen"
-                      :sources="sources"
-                      :previews="screenPreviews"
-                      :loading="screenPreviewsLoading"
-                      :disabled="isRecording || isBusy || displaySources.length === 0"
-                      @toggle="
-                        handleDropdownToggle($event);
-                        if ($event) emit('focus-feature', 'source');
-                      "
-                    />
-                    <Button
-                      :variant="selectedScreenRegion ? 'primary' : 'secondary'"
-                      size="sm"
-                      icon-only
-                      :icon="isRegionConfirmationAnimating ? Check : Crop"
-                      :aria-label="selectedScreenRegion ? t('screenRegionSelected') : t('selectScreenRegion')"
-                      :tooltip="selectedScreenRegion ? t('editScreenRegion') : t('selectScreenRegion')"
-                      :disabled="isRecording || isBusy || !selectedScreenBounds"
-                      :class="{
-                        'screen-region-confirmed': Boolean(selectedScreenRegion),
-                        'screen-region-checkmark': isRegionConfirmationAnimating,
-                      }"
-                      @click="
-                        selectScreenRegion();
-                        emit('focus-feature', 'source');
-                      "
-                    />
-                  </div>
-                </div>
               </template>
+
+              <div v-else class="device-row">
+                <Monitor class="device-icon" />
+                <div class="screen-select-controls">
+                  <SourceSelect
+                    v-if="desktopPlatform !== 'linux'"
+                    v-model="selectedScreenId"
+                    kind="screen"
+                    :sources="sources"
+                    :previews="screenPreviews"
+                    :loading="screenPreviewsLoading"
+                    :disabled="isRecording || isBusy || displaySources.length === 0"
+                    @toggle="
+                      handleDropdownToggle($event);
+                      if ($event) emit('focus-feature', 'source');
+                    "
+                  />
+                  <Button
+                    :variant="selectedScreenRegion ? 'primary' : 'secondary'"
+                    size="sm"
+                    :icon-only="desktopPlatform !== 'linux'"
+                    :block="desktopPlatform === 'linux'"
+                    :icon="isRegionConfirmationAnimating ? Check : Crop"
+                    :aria-label="selectedScreenRegion ? t('screenRegionSelected') : t('selectScreenRegion')"
+                    :tooltip="selectedScreenRegion ? t('editScreenRegion') : t('selectScreenRegion')"
+                    :disabled="isRecording || isBusy || (desktopPlatform !== 'linux' && !selectedScreenBounds)"
+                    :class="{
+                      'screen-region-confirmed': Boolean(selectedScreenRegion),
+                      'screen-region-checkmark': isRegionConfirmationAnimating,
+                    }"
+                    @click="
+                      selectScreenRegion();
+                      emit('focus-feature', 'source');
+                    "
+                  >
+                    <template v-if="desktopPlatform === 'linux'">
+                      {{ selectedScreenRegion ? t('editScreenRegion') : t('selectScreenRegion') }}
+                    </template>
+                  </Button>
+                </div>
+              </div>
 
               <!-- Audio and input devices -->
               <div class="selectors-stack">

--- a/src/components/hud/recorder/useRecordingController.ts
+++ b/src/components/hud/recorder/useRecordingController.ts
@@ -274,7 +274,7 @@ export function useRecordingController(
       if (!session.sessionId) throw new Error('The capture session did not provide an identifier.');
       sessionId = session.sessionId;
       projectId = session.projectId ?? null;
-      if (configuration.region && configuration.regionOverlay)
+      if (capture.platform !== 'linux' && configuration.region && configuration.regionOverlay)
         capture.showScreenRegionOverlay({ ...configuration.regionOverlay, region: configuration.region });
       if (projectId) capture.setTeleprompterSession({ projectId, sessionId });
       stage = 'start-sidecars';

--- a/src/components/hud/region/ScreenRegionOverlayApp.vue
+++ b/src/components/hud/region/ScreenRegionOverlayApp.vue
@@ -207,7 +207,14 @@ onBeforeUnmount(() => unsubscribe?.());
 </script>
 
 <template>
-  <main class="region-overlay" @pointerdown.prevent="begin" @pointermove="move" @pointerup="end" @pointercancel="end">
+  <main
+    class="region-overlay"
+    :class="{ selecting: isSelecting, recording: !isSelecting }"
+    @pointerdown.prevent="begin"
+    @pointermove="move"
+    @pointerup="end"
+    @pointercancel="end"
+  >
     <div v-if="isSelecting && !region" class="region-empty-backdrop" />
     <div
       v-if="region"
@@ -252,10 +259,13 @@ onBeforeUnmount(() => unsubscribe?.());
   position: fixed;
   inset: 0;
   overflow: hidden;
-  cursor: crosshair;
+  cursor: default;
   background: transparent;
   user-select: none;
   touch-action: none;
+}
+.region-overlay.selecting {
+  cursor: crosshair;
 }
 .region-empty-backdrop {
   position: absolute;
@@ -274,6 +284,7 @@ onBeforeUnmount(() => unsubscribe?.());
 }
 .region-frame.recording {
   border: 0;
+  cursor: default;
   outline: 2px solid var(--color-primary);
 }
 .resize-handle {

--- a/src/components/hud/tests/HUD.test.ts
+++ b/src/components/hud/tests/HUD.test.ts
@@ -868,7 +868,10 @@ describe('HUD', () => {
         displayBounds: { x: 10, y: 20, width: 1920, height: 1080 },
       },
     ]);
-    capture.selectScreenRegion.mockResolvedValue({ x: 0.2, y: 0.25, width: 0.4, height: 0.3 });
+    capture.selectScreenRegion.mockResolvedValue({
+      bounds: { x: 10, y: 20, width: 1920, height: 1080 },
+      region: { x: 0.2, y: 0.25, width: 0.4, height: 0.3 },
+    });
     const wrapper = mount(HUD, { global: { stubs } });
     await ready();
     const regionButton = wrapper.get('[aria-label="Select an area of the screen"]');
@@ -885,6 +888,19 @@ describe('HUD', () => {
     });
     expect(capture.setWindowVisible).toHaveBeenLastCalledWith(true);
     expect(wrapper.find('[aria-label="Screen area selected"]').exists()).toBe(true);
+    await wrapper
+      .findAll('button')
+      .find((button) => button.text().includes('Start Recording'))
+      ?.trigger('click');
+    expect(wrapper.emitted('start-recording')).toContainEqual([
+      expect.objectContaining({
+        region: { x: 0.2, y: 0.25, width: 0.4, height: 0.3 },
+        regionOverlay: {
+          bounds: { x: 10, y: 20, width: 1920, height: 1080 },
+          region: { x: 0.2, y: 0.25, width: 0.4, height: 0.3 },
+        },
+      }),
+    ]);
     vi.advanceTimersByTime(700);
     capture.selectScreenRegion.mockRejectedValueOnce(new Error('region denied'));
     await wrapper.get('[aria-label="Screen area selected"]').trigger('click');
@@ -917,7 +933,10 @@ describe('HUD', () => {
       },
     ]);
     capture.getDisplayBounds.mockResolvedValue({ x: 24, y: 48, width: 2560, height: 1440 });
-    capture.selectScreenRegion.mockResolvedValue({ x: 0.1, y: 0.2, width: 0.5, height: 0.4 });
+    capture.selectScreenRegion.mockResolvedValue({
+      bounds: { x: 24, y: 48, width: 2560, height: 1440 },
+      region: { x: 0.1, y: 0.2, width: 0.5, height: 0.4 },
+    });
 
     const wrapper = mount(HUD, { global: { stubs } });
     await ready();
@@ -934,6 +953,55 @@ describe('HUD', () => {
       bounds: { x: 24, y: 48, width: 2560, height: 1440 },
       region: null,
     });
+  });
+
+  it('keeps a textual Linux crop action enabled without a selected display and propagates the Portal result', async () => {
+    capture.platform = 'linux';
+    Object.defineProperty(window, 'capture', { configurable: true, value: capture });
+    capture.discover.mockResolvedValue({
+      sources: [
+        {
+          id: 'portal:monitor',
+          kind: 'display',
+          label: 'Choose a screen with the system picker',
+          isDefault: true,
+          selectionMode: 'portal',
+        },
+      ],
+      capabilities: {},
+    });
+    capture.getSources.mockResolvedValue([]);
+    const bounds = { x: -1920, y: 0, width: 1920, height: 1080 };
+    const region = { x: 0.2, y: 0.25, width: 0.4, height: 0.3 };
+    capture.selectScreenRegion.mockResolvedValue({ bounds, region });
+
+    const wrapper = mount(HUD, { global: { stubs } });
+    await ready();
+
+    const regionButton = wrapper.get('[aria-label="Select an area of the screen"]');
+    expect(regionButton.attributes('disabled')).toBeUndefined();
+    expect(regionButton.classes()).toContain('btn-block');
+    expect(regionButton.classes()).not.toContain('btn-icon-only');
+    expect(regionButton.text()).toContain('Select an area of the screen');
+
+    await regionButton.trigger('click');
+    vi.advanceTimersByTime(180);
+    await ready();
+
+    expect(capture.getDisplayBounds).not.toHaveBeenCalled();
+    expect(capture.selectScreenRegion).toHaveBeenCalledWith({ region: null });
+    expect(wrapper.find('[aria-label="Screen area selected"]').exists()).toBe(true);
+
+    await wrapper
+      .findAll('button')
+      .find((button) => button.text().includes('Start Recording'))
+      ?.trigger('click');
+    expect(wrapper.emitted('start-recording')).toContainEqual([
+      expect.objectContaining({
+        region,
+        regionOverlay: { bounds, region },
+      }),
+    ]);
   });
 
   it('shows the matching screen thumbnail without replacing the native screen id', async () => {
@@ -1226,12 +1294,13 @@ describe('HUD', () => {
     expect(wrapper.get('[aria-label="Select an area of the screen"]').attributes('disabled')).toBeDefined();
   });
 
-  it('keeps screen and window tabs but omits source selector list on Linux', async () => {
+  it('keeps screen and window tabs while exposing the Linux crop action without a source selector', async () => {
     Object.defineProperty(window, 'capture', { configurable: true, value: { ...capture, platform: 'linux' } });
     const wrapper = mount(HUD, { global: { stubs } });
     await ready();
     expect(wrapper.find('.mode-tabs').exists()).toBe(true);
-    expect(wrapper.find('.screen-select-controls').exists()).toBe(false);
+    expect(wrapper.find('.screen-select-controls').exists()).toBe(true);
+    expect(wrapper.get('[aria-label="Select an area of the screen"]').classes()).toContain('btn-block');
   });
 
   it('supports mouse back (button 3) and forward (button 4) navigation across HUD views', async () => {

--- a/src/components/hud/tests/ScreenRegionOverlayApp.test.ts
+++ b/src/components/hud/tests/ScreenRegionOverlayApp.test.ts
@@ -151,11 +151,44 @@ describe('ScreenRegionOverlayApp', () => {
     });
     await wrapper.vm.$nextTick();
 
+    const overlay = wrapper.get('.region-overlay');
+    expect(overlay.classes()).toContain('recording');
+    expect(overlay.classes()).not.toContain('selecting');
     const frame = wrapper.get('.region-frame');
     expect(frame.classes()).toContain('recording');
     expect(frame.classes()).not.toContain('selecting');
     expect(wrapper.find('.region-toolbar').exists()).toBe(false);
     expect(wrapper.findAll('.resize-handle')).toHaveLength(0);
+  });
+
+  it('uses crosshair and selection controls only in select mode', async () => {
+    let configure!: (value: {
+      mode: 'select' | 'record';
+      bounds: { width: number; height: number };
+      region: { x: number; y: number; width: number; height: number };
+    }) => void;
+    capture.onScreenRegionConfigure.mockImplementation((next: typeof configure) => {
+      configure = next;
+      return vi.fn();
+    });
+    const wrapper = mount(ScreenRegionOverlayApp, { global: { stubs: { Button, Select } } });
+    const region = { x: 0.1, y: 0.2, width: 0.5, height: 0.4 };
+    configure({ mode: 'select', bounds: { width: 1920, height: 1080 }, region });
+    await wrapper.vm.$nextTick();
+
+    const overlay = wrapper.get('.region-overlay');
+    expect(overlay.classes()).toContain('selecting');
+    expect(overlay.classes()).not.toContain('recording');
+    expect(wrapper.get('.region-frame').classes()).toContain('selecting');
+    expect(wrapper.find('.region-toolbar').exists()).toBe(true);
+
+    configure({ mode: 'record', bounds: { width: 1920, height: 1080 }, region });
+    await wrapper.vm.$nextTick();
+    expect(overlay.classes()).toContain('recording');
+    expect(overlay.classes()).not.toContain('selecting');
+    expect(wrapper.get('.region-frame').classes()).toContain('recording');
+    expect(wrapper.get('.region-frame').classes()).not.toContain('selecting');
+    expect(wrapper.find('.region-toolbar').exists()).toBe(false);
   });
 
   it('applies a selected preset and persists it to preferences', async () => {

--- a/src/components/hud/tests/capture.mock.ts
+++ b/src/components/hud/tests/capture.mock.ts
@@ -1,4 +1,5 @@
 import { vi } from 'vitest';
+import type { ScreenRegionSelectionOptions, ScreenRegionSelectionResult } from '../../../api/types/screen-region';
 
 export const captureMock = {
   platform: 'darwin',
@@ -22,7 +23,7 @@ export const captureMock = {
     shortcuts: true,
     recordsText: false,
   }),
-  selectScreenRegion: vi.fn(),
+  selectScreenRegion: vi.fn<(options: ScreenRegionSelectionOptions) => Promise<ScreenRegionSelectionResult | null>>(),
   startRecording: vi.fn(),
   stop: vi.fn(),
   discardRecording: vi.fn(),

--- a/src/components/hud/tests/useRecordingControllerBranches.test.ts
+++ b/src/components/hud/tests/useRecordingControllerBranches.test.ts
@@ -220,6 +220,7 @@ describe('useRecordingController branch behavior', () => {
   });
 
   it('shows the recording area marker only after native recording starts', async () => {
+    capture.platform = 'darwin';
     const controller = useRecordingController(vi.fn());
 
     await controller.start(
@@ -239,6 +240,21 @@ describe('useRecordingController branch behavior', () => {
     expect(capture.startPreparedRecording.mock.invocationCallOrder[0]).toBeLessThan(
       capture.showScreenRegionOverlay.mock.invocationCallOrder[0],
     );
+  });
+
+  it('does not show a second region overlay while recording on Linux', async () => {
+    capture.platform = 'linux';
+    const controller = useRecordingController(vi.fn());
+    await controller.start(
+      configuration({
+        region: { x: 0.1, y: 0.2, width: 0.5, height: 0.4 },
+        regionOverlay: { bounds: { x: 10, y: 20, width: 100, height: 80 } },
+      }),
+    );
+    await waitForRecording(controller);
+
+    expect(capture.showScreenRegionOverlay).not.toHaveBeenCalled();
+    await controller.stop();
   });
 
   it('starts the sidecar timeline after delayed native startup', async () => {

--- a/test/capture-config.test.cjs
+++ b/test/capture-config.test.cjs
@@ -174,10 +174,16 @@ test('enables clicks and shortcuts on Linux only when interaction recording is o
   });
 });
 
-test('builds a Linux window Portal selection and rejects region capture', () => {
+test('keeps a region for Linux Portal monitors and rejects it for windows', () => {
   const portalCatalog = {
     capabilities: { portalSelection: true },
     sources: [
+      {
+        id: 'portal:monitor',
+        kind: 'display',
+        isDefault: true,
+        selectionMode: 'portal',
+      },
       {
         id: 'portal:window',
         kind: 'window',
@@ -187,15 +193,31 @@ test('builds a Linux window Portal selection and rejects region capture', () => 
     ],
   };
   const linux = { ...environment, platform: 'linux' };
-  assert.equal(buildDefaultCaptureConfig(portalCatalog, { screenKind: 'window' }, linux).screen.kind, 'window');
+  const region = { x: 0.1, y: 0.2, width: 0.5, height: 0.4 };
+  const monitor = buildDefaultCaptureConfig(
+    portalCatalog,
+    { screenId: 'portal:monitor', region },
+    linux,
+  );
+  assert.deepEqual(monitor.screen, {
+    mode: 'portal',
+    kind: 'monitor',
+    restoreToken: null,
+  });
+  assert.deepEqual(monitor.region, region);
+
+  assert.equal(
+    buildDefaultCaptureConfig(portalCatalog, { screenKind: 'window', screenId: 'portal:window' }, linux).screen.kind,
+    'window',
+  );
   assert.throws(
     () =>
       buildDefaultCaptureConfig(
         portalCatalog,
-        { screenKind: 'window', region: { x: 0, y: 0, width: 1, height: 1 } },
+        { screenKind: 'window', screenId: 'portal:window', region },
         linux,
       ),
-    /picker système Linux/,
+    /uniquement pour un écran/,
   );
 });
 

--- a/test/screen-region-overlay.test.cjs
+++ b/test/screen-region-overlay.test.cjs
@@ -6,6 +6,10 @@ test('cleans a failed region selection so a later selection can complete', async
   const calls = [];
   const listeners = new Map();
   let destroyed = false;
+  const parentWindow = {
+    isDestroyed: () => false,
+    getBounds: () => ({ x: 2048, y: 120, width: 352, height: 512 }),
+  };
   const window = {
     webContents: { send: (...args) => calls.push(['send', ...args]) },
     once: (event, listener) => listeners.set(event, listener),
@@ -13,6 +17,7 @@ test('cleans a failed region selection so a later selection can complete', async
     isDestroyed: () => destroyed,
     setContentProtection: (value) => calls.push(['contentProtection', value]),
     setBounds: (bounds) => calls.push(['bounds', bounds]),
+    setParentWindow: (parent) => calls.push(['parent', parent]),
     setIgnoreMouseEvents: (value) => calls.push(['mouse', value]),
     show: () => calls.push(['show']),
     showInactive: () => calls.push(['showInactive']),
@@ -32,6 +37,13 @@ test('cleans a failed region selection so a later selection can complete', async
         return window;
       }
     },
+    screen: {
+      getDisplayMatching: (bounds) => {
+        calls.push(['getDisplayMatching', bounds]);
+        return { bounds: { x: 1920, y: 0, width: 2560, height: 1440 } };
+      },
+      getPrimaryDisplay: () => ({ bounds: { x: 0, y: 0, width: 1920, height: 1080 } }),
+    },
   };
   const originalLoad = Module._load;
   Module._load = function load(request, parent, isMain) {
@@ -39,19 +51,110 @@ test('cleans a failed region selection so a later selection can complete', async
   };
 
   try {
+    const modulePath = require.resolve('../electron/screen-region-overlay.cjs');
+    delete require.cache[modulePath];
     const { createScreenRegionOverlayWindow } = require('../electron/screen-region-overlay.cjs');
-    const overlay = createScreenRegionOverlayWindow({ applicationRoot: '/app', isPackaged: false });
+    const overlay = createScreenRegionOverlayWindow({
+      applicationRoot: '/app',
+      isPackaged: false,
+      platform: 'linux',
+      screen: electron.screen,
+    });
 
     assert.throws(
-      () => overlay.select({ bounds: { x: 0, y: 0, width: 0, height: 1080 }, region: null }),
+      () => overlay.select({ bounds: { x: 0, y: 0, width: 0, height: 1080 }, region: null }, parentWindow),
       /Screen overlay size is invalid/,
     );
-    assert.ok(calls.some((call) => call[0] === 'hide'));
 
-    const nextSelection = overlay.select({ bounds: { x: 0, y: 0, width: 1920, height: 1080 }, region: null });
+    const bounds = { x: 0, y: 0, width: 1920, height: 1080 };
+    const nextSelection = overlay.select({ bounds, region: null }, parentWindow);
     const selectedRegion = { x: 0.1, y: 0.2, width: 0.5, height: 0.4 };
     overlay.confirm(selectedRegion);
-    assert.deepEqual(await nextSelection, selectedRegion);
+    assert.deepEqual(await nextSelection, { bounds, region: selectedRegion });
+    assert.deepEqual(
+      calls.filter((call) => call[0] === 'parent').map((call) => call[1]),
+      [parentWindow, null],
+    );
+  } finally {
+    Module._load = originalLoad;
+  }
+});
+
+test('resolves Linux selection bounds from the parent display and falls back to the primary display', async () => {
+  const calls = [];
+  const listeners = new Map();
+  let destroyed = false;
+  const parentWindow = {
+    isDestroyed: () => false,
+    getBounds: () => ({ x: 2048, y: 120, width: 352, height: 512 }),
+  };
+  const window = {
+    webContents: { send: (...args) => calls.push(['send', ...args]) },
+    once: (event, listener) => listeners.set(event, listener),
+    on: (event, listener) => listeners.set(event, listener),
+    isDestroyed: () => destroyed,
+    setContentProtection: (value) => calls.push(['contentProtection', value]),
+    setBounds: (bounds) => calls.push(['bounds', bounds]),
+    setParentWindow: (parent) => calls.push(['parent', parent]),
+    setIgnoreMouseEvents: (value) => calls.push(['mouse', value]),
+    show: () => calls.push(['show']),
+    showInactive: () => calls.push(['showInactive']),
+    focus: () => calls.push(['focus']),
+    moveTop: () => calls.push(['moveTop']),
+    hide: () => calls.push(['hide']),
+    destroy: () => {
+      destroyed = true;
+      listeners.get('closed')?.();
+    },
+    loadURL: () => undefined,
+    loadFile: () => undefined,
+  };
+  const matchingBounds = { x: 1920, y: 0, width: 2560, height: 1440 };
+  const primaryBounds = { x: 0, y: 0, width: 1920, height: 1080 };
+  const screen = {
+    getDisplayMatching: (bounds) => {
+      calls.push(['getDisplayMatching', bounds]);
+      return { bounds: matchingBounds };
+    },
+    getPrimaryDisplay: () => ({ bounds: primaryBounds }),
+  };
+  const electron = {
+    BrowserWindow: class {
+      constructor() {
+        return window;
+      }
+    },
+  };
+  const originalLoad = Module._load;
+  Module._load = function load(request, parent, isMain) {
+    return request === 'electron' ? electron : originalLoad.call(this, request, parent, isMain);
+  };
+
+  try {
+    const modulePath = require.resolve('../electron/screen-region-overlay.cjs');
+    delete require.cache[modulePath];
+    const { createScreenRegionOverlayWindow } = require('../electron/screen-region-overlay.cjs');
+    const overlay = createScreenRegionOverlayWindow({
+      applicationRoot: '/app',
+      isPackaged: false,
+      platform: 'linux',
+      screen,
+    });
+
+    const parentSelection = overlay.select({ region: null }, parentWindow);
+    const selectedRegion = { x: 0.2, y: 0.25, width: 0.4, height: 0.3 };
+    overlay.confirm(selectedRegion);
+    assert.deepEqual(await parentSelection, { bounds: matchingBounds, region: selectedRegion });
+    assert.deepEqual(
+      calls.find((call) => call[0] === 'getDisplayMatching'),
+      ['getDisplayMatching', parentWindow.getBounds()],
+    );
+
+    const primarySelection = overlay.select({ region: null });
+    overlay.cancel();
+    assert.equal(await primarySelection, null);
+    assert.deepEqual(calls.filter((call) => call[0] === 'bounds').at(-1), ['bounds', primaryBounds]);
+    assert.deepEqual(calls.filter((call) => call[0] === 'parent').at(-1), ['parent', null]);
   } finally {
     Module._load = originalLoad;
   }


### PR DESCRIPTION
## Summary

- add normalized monitor-region cropping to the Linux Portal/PipeWire capture path
- expose a dedicated Linux crop action and resolve overlay bounds from the HUD display
- keep the selection overlay interactive, then hide it during Linux recording to preserve normal pointer behavior
- retain the passive click-through recording marker on Windows and macOS

## Validation

- cargo fmt -p capture --check
- cargo test -p capture screen::linux::pipewire::tests (34 passed)
- cargo test -p capture --test model (8 passed)
- cargo clippy -p capture --lib --tests -- -D warnings
- focused Electron Node tests (13 passed)
- focused HUD/overlay/controller Vitest tests (53 passed)
- TypeScript typecheck passed

## Notes

- The real Portal/PipeWire hardware flow still requires manual validation in an active Linux desktop session.
- The repository-wide Vue typecheck is currently blocked by an unrelated master error in WebsiteHeroDrag.vue: the required autoHide prop is missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Linux screen recording now supports selecting and cropping regions from Portal monitor captures.
  - Region selection works without manually choosing a display first.
  - Selection results retain both the selected area and its display bounds.
  - Linux capture preserves cursor positioning and handles rotated or padded frames correctly.

- **Bug Fixes**
  - Improved overlay behavior when selecting, confirming, or canceling regions.
  - Portal window captures correctly reject unsupported region selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->