### PR TITLE
fix(capture): filter macOS system surfaces from window picker

### DIFF
--- a/packages/capture/src/screen/mac/catalog.rs
+++ b/packages/capture/src/screen/mac/catalog.rs
@@ -63,6 +63,9 @@ fn window_descriptor(
     window: screencapturekit::shareable_content::SCWindow,
 ) -> Option<SourceDescriptor> {
     let title = window.title()?;
+    if title.trim().is_empty() {
+        return None;
+    }
     let application = window.owning_application()?;
     let application_name = application.application_name();
     let frame = window.frame();

--- a/packages/capture/src/screen/mac/catalog.rs
+++ b/packages/capture/src/screen/mac/catalog.rs
@@ -8,6 +8,8 @@ use crate::{
     },
 };
 
+use super::catalog_policy::is_user_window_candidate;
+
 pub fn discover_sources() -> Result<Vec<SourceDescriptor>, CaptureError> {
     let content = SCShareableContent::create()
         // Desktop-independent windows remain selectable in other Spaces and
@@ -61,16 +63,21 @@ fn window_descriptor(
     window: screencapturekit::shareable_content::SCWindow,
 ) -> Option<SourceDescriptor> {
     let title = window.title()?;
-    if title.trim().is_empty() {
+    let application = window.owning_application()?;
+    let application_name = application.application_name();
+    let frame = window.frame();
+    if !is_user_window_candidate(
+        window.window_layer(),
+        &title,
+        &application_name,
+        frame.size.width,
+        frame.size.height,
+    ) {
         return None;
     }
-    let frame = window.frame();
     let width = dimension(frame.size.width);
     let height = dimension(frame.size.height);
-    let label = window.owning_application().map_or_else(
-        || title.clone(),
-        |application| format!("{title} — {}", application.application_name()),
-    );
+    let label = format!("{title} — {application_name}");
     Some(SourceDescriptor {
         id: SourceId::new(format!("sck:window:{}", window.window_id())).ok()?,
         kind: SourceKind::Window,

--- a/packages/capture/src/screen/mac/catalog_policy.rs
+++ b/packages/capture/src/screen/mac/catalog_policy.rs
@@ -1,0 +1,19 @@
+// ScreenCaptureKit also reports menu-bar items and other WindowServer surfaces.
+// AppKit reserves layer 0 for normal application windows.
+const NORMAL_WINDOW_LAYER: i32 = 0;
+
+pub(crate) fn is_user_window_candidate(
+    window_layer: i32,
+    title: &str,
+    application_name: &str,
+    width: f64,
+    height: f64,
+) -> bool {
+    window_layer == NORMAL_WINDOW_LAYER
+        && !title.trim().is_empty()
+        && !application_name.trim().is_empty()
+        && width.is_finite()
+        && width > 0.0
+        && height.is_finite()
+        && height > 0.0
+}

--- a/packages/capture/src/screen/mac/mod.rs
+++ b/packages/capture/src/screen/mac/mod.rs
@@ -1,5 +1,6 @@
 mod capture;
 mod catalog;
+mod catalog_policy;
 mod permissions;
 mod preview;
 

--- a/packages/capture/tests/mac_window_catalog_policy.rs
+++ b/packages/capture/tests/mac_window_catalog_policy.rs
@@ -1,3 +1,5 @@
+// The native macOS module is target-gated, so include this pure policy directly
+// to exercise it in the Linux quality job as well as macOS builds.
 #[path = "../src/screen/mac/catalog_policy.rs"]
 mod catalog_policy;
 
@@ -5,10 +7,10 @@ use catalog_policy::is_user_window_candidate;
 
 #[test]
 fn normal_application_windows_are_candidates() {
-    for (application_name, title) in [
-        ("Google Chrome", "Beam documentation"),
-        ("Beam Editor", "Untitled project"),
-        ("Discord", "Beam team"),
+    for (title, application_name) in [
+        ("Beam documentation", "Google Chrome"),
+        ("Untitled project", "Beam Editor"),
+        ("Beam team", "Discord"),
     ] {
         assert!(is_user_window_candidate(
             0,

--- a/packages/capture/tests/mac_window_catalog_policy.rs
+++ b/packages/capture/tests/mac_window_catalog_policy.rs
@@ -1,0 +1,86 @@
+#[path = "../src/screen/mac/catalog_policy.rs"]
+mod catalog_policy;
+
+use catalog_policy::is_user_window_candidate;
+
+#[test]
+fn normal_application_windows_are_candidates() {
+    for (application_name, title) in [
+        ("Google Chrome", "Beam documentation"),
+        ("Beam Editor", "Untitled project"),
+        ("Discord", "Beam team"),
+    ] {
+        assert!(is_user_window_candidate(
+            0,
+            title,
+            application_name,
+            1280.0,
+            720.0,
+        ));
+    }
+}
+
+#[test]
+fn system_and_floating_window_layers_are_rejected() {
+    for window_layer in [3, 24, 25, 101] {
+        assert!(!is_user_window_candidate(
+            window_layer,
+            "System UI",
+            "SystemUIServer",
+            1280.0,
+            720.0,
+        ));
+    }
+}
+
+#[test]
+fn missing_window_titles_are_rejected() {
+    for title in ["", " ", "\t", "\n", "  \t\n  "] {
+        assert!(!is_user_window_candidate(
+            0,
+            title,
+            "Beam Editor",
+            1280.0,
+            720.0,
+        ));
+    }
+}
+
+#[test]
+fn missing_application_names_are_rejected() {
+    for application_name in ["", " ", "\t", "\n", "  \t\n  "] {
+        assert!(!is_user_window_candidate(
+            0,
+            "Untitled project",
+            application_name,
+            1280.0,
+            720.0,
+        ));
+    }
+}
+
+#[test]
+fn invalid_window_dimensions_are_rejected() {
+    let invalid_dimensions = [
+        (0.0, 720.0),
+        (1280.0, 0.0),
+        (-1.0, 720.0),
+        (1280.0, -1.0),
+        (f64::NAN, 720.0),
+        (1280.0, f64::NAN),
+        (f64::INFINITY, 720.0),
+        (1280.0, f64::INFINITY),
+        (f64::NEG_INFINITY, 720.0),
+        (1280.0, f64::NEG_INFINITY),
+    ];
+
+    for (width, height) in invalid_dimensions {
+        assert!(!is_user_window_candidate(
+            0,
+            "Untitled project",
+            "Beam Editor",
+            width,
+            height,
+        ));
+    }
+}


### PR DESCRIPTION
## Summary

- keep ScreenCaptureKit discovery enabled across macOS Spaces and fullscreen contexts
- restrict HUD window candidates to normal application windows with an owner, title, and valid geometry
- prevent status-bar, menu, floating, and popup surfaces from reaching the native preview fan-out

## Testing

- `cargo fmt --all --check`
- `cargo test -p capture --test mac_window_catalog_policy` (5 passed)
- `cargo clippy -p capture --test mac_window_catalog_policy -- -D warnings`
- `git diff --check`

## Platform note

A macOS cross-target check was attempted from Linux, but the ScreenCaptureKit and Metal Swift bridges require Xcode/`xcrun`. Manual macOS validation should cover Chrome, Discord, Beam Editor, another Space, fullscreen, and confirm that StatusBar / Audio-Video Module / `com.apple.screencapture` entries are absent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS window selection for screen capture.
  * Excludes system, floating, untitled, unnamed, and invalid-size windows from available capture options.
  * Displays accepted windows with labels that include their owning application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->