### PR TITLE
fix(hud): prevent accidental browser zoom

### DIFF
--- a/docs/electron_window.md
+++ b/docs/electron_window.md
@@ -6,11 +6,11 @@ This application uses transparent, frameless Electron windows as part of the UI.
 
 The transparent main window is controlled by `electron/window/window-controller.cjs` and owns the HUD and Recorder modes. The editor uses a separate opaque window created by `electron/window/editor-window.cjs`; this separation is required for native window animations and Windows Snap Layouts.
 
-| Mode       | Bounds / behavior                                                                                                                                                                                                                                 | Interaction                                                                                                                                                                                                                               |
-| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `hud`      | `352 × 512`: a `320 × 480` HUD card plus 16 px of room on every edge for its border and shadow. It returns to its prior HUD position after Recorder mode. Dragging is bounded by the physical display bounds, not the taskbar-excluded work area. | macOS/Windows: transparent pixels pass through; renderer enables mouse handling only over interactive HUD elements. Linux: the window stays fully interactive, so the 16 px transparent margin also captures clicks (accepted trade-off). |
-| `recorder` | `72 × 344`, positioned at the right-middle of the active display. It is draggable and remembers a position per display in preferences.                                                                                                            | Always on top, fixed size, content protected. Drag starts only on mousedown, never on hover.                                                                                                                                              |
-| `editor`   | Independent opaque windows starting at `1280 × 800`, with a native minimum of `960 × 600`.                                                                                                                                                        | `titleBarStyle: hidden` keeps the custom Beam content while Window Controls Overlay supplies the native system buttons. The empty titlebar area uses `app-region: drag`; Beam actions stay in `no-drag` regions.                          |
+| Mode       | Bounds / behavior                                                                                                                                                                                                                                                                                                                                                                              | Interaction                                                                                                                                                                                                                         |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `hud`      | Fixed at `352 × 512`: a `320 × 480` HUD card plus 16 px of room on every edge for its border and shadow. The canonical dimensions live in `preferences.json` as `hudWindow`; startup normalization restores them when missing or unexpected. It returns to its prior HUD position after Recorder mode. Dragging is bounded by the physical display bounds, not the taskbar-excluded work area. | macOS/Windows: transparent pixels pass through; renderer enables mouse handling only over interactive HUD elements. Linux: the window stays fully interactive, so the transparent margin also captures clicks (accepted trade-off). |
+| `recorder` | `72 × 344`, positioned at the right-middle of the active display. It is draggable and remembers a position per display in preferences.                                                                                                                                                                                                                                                         | Always on top, fixed size, content protected. Drag starts only on mousedown, never on hover.                                                                                                                                        |
+| `editor`   | Independent opaque windows starting at `1280 × 800`, with a native minimum of `960 × 600`.                                                                                                                                                                                                                                                                                                     | `titleBarStyle: hidden` keeps the custom Beam content while Window Controls Overlay supplies the native system buttons. The empty titlebar area uses `app-region: drag`; Beam actions stay in `no-drag` regions.                    |
 
 Use `window:show-hud` / `capture.showHud()` to return from the editor. Do not reproduce it by separately changing mode, maximize state, size, and position: ordering matters.
 
@@ -26,7 +26,7 @@ Native window titles identify their role in the operating-system switcher: the H
 
 Electron clips painting outside the BrowserWindow. A CSS shadow around an element that touches the renderer viewport is therefore visibly cut off and looks like a rectangular dark block.
 
-- Keep the HUD card at `320 × 480`, but keep the BrowserWindow at `352 × 512` and the card inset by `16px`.
+- Keep the HUD card at `320 × 480` pixels, with a `352 × 512` BrowserWindow and a 16 px inset.
 - When HUD content changes height or width, include the 32 px outer allowance in the Electron `setSize` request.
 - Do not solve a clipped shadow by increasing the shadow token. Prefer reserving physical renderer space first.
 - The countdown uses the same rule: its circle is inset by 16 px in a larger transparent window so its border and shadow remain intact.
@@ -53,6 +53,12 @@ Teleporting a popover to `body` does not let it escape its BrowserWindow. It can
 - The camera popover temporarily expands its native window. Before expansion, store the window bounds; after expansion, offset the rendered camera preview by the inverse native-window displacement. On close, restore both the original bounds and a zero preview offset. Without that compensation, opening the popover visibly moves the camera preview.
 - Nested teleported popovers must be registered as descendants using `data-popover-owner`; otherwise selecting an inner `Select` is treated as an outside click and closes its parent.
 
+## UI scaling and browser zoom
+
+- `appearance.uiScale` is an editor-only product setting. Do not expose or apply it in the HUD.
+- Chromium page zoom is not a product setting. Keep `webPreferences.zoomFactor` at 1, reset persisted page zoom before presenting HUD/editor windows, and block Ctrl/Cmd plus wheel or browser zoom keys. Timeline and canvas zoom handlers may still consume wheel input for their own scoped behavior.
+- Keep `hudWindow.width` and `hudWindow.height` at the canonical `352 × 512` values. Preferences normalization must replace missing, malformed, or unexpected values before the HUD window is created.
+
 ## Content protection and capture
 
 Recorder mode enables Electron content protection. Camera and Recorder windows must remain separate from the native capture session logic; renderer-side windows are only presentation and sidecar controls. Do not broaden preload APIs beyond narrow, named IPC calls.
@@ -65,4 +71,5 @@ Recorder mode enables Electron content protection. Camera and Recorder windows m
 4. Verify transparent regions do not steal clicks or focus.
 5. Verify popovers at each screen edge and with nested selects.
 6. Verify HUD → Recorder → Editor → HUD restores the intended bounds and position.
-7. Run `bun run build` and the focused tests.
+7. Verify Ctrl/Cmd plus wheel, `+`, `-`, and `0` cannot change HUD or editor browser zoom, while editor timeline/canvas zoom still works.
+8. Run `bun run build` and the focused tests.

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -27,6 +27,8 @@ const {
 const { createProjectMediaHandler } = require('./projects/project-media-protocol.cjs');
 const { WindowController } = require('./window/window-controller.cjs');
 const { registerWindowIpc } = require('./window/window-ipc.cjs');
+const { enforceDefaultZoom, installBrowserZoomPolicy } = require('./window/browser-zoom-policy.cjs');
+const { normalizeHudWindowSize } = require('./window/hud-window-size.cjs');
 const { shouldAutoOpenDevTools } = require('./window/devtools-policy.cjs');
 const { createEditorWindowManager } = require('./window/editor-window.cjs');
 const { createOnboardingWindowManager } = require('./window/onboarding-window.cjs');
@@ -191,9 +193,10 @@ function getAppIconPath() {
 
 function createWindow(preferencesStore, appIconPath) {
   logStartup('Creating BrowserWindow.');
+  const initialSize = normalizeHudWindowSize(preferencesStore.read().hudWindow);
   const win = new BrowserWindow({
-    width: 352,
-    height: 512,
+    width: initialSize.width,
+    height: initialSize.height,
     frame: false,
     transparent: true,
     alwaysOnTop: true,
@@ -208,14 +211,20 @@ function createWindow(preferencesStore, appIconPath) {
       contextIsolation: true,
       sandbox: false,
       webSecurity: false,
+      zoomFactor: 1,
     },
   });
+  // Calling setZoomFactor on a hidden window before its first paint can suppress
+  // `ready-to-show`. The constructor default handles initial rendering; reset
+  // persisted Chromium zoom only after that event.
+  installBrowserZoomPolicy(win.webContents, { resetOnLoad: false });
   const controller = new WindowController(win, { preferencesStore });
   controllers.set(win, controller);
   // use profileRendererRequests() to see all the requests made by the app and find out why it's slow to launch.
   // profileRendererRequests(win.webContents)
   win.once('ready-to-show', () => {
     logStartup('Window is ready to show (ready-to-show).');
+    enforceDefaultZoom(win.webContents);
     if (preferencesStore.read().onboardingCompleted) controller.markReadyToShow();
   });
   win.webContents.once('did-start-loading', () => logStartup('Renderer navigation started.'));
@@ -258,6 +267,7 @@ function initializeApplication() {
     registerInputAccessIpc(applicationIpc, inputAccess);
     const userPaths = createUserPaths(app.getPath('videos'));
     const preferencesStore = createPreferencesStore(userPaths.preferences, { platform: process.platform });
+    const startupPreferences = preferencesStore.repair();
     const applySpellCheck = (preferences) =>
       applySpellCheckPreferences({
         electronSession: session.defaultSession,
@@ -265,7 +275,7 @@ function initializeApplication() {
         platform: process.platform,
         systemLocale: app.getLocale(),
       });
-    applySpellCheck(preferencesStore.read());
+    applySpellCheck(startupPreferences);
     const spellCheckContextMenuCleanup = registerSpellCheckContextMenu({
       app,
       Menu,

--- a/electron/preferences/preferences-store.cjs
+++ b/electron/preferences/preferences-store.cjs
@@ -191,13 +191,39 @@ const normalize = (value, platform = process.platform) => {
 };
 function createPreferencesStore(file, { platform = process.platform } = {}) {
   const targetFile = path.extname(file) ? file : path.join(file, 'preferencesSettings.json');
-  const read = () => {
+  const runtimeFallback = (value) => {
     try {
-      return normalize(JSON.parse(fs.readFileSync(targetFile, 'utf8')), platform);
+      return normalize({ ...(value && typeof value === 'object' ? value : {}), shortcuts: undefined }, platform);
     } catch {
       return defaults(platform);
     }
   };
+  const inspect = () => {
+    let source;
+    try {
+      source = fs.readFileSync(targetFile, 'utf8');
+    } catch (error) {
+      if (error?.code === 'ENOENT') return { preferences: defaults(platform), writable: true, quarantine: false };
+      return { preferences: defaults(platform), writable: false, quarantine: false, error };
+    }
+
+    let parsed;
+    try {
+      parsed = JSON.parse(source);
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        return { preferences: defaults(platform), writable: true, quarantine: true };
+      }
+      return { preferences: defaults(platform), writable: false, quarantine: false, error };
+    }
+
+    try {
+      return { preferences: normalize(parsed, platform), writable: true, quarantine: false };
+    } catch (error) {
+      return { preferences: runtimeFallback(parsed), writable: false, quarantine: false, error };
+    }
+  };
+  const read = () => inspect().preferences;
   const write = (value) => {
     const next = normalize(value, platform);
     fs.mkdirSync(path.dirname(targetFile), { recursive: true });
@@ -207,7 +233,9 @@ function createPreferencesStore(file, { platform = process.platform } = {}) {
     return next;
   };
   const patch = (value) => {
-    const current = read();
+    const inspected = inspect();
+    if (!inspected.writable) throw inspected.error;
+    const current = inspected.preferences;
     const nextAppearance = value?.appearance ? { ...current.appearance, ...value.appearance } : current.appearance;
     const nextTheme = value?.theme || value?.appearance?.theme || current.theme;
     if (nextAppearance) {
@@ -232,7 +260,23 @@ function createPreferencesStore(file, { platform = process.platform } = {}) {
       extras: { ...current.extras, ...(value?.extras || {}) },
     });
   };
-  const repair = () => write(read());
+  const quarantineMalformedFile = () => {
+    const base = `${targetFile}.invalid`;
+    let quarantineFile = base;
+    let suffix = 1;
+    while (fs.existsSync(quarantineFile)) quarantineFile = `${base}-${suffix++}`;
+    fs.renameSync(targetFile, quarantineFile);
+  };
+  const repair = () => {
+    const inspected = inspect();
+    if (!inspected.writable) return inspected.preferences;
+    try {
+      if (inspected.quarantine) quarantineMalformedFile();
+      return write(inspected.preferences);
+    } catch {
+      return inspected.preferences;
+    }
+  };
   return { read, write, patch, repair, file: targetFile };
 }
 module.exports = { createPreferencesStore, defaults, normalize };

--- a/electron/preferences/preferences-store.cjs
+++ b/electron/preferences/preferences-store.cjs
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const { DEFAULT_HUD_WINDOW_SIZE, normalizeHudWindowSize } = require('../window/hud-window-size.cjs');
 
 const defaultAppearance = () => ({
   theme: 'light',
@@ -23,6 +24,7 @@ const defaults = (platform = process.platform) => ({
   schemaVersion: 3,
   theme: 'light',
   appearance: defaultAppearance(),
+  hudWindow: { ...DEFAULT_HUD_WINDOW_SIZE },
   recordingBar: { visibility: platform === 'linux' ? 'hover-only' : 'always' },
   recordingInteractions: { enabled: false, noticeDismissed: false },
   voiceover: { countdownSeconds: 3, monitorProjectAudio: false },
@@ -151,6 +153,7 @@ const normalize = (value, platform = process.platform) => {
     schemaVersion: 3,
     theme: resolvedTheme,
     appearance: appearanceSettings,
+    hudWindow: normalizeHudWindowSize(next.hudWindow),
     recordingBar: {
       visibility: ['always', 'auto-fade', 'hover-only'].includes(next.recordingBar?.visibility)
         ? next.recordingBar.visibility
@@ -215,6 +218,7 @@ function createPreferencesStore(file, { platform = process.platform } = {}) {
       ...(value || {}),
       theme: nextTheme,
       appearance: nextAppearance,
+      hudWindow: { ...current.hudWindow, ...value?.hudWindow },
       recordingBar: { ...current.recordingBar, ...(value?.recordingBar || {}) },
       recordingInteractions: {
         ...current.recordingInteractions,
@@ -228,6 +232,7 @@ function createPreferencesStore(file, { platform = process.platform } = {}) {
       extras: { ...current.extras, ...(value?.extras || {}) },
     });
   };
-  return { read, write, patch, file: targetFile };
+  const repair = () => write(read());
+  return { read, write, patch, repair, file: targetFile };
 }
 module.exports = { createPreferencesStore, defaults, normalize };

--- a/electron/window/browser-zoom-policy.cjs
+++ b/electron/window/browser-zoom-policy.cjs
@@ -1,0 +1,42 @@
+const DEFAULT_ZOOM_FACTOR = 1;
+const ZOOM_KEYS = new Set(['+', '=', '-', '_', '0']);
+
+function isBrowserZoomShortcut(input) {
+  return Boolean(
+    input?.type === 'keyDown' &&
+    (input.control || input.meta) &&
+    ZOOM_KEYS.has(typeof input.key === 'string' ? input.key : ''),
+  );
+}
+
+function enforceDefaultZoom(webContents) {
+  if (!webContents || webContents.isDestroyed?.()) return;
+  webContents.setZoomLevel?.(0);
+  webContents.setZoomFactor?.(DEFAULT_ZOOM_FACTOR);
+}
+
+function installBrowserZoomPolicy(webContents, { resetOnLoad = true } = {}) {
+  if (!webContents) return () => undefined;
+
+  const restore = () => enforceDefaultZoom(webContents);
+  const restoreAfterRequest = (event) => {
+    event?.preventDefault?.();
+    restore();
+    setImmediate(restore);
+  };
+  const preventKeyboardZoom = (event, input) => {
+    if (isBrowserZoomShortcut(input)) event.preventDefault();
+  };
+
+  webContents.on?.('zoom-changed', restoreAfterRequest);
+  webContents.on?.('before-input-event', preventKeyboardZoom);
+  if (resetOnLoad) webContents.on?.('did-finish-load', restore);
+
+  return () => {
+    webContents.removeListener?.('zoom-changed', restoreAfterRequest);
+    webContents.removeListener?.('before-input-event', preventKeyboardZoom);
+    if (resetOnLoad) webContents.removeListener?.('did-finish-load', restore);
+  };
+}
+
+module.exports = { DEFAULT_ZOOM_FACTOR, enforceDefaultZoom, installBrowserZoomPolicy, isBrowserZoomShortcut };

--- a/electron/window/editor-window.cjs
+++ b/electron/window/editor-window.cjs
@@ -235,7 +235,7 @@ function createEditorWindowManager({
         zoomFactor: 1,
       },
     });
-    installBrowserZoomPolicy(window.webContents);
+    const cleanupBrowserZoomPolicy = installBrowserZoomPolicy(window.webContents);
     const session = {
       window,
       controller: null,
@@ -283,7 +283,10 @@ function createEditorWindowManager({
       if (!isPackaged) contents.openDevTools?.({ mode: 'detach' });
       sendProgress(session, 'loadingEditor');
     });
-    contents.once('destroyed', () => cleanupWindow?.(contents));
+    contents.once('destroyed', () => {
+      cleanupBrowserZoomPolicy();
+      cleanupWindow?.(contents);
+    });
     window.on('closed', () => {
       const shouldQuit = !session.returningToHud;
       if (session.returningToHud) session.resolvePresentation?.(false);

--- a/electron/window/editor-window.cjs
+++ b/electron/window/editor-window.cjs
@@ -1,5 +1,6 @@
 const { BrowserWindow } = require('electron');
 const path = require('path');
+const { installBrowserZoomPolicy } = require('./browser-zoom-policy.cjs');
 
 const EDITOR_DEFAULT_SIZE = { width: 1280, height: 800 };
 const EDITOR_MIN_SIZE = { width: 960, height: 600 };
@@ -231,8 +232,10 @@ function createEditorWindowManager({
         contextIsolation: true,
         sandbox: false,
         webSecurity: false,
+        zoomFactor: 1,
       },
     });
+    installBrowserZoomPolicy(window.webContents);
     const session = {
       window,
       controller: null,

--- a/electron/window/hud-window-size.cjs
+++ b/electron/window/hud-window-size.cjs
@@ -1,0 +1,10 @@
+const DEFAULT_HUD_WINDOW_SIZE = Object.freeze({ width: 352, height: 512 });
+
+function normalizeHudWindowSize(value) {
+  if (value && value.width === DEFAULT_HUD_WINDOW_SIZE.width && value.height === DEFAULT_HUD_WINDOW_SIZE.height) {
+    return { width: value.width, height: value.height };
+  }
+  return { ...DEFAULT_HUD_WINDOW_SIZE };
+}
+
+module.exports = { DEFAULT_HUD_WINDOW_SIZE, normalizeHudWindowSize };

--- a/electron/window/window-controller.cjs
+++ b/electron/window/window-controller.cjs
@@ -1,4 +1,6 @@
-const HUD_SIZE = { width: 352, height: 512 };
+const { DEFAULT_HUD_WINDOW_SIZE, normalizeHudWindowSize } = require('./hud-window-size.cjs');
+
+const HUD_SIZE = DEFAULT_HUD_WINDOW_SIZE;
 const RECORDER_SIZE = { width: 72, height: 344 };
 
 function clampToDisplayBounds(x, y, width, height, displayBounds) {
@@ -28,14 +30,15 @@ class WindowController {
     this.recorderPositions = this.readRecorderPositions();
     this.recorderPositionSaveTimer = null;
     this.hudPosition = this.readHudPosition();
+    this.hudSize = this.readHudSize();
     this.hudPositionSaveTimer = null;
     if (this.hudPosition) {
       const display = this.screen.getDisplayNearestPoint({ x: this.hudPosition[0], y: this.hudPosition[1] });
       const position = clampToDisplayBounds(
         this.hudPosition[0],
         this.hudPosition[1],
-        HUD_SIZE.width,
-        HUD_SIZE.height,
+        this.hudSize.width,
+        this.hudSize.height,
         display.bounds,
       );
       this.window.setPosition(position.x, position.y);
@@ -120,6 +123,10 @@ class WindowController {
     return null;
   }
 
+  readHudSize() {
+    return normalizeHudWindowSize(this.preferencesStore?.read()?.hudWindow);
+  }
+
   rememberHudPosition() {
     if (this.mode !== 'hud' || this.window.isDestroyed()) return;
     const pos = this.window.getPosition();
@@ -173,6 +180,7 @@ class WindowController {
       this.flushHudPosition();
     }
     this.mode = mode;
+    if (mode === 'hud') this.hudSize = this.readHudSize();
     this.applySizeConstraints();
     if (mode === 'hud') this.hudOverInteractive = false;
     if (mode === 'recorder') this.placeRecorder();
@@ -183,8 +191,8 @@ class WindowController {
         const position = clampToDisplayBounds(
           targetPos[0],
           targetPos[1],
-          HUD_SIZE.width,
-          HUD_SIZE.height,
+          this.hudSize.width,
+          this.hudSize.height,
           display.bounds,
         );
         this.window.setPosition(position.x, position.y);
@@ -228,7 +236,7 @@ class WindowController {
   }
 
   applySizeConstraints() {
-    const minimumSize = this.mode === 'recorder' ? RECORDER_SIZE : HUD_SIZE;
+    const minimumSize = this.mode === 'recorder' ? RECORDER_SIZE : this.hudSize;
     this.window.setMinimumSize?.(minimumSize.width, minimumSize.height);
   }
 
@@ -330,19 +338,20 @@ class WindowController {
 
   showHud() {
     if (this.window.isDestroyed()) return;
+    this.hudSize = this.readHudSize();
     const applyHudBounds = () => {
       if (this.window.isDestroyed()) return;
       this.window.setResizable?.(false);
       this.window.setMaximizable?.(false);
-      this.window.setMinimumSize?.(HUD_SIZE.width, HUD_SIZE.height);
-      this.window.setSize?.(HUD_SIZE.width, HUD_SIZE.height);
+      this.window.setMinimumSize?.(this.hudSize.width, this.hudSize.height);
+      this.window.setSize?.(this.hudSize.width, this.hudSize.height);
       if (this.hudPosition && Array.isArray(this.hudPosition)) {
         const display = this.screen.getDisplayNearestPoint({ x: this.hudPosition[0], y: this.hudPosition[1] });
         const position = clampToDisplayBounds(
           this.hudPosition[0],
           this.hudPosition[1],
-          HUD_SIZE.width,
-          HUD_SIZE.height,
+          this.hudSize.width,
+          this.hudSize.height,
           display.bounds,
         );
         this.window.setPosition?.(position.x, position.y);

--- a/src/api/types/capture-api.ts
+++ b/src/api/types/capture-api.ts
@@ -256,6 +256,7 @@ export interface PreferenceSettings {
   schemaVersion: 3;
   theme: 'light' | 'dark' | 'system';
   appearance?: AppearanceSettings;
+  hudWindow?: { width: number; height: number };
   recordingBar: { visibility: RecordingBarVisibility };
   recordingInteractions: { enabled: boolean; noticeDismissed: boolean };
   voiceover?: { countdownSeconds: 0 | 3 | 5 | 10; monitorProjectAudio: boolean };

--- a/src/components/hud/settings/HudPreferences.vue
+++ b/src/components/hud/settings/HudPreferences.vue
@@ -222,7 +222,7 @@ const openOnboarding = () => {
           </div>
 
           <div class="preference-item preference-appearance-item">
-            <AppearanceSettings :show-title="false" :compact="true" />
+            <AppearanceSettings :show-title="false" :compact="true" :show-ui-scaling="false" />
           </div>
 
           <!-- Category: About -->

--- a/src/components/hud/tests/HudPreferences.test.ts
+++ b/src/components/hud/tests/HudPreferences.test.ts
@@ -3,6 +3,7 @@ import { mount } from '@vue/test-utils';
 import { defineComponent, h } from 'vue';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import HudPreferences from '../settings/HudPreferences.vue';
+import AppearanceSettings from '~/components/settings/AppearanceSettings.vue';
 import { captureMock as capture } from './capture.mock';
 
 vi.mock('../../../api/capture', async () => ({ capture: (await import('./capture.mock')).captureMock }));
@@ -84,6 +85,19 @@ describe('HudPreferences', () => {
     const wrapper = mountPreferences({ countdownSeconds: 0 });
     expect(wrapper.find('.appearance-settings').exists()).toBe(true);
     expect(wrapper.find('.theme-mode-group').exists()).toBe(true);
+  });
+
+  it('passes the HUD-specific scaling flag and does not render scaling controls', async () => {
+    const wrapper = mountPreferences();
+    const appearance = wrapper.findComponent(AppearanceSettings);
+
+    expect(appearance.exists()).toBe(true);
+    expect(appearance.props('showUiScaling')).toBe(false);
+
+    await appearance.get('.advanced-toggle').trigger('click');
+
+    expect(appearance.find('.ui-scale-setting').exists()).toBe(false);
+    expect(appearance.find('.ui-scale-slider').exists()).toBe(false);
   });
 
   it('opens language advanced settings and toggles spell check', async () => {

--- a/src/components/settings/AppearanceSettings.test.ts
+++ b/src/components/settings/AppearanceSettings.test.ts
@@ -156,6 +156,27 @@ describe('AppearanceSettings.vue', () => {
     expect(wrapper.find('.appearance-advanced-panel .accordion').exists()).toBe(false);
   });
 
+  it('hides the UI scaling section when explicitly disabled', async () => {
+    const wrapper = mount(AppearanceSettings, { props: { showUiScaling: false } });
+    await flushPromises();
+
+    await wrapper.get('.advanced-toggle').trigger('click');
+
+    expect(wrapper.find('.ui-scale-setting').exists()).toBe(false);
+    expect(wrapper.find('.ui-scale-slider').exists()).toBe(false);
+    expect(wrapper.find('.theme-customization-section').exists()).toBe(true);
+  });
+
+  it('keeps the UI scaling section enabled by default for editor settings', async () => {
+    const wrapper = mount(AppearanceSettings);
+    await flushPromises();
+
+    await wrapper.get('.advanced-toggle').trigger('click');
+
+    expect(wrapper.find('.ui-scale-setting').exists()).toBe(true);
+    expect(wrapper.find('.ui-scale-slider').exists()).toBe(true);
+  });
+
   it('aligns one color picker with each primary and secondary color section', async () => {
     const wrapper = mount(AppearanceSettings);
     await flushPromises();

--- a/src/components/settings/AppearanceSettings.vue
+++ b/src/components/settings/AppearanceSettings.vue
@@ -29,10 +29,12 @@ withDefaults(
   defineProps<{
     showTitle?: boolean;
     compact?: boolean;
+    showUiScaling?: boolean;
   }>(),
   {
     showTitle: true,
     compact: false,
+    showUiScaling: true,
   },
 );
 
@@ -189,7 +191,7 @@ const isCustomSecondaryColor = computed(() => {
     </div>
 
     <div v-if="advancedOpen" id="appearance-advanced-panel" class="appearance-advanced-panel">
-      <section class="advanced-category ui-scale-setting setting-section">
+      <section v-if="showUiScaling" class="advanced-category ui-scale-setting setting-section">
         <h4 class="advanced-category-title">{{ t('scalingCategory') }}</h4>
         <div class="section-title-row">
           <div class="title-with-icon">

--- a/src/editor-main.ts
+++ b/src/editor-main.ts
@@ -6,10 +6,12 @@ import EditorWindowApp from './components/video-editor/EditorWindowApp.vue';
 import { initI18n } from './i18n';
 import { useThemeStore } from './stores/theme';
 import { capture } from './api/capture';
+import { installBrowserZoomGuard } from './utils/browserZoomGuard';
 
 // The HUD intentionally uses a transparent document root. The editor is an
 // opaque native window and must not inherit that transparent fallback.
 document.documentElement.classList.add('editor-window-root');
+installBrowserZoomGuard();
 
 const bootstrap = async () => {
   try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,9 @@ import './style.css';
 import App from './App.vue';
 import { useThemeStore } from './stores/theme';
 import { initI18n } from './i18n';
+import { installBrowserZoomGuard } from './utils/browserZoomGuard';
+
+installBrowserZoomGuard();
 
 const app = createApp(App);
 const pinia = createPinia();

--- a/src/utils/browserZoomGuard.test.ts
+++ b/src/utils/browserZoomGuard.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { installBrowserZoomGuard } from './browserZoomGuard';
+
+const dispatchWheel = (target: EventTarget, modifiers: KeyboardEventInit = {}) => {
+  const event = new WheelEvent('wheel', { ...modifiers, cancelable: true });
+  target.dispatchEvent(event);
+  return event;
+};
+
+const dispatchKeydown = (target: EventTarget, key: string, modifiers: KeyboardEventInit = {}) => {
+  const event = new KeyboardEvent('keydown', { ...modifiers, key, cancelable: true });
+  target.dispatchEvent(event);
+  return event;
+};
+
+describe('installBrowserZoomGuard', () => {
+  it('blocks Ctrl/Cmd + wheel zoom gestures', () => {
+    const target = new EventTarget();
+    const cleanup = installBrowserZoomGuard(target as Window);
+
+    expect(dispatchWheel(target, { ctrlKey: true }).defaultPrevented).toBe(true);
+    expect(dispatchWheel(target, { metaKey: true }).defaultPrevented).toBe(true);
+
+    cleanup();
+  });
+
+  it('blocks Ctrl/Cmd zoom shortcuts while preserving unrelated keys', () => {
+    const target = new EventTarget();
+    const cleanup = installBrowserZoomGuard(target as Window);
+
+    for (const key of ['+', '=', '-', '_', '0']) {
+      expect(dispatchKeydown(target, key, { ctrlKey: true }).defaultPrevented).toBe(true);
+      expect(dispatchKeydown(target, key, { metaKey: true }).defaultPrevented).toBe(true);
+    }
+
+    expect(dispatchKeydown(target, 'a', { ctrlKey: true }).defaultPrevented).toBe(false);
+    expect(dispatchKeydown(target, 'a', { metaKey: true }).defaultPrevented).toBe(false);
+    expect(dispatchKeydown(target, '+').defaultPrevented).toBe(false);
+
+    cleanup();
+  });
+
+  it('preserves normal wheel events', () => {
+    const target = new EventTarget();
+    const cleanup = installBrowserZoomGuard(target as Window);
+
+    expect(dispatchWheel(target).defaultPrevented).toBe(false);
+
+    cleanup();
+  });
+
+  it('removes all zoom guards during cleanup', () => {
+    const target = new EventTarget();
+    const cleanup = installBrowserZoomGuard(target as Window);
+
+    cleanup();
+
+    expect(dispatchWheel(target, { ctrlKey: true }).defaultPrevented).toBe(false);
+    expect(dispatchWheel(target, { metaKey: true }).defaultPrevented).toBe(false);
+    expect(dispatchKeydown(target, '0', { ctrlKey: true }).defaultPrevented).toBe(false);
+    expect(dispatchKeydown(target, '+', { metaKey: true }).defaultPrevented).toBe(false);
+  });
+});

--- a/src/utils/browserZoomGuard.ts
+++ b/src/utils/browserZoomGuard.ts
@@ -1,0 +1,18 @@
+const ZOOM_KEYS = new Set(['+', '=', '-', '_', '0']);
+
+export function installBrowserZoomGuard(target: Window = window): () => void {
+  const preventWheelZoom = (event: WheelEvent) => {
+    if (event.ctrlKey || event.metaKey) event.preventDefault();
+  };
+  const preventKeyboardZoom = (event: KeyboardEvent) => {
+    if ((event.ctrlKey || event.metaKey) && ZOOM_KEYS.has(event.key)) event.preventDefault();
+  };
+
+  target.addEventListener('wheel', preventWheelZoom, { passive: false });
+  target.addEventListener('keydown', preventKeyboardZoom);
+
+  return () => {
+    target.removeEventListener('wheel', preventWheelZoom);
+    target.removeEventListener('keydown', preventKeyboardZoom);
+  };
+}

--- a/test/browser-zoom-policy.test.cjs
+++ b/test/browser-zoom-policy.test.cjs
@@ -1,0 +1,150 @@
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const test = require('node:test');
+
+const {
+  DEFAULT_ZOOM_FACTOR,
+  enforceDefaultZoom,
+  installBrowserZoomPolicy,
+  isBrowserZoomShortcut,
+} = require('../electron/window/browser-zoom-policy.cjs');
+
+function createWebContents({ destroyed = false } = {}) {
+  const webContents = new EventEmitter();
+  const calls = [];
+
+  webContents.isDestroyed = () => destroyed;
+  webContents.setZoomLevel = (level) => calls.push(['setZoomLevel', level]);
+  webContents.setZoomFactor = (factor) => calls.push(['setZoomFactor', factor]);
+
+  return { webContents, calls };
+}
+
+function waitForImmediate() {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+test('enforceDefaultZoom resets both Chromium zoom representations', () => {
+  const { webContents, calls } = createWebContents();
+
+  enforceDefaultZoom(webContents);
+
+  assert.deepEqual(calls, [
+    ['setZoomLevel', 0],
+    ['setZoomFactor', DEFAULT_ZOOM_FACTOR],
+  ]);
+});
+
+test('installBrowserZoomPolicy resets zoom after loading', () => {
+  const { webContents, calls } = createWebContents();
+
+  const cleanup = installBrowserZoomPolicy(webContents);
+
+  assert.deepEqual(calls, []);
+
+  webContents.emit('did-finish-load');
+
+  assert.deepEqual(calls, [
+    ['setZoomLevel', 0],
+    ['setZoomFactor', DEFAULT_ZOOM_FACTOR],
+  ]);
+
+  cleanup();
+});
+
+test('installBrowserZoomPolicy prevents a zoom request and restores the default after it', async () => {
+  const { webContents, calls } = createWebContents();
+  let prevented = false;
+
+  const cleanup = installBrowserZoomPolicy(webContents);
+  const initialCallCount = calls.length;
+
+  webContents.emit('zoom-changed', {
+    preventDefault() {
+      prevented = true;
+    },
+  });
+
+  assert.equal(prevented, true);
+  await waitForImmediate();
+
+  assert.ok(calls.length >= initialCallCount + 2);
+  assert.deepEqual(calls.slice(-2), [
+    ['setZoomLevel', 0],
+    ['setZoomFactor', DEFAULT_ZOOM_FACTOR],
+  ]);
+
+  cleanup();
+});
+
+test('browser zoom keyboard shortcuts are blocked without consuming application shortcuts', () => {
+  const { webContents } = createWebContents();
+  const cleanup = installBrowserZoomPolicy(webContents);
+
+  for (const input of [
+    { type: 'keyDown', control: true, key: '+' },
+    { type: 'keyDown', control: true, key: '-' },
+    { type: 'keyDown', meta: true, key: '0' },
+  ]) {
+    let prevented = false;
+    webContents.emit('before-input-event', { preventDefault: () => (prevented = true) }, input);
+    assert.equal(prevented, true);
+    assert.equal(isBrowserZoomShortcut(input), true);
+  }
+
+  let prevented = false;
+  webContents.emit(
+    'before-input-event',
+    { preventDefault: () => (prevented = true) },
+    { type: 'keyDown', control: true, key: 'a' },
+  );
+  assert.equal(prevented, false);
+  cleanup();
+});
+
+test('cleanup removes zoom policy listeners', () => {
+  const { webContents, calls } = createWebContents();
+  const cleanup = installBrowserZoomPolicy(webContents);
+  const initialCallCount = calls.length;
+
+  cleanup();
+
+  assert.equal(webContents.listenerCount('zoom-changed'), 0);
+  assert.equal(webContents.listenerCount('before-input-event'), 0);
+  assert.equal(webContents.listenerCount('did-finish-load'), 0);
+
+  webContents.emit('did-finish-load');
+  webContents.emit('zoom-changed', { preventDefault() {} });
+
+  assert.equal(calls.length, initialCallCount);
+});
+
+test('resetOnLoad can be disabled for windows that wait for ready-to-show', () => {
+  const { webContents, calls } = createWebContents();
+  const cleanup = installBrowserZoomPolicy(webContents, { resetOnLoad: false });
+
+  webContents.emit('did-finish-load');
+
+  assert.deepEqual(calls, []);
+  assert.equal(webContents.listenerCount('did-finish-load'), 0);
+  cleanup();
+});
+
+test('enforceDefaultZoom is a no-op for destroyed webContents', () => {
+  const { webContents, calls } = createWebContents({ destroyed: true });
+
+  enforceDefaultZoom(webContents);
+
+  assert.deepEqual(calls, []);
+});
+
+test('installBrowserZoomPolicy does not touch destroyed webContents', () => {
+  const { webContents, calls } = createWebContents({ destroyed: true });
+
+  const cleanup = installBrowserZoomPolicy(webContents);
+  webContents.emit('did-finish-load');
+  webContents.emit('zoom-changed', { preventDefault() {} });
+
+  assert.deepEqual(calls, []);
+  cleanup();
+});

--- a/test/editor-window.test.cjs
+++ b/test/editor-window.test.cjs
@@ -15,10 +15,47 @@ function fakeWindow(calls, options = {}) {
     width: options.width ?? 1280,
     height: options.height ?? 800,
   };
+  const addContentListener = (event, listener, once = false) => {
+    const registrations = contentListeners.get(event) ?? [];
+    const registration = {
+      listener,
+      wrapped: once
+        ? (...args) => {
+            removeContentListener(event, registration.listener);
+            listener(...args);
+          }
+        : listener,
+    };
+    registrations.push(registration);
+    contentListeners.set(event, registrations);
+  };
+  const removeContentListener = (event, listener) => {
+    const registrations = contentListeners.get(event) ?? [];
+    const remaining = registrations.filter(
+      (registration) => registration.listener !== listener && registration.wrapped !== listener,
+    );
+    if (remaining.length > 0) contentListeners.set(event, remaining);
+    else contentListeners.delete(event);
+  };
+  const emitContent = (event, ...args) => {
+    for (const registration of (contentListeners.get(event) ?? []).slice()) registration.wrapped(...args);
+  };
   const webContents = {
     id: 42,
-    on: (event, listener) => contentListeners.set(event, listener),
-    once: (event, listener) => contentListeners.set(event, listener),
+    on: (event, listener) => {
+      addContentListener(event, listener);
+      return webContents;
+    },
+    once: (event, listener) => {
+      addContentListener(event, listener, true);
+      return webContents;
+    },
+    removeListener: (event, listener) => {
+      removeContentListener(event, listener);
+      return webContents;
+    },
+    listenerCount: (event) => (contentListeners.get(event) ?? []).length,
+    isDestroyed: () => destroyed,
     send: (...args) => calls.push(['editor-send', ...args]),
     openDevTools: (...args) => calls.push(['openDevTools', ...args]),
     closeDevTools: () => calls.push(['closeDevTools']),
@@ -26,7 +63,7 @@ function fakeWindow(calls, options = {}) {
   };
   return {
     webContents,
-    emitContent: (event) => contentListeners.get(event)?.(),
+    emitContent,
     on: (event, listener) => listeners.set(event, listener),
     emit: (event, ...args) => listeners.get(event)?.(...args),
     isDestroyed: () => destroyed,
@@ -44,11 +81,14 @@ function fakeWindow(calls, options = {}) {
     focus: () => calls.push(['focus']),
     close: () => {
       calls.push(['close']);
+      destroyed = true;
+      emitContent('destroyed');
       listeners.get('closed')?.();
     },
     destroy: () => {
       destroyed = true;
       calls.push(['destroy']);
+      emitContent('destroyed');
       listeners.get('closed')?.();
     },
     loadURL: (url) => calls.push(['loadURL', url]),
@@ -437,7 +477,7 @@ test('restores and persists editor window dimensions via preferencesStore', asyn
   }
 });
 
-function createRecorderFixture() {
+function createRecorderFixture({ isPackaged = false, cleanupWindow = null } = {}) {
   const calls = [];
   const windows = [];
   const ipcHandlers = new Map();
@@ -497,7 +537,7 @@ function createRecorderFixture() {
   const { createEditorWindowManager } = require('../electron/window/editor-window.cjs');
   const manager = createEditorWindowManager({
     applicationRoot: '/app',
-    isPackaged: false,
+    isPackaged,
     ipcMain: {
       handle: (channel, listener) => ipcHandlers.set(channel, listener),
       on: (channel, listener) => ipcListeners.set(channel, listener),
@@ -513,6 +553,7 @@ function createRecorderFixture() {
       },
     },
     registerController: () => undefined,
+    cleanupWindow,
   });
   return {
     calls,
@@ -527,6 +568,34 @@ function createRecorderFixture() {
     },
   };
 }
+
+test('editor destruction removes browser zoom policy listeners and still cleans the webContents owner', async () => {
+  const cleanedContents = [];
+  const fixture = createRecorderFixture({
+    isPackaged: true,
+    cleanupWindow: (contents) => cleanedContents.push(contents),
+  });
+  try {
+    const opening = fixture.manager.open(projectId);
+    const editor = await readyEditor(fixture, opening);
+
+    assert.equal(editor.webContents.listenerCount('zoom-changed'), 1);
+    assert.equal(editor.webContents.listenerCount('before-input-event'), 1);
+    assert.equal(editor.webContents.listenerCount('did-finish-load'), 2);
+
+    editor.emitContent('did-finish-load');
+    assert.equal(editor.webContents.listenerCount('did-finish-load'), 1);
+
+    editor.close();
+
+    assert.equal(editor.webContents.listenerCount('zoom-changed'), 0);
+    assert.equal(editor.webContents.listenerCount('before-input-event'), 0);
+    assert.equal(editor.webContents.listenerCount('did-finish-load'), 0);
+    assert.deepEqual(cleanedContents, [editor.webContents]);
+  } finally {
+    fixture.restore();
+  }
+});
 
 test('editor:open-recorder keeps the editor open, shows the real HUD, and supplies its media source', async () => {
   const fixture = createRecorderFixture();

--- a/test/editor-window.test.cjs
+++ b/test/editor-window.test.cjs
@@ -134,6 +134,7 @@ test('editor window is opaque and routes native editor lifecycle without changin
     assert.equal(options.icon, appIconPath);
     assert.equal(options.minWidth, EDITOR_MIN_SIZE.width);
     assert.equal(options.minHeight, EDITOR_MIN_SIZE.height);
+    assert.equal(options.webPreferences.zoomFactor, 1);
     if (process.platform !== 'darwin') {
       assert.deepEqual(options.titleBarOverlay, {
         color: '#00000000',

--- a/test/preferences/preferences-store.test.cjs
+++ b/test/preferences/preferences-store.test.cjs
@@ -53,6 +53,34 @@ test('rejects duplicate global shortcuts', () => {
   );
 });
 
+test('repair returns safe runtime preferences for duplicate global shortcuts without rewriting the file', () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'demo-preferences-duplicate-shortcuts-'));
+  const file = path.join(directory, 'preferences.json');
+  const store = createPreferencesStore(file, { platform: 'darwin' });
+  const original = {
+    theme: 'dark',
+    devices: { cameraId: 'camera-1', micId: 'mic-1' },
+    extras: { locale: 'fr', marker: 'preserve-me' },
+    shortcuts: {
+      first: { keys: 'Ctrl+F', scope: 'global', category: 'hud' },
+      second: { keys: 'Ctrl+F', scope: 'global', category: 'editor' },
+    },
+  };
+  const originalContents = JSON.stringify(original);
+  fs.writeFileSync(file, originalContents);
+
+  const repaired = store.repair();
+
+  assert.equal(repaired.theme, 'dark');
+  assert.deepEqual(repaired.devices, original.devices);
+  assert.deepEqual(repaired.extras, original.extras);
+  assert.deepEqual(repaired.shortcuts, defaults('darwin').shortcuts);
+  assert.equal(fs.readFileSync(file, 'utf8'), originalContents);
+
+  assert.throws(() => store.patch({ extras: { changed: true } }), /dupliqué/);
+  assert.equal(fs.readFileSync(file, 'utf8'), originalContents);
+});
+
 test('accepts hover-only recorder visibility and falls back for invalid values', () => {
   assert.equal(normalize({ recordingBar: { visibility: 'hover-only' } }).recordingBar.visibility, 'hover-only');
   assert.equal(normalize({ recordingBar: { visibility: 'not-a-mode' } }, 'win32').recordingBar.visibility, 'always');
@@ -141,16 +169,102 @@ test('repair rewrites preferences.json with canonical HUD dimensions and preserv
   assert.deepEqual(persisted.extras, original.extras);
 });
 
-test('repair creates missing preferences and recovers malformed JSON with canonical HUD dimensions', () => {
-  for (const initialContents of [null, '{broken']) {
-    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'demo-preferences-hud-window-recovery-'));
-    const file = path.join(directory, 'preferences.json');
-    if (initialContents !== null) fs.writeFileSync(file, initialContents);
-    const store = createPreferencesStore(file, { platform: 'darwin' });
+test('repair creates missing preferences and quarantines malformed JSON before writing defaults', () => {
+  const missingDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'demo-preferences-hud-window-missing-'));
+  const missingFile = path.join(missingDirectory, 'preferences.json');
+  const missingStore = createPreferencesStore(missingFile, { platform: 'darwin' });
 
-    assert.deepEqual(store.repair().hudWindow, CANONICAL_HUD_WINDOW);
-    assert.deepEqual(JSON.parse(fs.readFileSync(file, 'utf8')).hudWindow, CANONICAL_HUD_WINDOW);
+  assert.deepEqual(missingStore.repair().hudWindow, CANONICAL_HUD_WINDOW);
+  assert.deepEqual(JSON.parse(fs.readFileSync(missingFile, 'utf8')).hudWindow, CANONICAL_HUD_WINDOW);
+  assert.equal(fs.existsSync(`${missingFile}.invalid`), false);
+
+  const malformedDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'demo-preferences-hud-window-malformed-'));
+  const malformedFile = path.join(malformedDirectory, 'preferences.json');
+  const malformedContents = '{broken';
+  fs.writeFileSync(malformedFile, malformedContents);
+  const malformedStore = createPreferencesStore(malformedFile, { platform: 'darwin' });
+
+  const repaired = malformedStore.repair();
+  const quarantinedFile = `${malformedFile}.invalid`;
+
+  assert.deepEqual(repaired, defaults('darwin'));
+  assert.equal(fs.readFileSync(quarantinedFile, 'utf8'), malformedContents);
+  assert.deepEqual(JSON.parse(fs.readFileSync(malformedFile, 'utf8')), defaults('darwin'));
+});
+
+test('repair returns normalized preferences when writing the temporary file fails without replacing the original', () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'demo-preferences-repair-write-failure-'));
+  const file = path.join(directory, 'preferences.json');
+  const store = createPreferencesStore(file, { platform: 'darwin' });
+  const original = {
+    theme: 'dark',
+    hudWindow: { width: 640, height: 900 },
+    devices: { cameraId: 'camera-1' },
+    extras: { marker: 'preserve-me' },
+  };
+  const originalContents = JSON.stringify(original);
+  fs.writeFileSync(file, originalContents);
+  const writeFileSync = fs.writeFileSync;
+  let attempted = false;
+  fs.writeFileSync = (destination, ...args) => {
+    if (destination === `${file}.tmp`) {
+      attempted = true;
+      throw new Error('temporary preferences write failed');
+    }
+    return writeFileSync(destination, ...args);
+  };
+
+  let repaired;
+  try {
+    repaired = store.repair();
+  } finally {
+    fs.writeFileSync = writeFileSync;
   }
+
+  assert.equal(attempted, true);
+  assert.equal(repaired.theme, 'dark');
+  assert.deepEqual(repaired.hudWindow, CANONICAL_HUD_WINDOW);
+  assert.deepEqual(repaired.devices, original.devices);
+  assert.deepEqual(repaired.extras, original.extras);
+  assert.equal(fs.readFileSync(file, 'utf8'), originalContents);
+});
+
+test('repair returns normalized preferences when atomic rename fails without replacing the original', () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'demo-preferences-repair-rename-failure-'));
+  const file = path.join(directory, 'preferences.json');
+  const store = createPreferencesStore(file, { platform: 'darwin' });
+  const original = {
+    theme: 'dark',
+    hudWindow: { width: 640, height: 900 },
+    devices: { micId: 'mic-1' },
+    extras: { marker: 'preserve-me' },
+  };
+  const originalContents = JSON.stringify(original);
+  fs.writeFileSync(file, originalContents);
+  const renameSync = fs.renameSync;
+  let attempted = false;
+  fs.renameSync = (source, destination) => {
+    if (destination === file) {
+      attempted = true;
+      throw new Error('atomic preferences rename failed');
+    }
+    return renameSync(source, destination);
+  };
+
+  let repaired;
+  try {
+    repaired = store.repair();
+  } finally {
+    fs.renameSync = renameSync;
+    fs.rmSync(`${file}.tmp`, { force: true });
+  }
+
+  assert.equal(attempted, true);
+  assert.equal(repaired.theme, 'dark');
+  assert.deepEqual(repaired.hudWindow, CANONICAL_HUD_WINDOW);
+  assert.deepEqual(repaired.devices, original.devices);
+  assert.deepEqual(repaired.extras, original.extras);
+  assert.equal(fs.readFileSync(file, 'utf8'), originalContents);
 });
 
 test('preserves an explicit recorder visibility preference on Linux', () => {

--- a/test/preferences/preferences-store.test.cjs
+++ b/test/preferences/preferences-store.test.cjs
@@ -5,6 +5,8 @@ const path = require('node:path');
 const test = require('node:test');
 const { createPreferencesStore, defaults, normalize } = require('../../electron/preferences/preferences-store.cjs');
 
+const CANONICAL_HUD_WINDOW = { width: 352, height: 512 };
+
 test('writes durable generic preferences and merges patches', () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'demo-preferences-'));
   const store = createPreferencesStore(directory);
@@ -67,6 +69,88 @@ test('uses hover-only defaults on Linux and always-visible defaults on desktop p
   assert.equal(normalize({}, 'linux').recordingBar.visibility, 'hover-only');
   assert.equal(normalize({}, 'win32').recordingBar.visibility, 'always');
   assert.equal(normalize({}, 'darwin').recordingBar.visibility, 'always');
+});
+
+test('exposes canonical HUD window dimensions in defaults and normalized preferences', () => {
+  assert.deepEqual(defaults().hudWindow, CANONICAL_HUD_WINDOW);
+  assert.deepEqual(defaults('darwin').hudWindow, CANONICAL_HUD_WINDOW);
+  assert.deepEqual(normalize({}).hudWindow, CANONICAL_HUD_WINDOW);
+  assert.deepEqual(
+    normalize({ hudWindow: { width: 352, height: 512, unexpected: 'discarded' } }).hudWindow,
+    CANONICAL_HUD_WINDOW,
+  );
+});
+
+test('normalizes missing, partial, malformed, and unexpected HUD window sizes exactly', () => {
+  const invalidSizes = [
+    null,
+    {},
+    { width: 352 },
+    { height: 512 },
+    { width: undefined, height: 512 },
+    { width: 352, height: undefined },
+    { width: 351, height: 512 },
+    { width: 352, height: 511 },
+    { width: 352.5, height: 512 },
+    { width: 352, height: '512' },
+    { width: '352', height: 512 },
+    { width: 0, height: 0 },
+    { width: -352, height: -512 },
+    { width: 352, height: 512, scale: 2 },
+    [352, 512],
+    '352x512',
+    true,
+  ];
+
+  for (const hudWindow of invalidSizes) {
+    assert.deepEqual(normalize({ hudWindow }).hudWindow, CANONICAL_HUD_WINDOW, JSON.stringify(hudWindow));
+  }
+});
+
+test('repair rewrites preferences.json with canonical HUD dimensions and preserves valid preferences', () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'demo-preferences-hud-window-'));
+  const file = path.join(directory, 'preferences.json');
+  const store = createPreferencesStore(file, { platform: 'darwin' });
+  const original = {
+    theme: 'dark',
+    appearance: {
+      theme: 'dark',
+      primaryColor: '#8b5cf6',
+      secondaryColor: '#06b6d4',
+      radiusPx: 16,
+      isPillRadius: false,
+      surfaceTone: 'slate',
+      activePresetId: 'cyber-violet',
+    },
+    hudWindow: { width: 640, height: 900, staleScale: 2 },
+    recordingBar: { visibility: 'always' },
+    devices: { cameraId: 'camera-1', micId: 'mic-1' },
+    extras: { locale: 'fr', hudPosition: { x: 42, y: 84 } },
+  };
+  fs.writeFileSync(file, JSON.stringify(original));
+
+  const repaired = store.repair();
+  const persisted = JSON.parse(fs.readFileSync(file, 'utf8'));
+
+  assert.deepEqual(repaired.hudWindow, CANONICAL_HUD_WINDOW);
+  assert.deepEqual(persisted.hudWindow, CANONICAL_HUD_WINDOW);
+  assert.equal(persisted.theme, 'dark');
+  assert.equal(persisted.appearance.primaryColor, '#8b5cf6');
+  assert.equal(persisted.appearance.surfaceTone, 'slate');
+  assert.deepEqual(persisted.devices, original.devices);
+  assert.deepEqual(persisted.extras, original.extras);
+});
+
+test('repair creates missing preferences and recovers malformed JSON with canonical HUD dimensions', () => {
+  for (const initialContents of [null, '{broken']) {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'demo-preferences-hud-window-recovery-'));
+    const file = path.join(directory, 'preferences.json');
+    if (initialContents !== null) fs.writeFileSync(file, initialContents);
+    const store = createPreferencesStore(file, { platform: 'darwin' });
+
+    assert.deepEqual(store.repair().hudWindow, CANONICAL_HUD_WINDOW);
+    assert.deepEqual(JSON.parse(fs.readFileSync(file, 'utf8')).hudWindow, CANONICAL_HUD_WINDOW);
+  }
 });
 
 test('preserves an explicit recorder visibility preference on Linux', () => {

--- a/test/window-controller.test.cjs
+++ b/test/window-controller.test.cjs
@@ -94,6 +94,35 @@ function expectedAlwaysOnTopLevel() {
   return process.platform === 'win32' ? 'screen-saver' : undefined;
 }
 
+function preferencesWithHudWindow(hudWindow, extras = {}) {
+  let hudWindowReads = 0;
+  const preferences = { extras };
+  Object.defineProperty(preferences, 'hudWindow', {
+    enumerable: true,
+    get: () => {
+      hudWindowReads += 1;
+      return hudWindow;
+    },
+  });
+  return {
+    read: () => preferences,
+    patch: () => undefined,
+    hudWindowReads: () => hudWindowReads,
+  };
+}
+
+function hudDisplay() {
+  const display = {
+    id: 1,
+    bounds: { x: 100, y: 200, width: 400, height: 600 },
+    workArea: { x: 100, y: 200, width: 400, height: 600 },
+  };
+  return {
+    getCursorScreenPoint: () => ({ x: 300, y: 500 }),
+    getDisplayNearestPoint: () => display,
+  };
+}
+
 test('hidden window ignores mouse events before it is ready', () => {
   const win = fakeWindow();
   new WindowController(win);
@@ -322,4 +351,58 @@ test('editor transition demotes and hides the HUD until it is explicitly shown a
 
   controller.setVisible(true);
   assert.equal(topCalls(win).at(-1)[1], true);
+});
+
+test('WindowController reads hudWindow and normalizes every unexpected size to the default', () => {
+  for (const hudWindow of [
+    undefined,
+    null,
+    {},
+    { width: 351, height: 512 },
+    { width: 352, height: 511 },
+    { width: 352.5, height: 512 },
+    { width: '352', height: 512 },
+    [352, 512],
+  ]) {
+    const preferencesStore = preferencesWithHudWindow(hudWindow);
+    const controller = new WindowController(fakeWindow(), { preferencesStore });
+
+    assert.ok(preferencesStore.hudWindowReads() > 0);
+    assert.deepEqual(controller.hudSize, HUD_SIZE);
+  }
+});
+
+test('showHud applies the normalized HUD size to native bounds, minimum, and saved-position clamping', () => {
+  const win = fakeWindow();
+  const controller = new WindowController(win, {
+    preferencesStore: preferencesWithHudWindow({ width: 999, height: 999 }, { hudPosition: { x: 999, y: 999 } }),
+    screenModule: hudDisplay(),
+  });
+
+  controller.showHud();
+
+  assert.deepEqual(win.getBounds(), { x: 148, y: 288, width: 352, height: 512 });
+  assert.deepEqual(win.calls.filter((call) => call[0] === 'minimumSize').at(-1), [
+    'minimumSize',
+    HUD_SIZE.width,
+    HUD_SIZE.height,
+  ]);
+  assert.deepEqual(win.calls.filter((call) => call[0] === 'position').at(-1), ['position', 148, 288]);
+});
+
+test('Recorder keeps its fixed 72x344 native bounds with an unexpected HUD size', () => {
+  const win = fakeWindow();
+  const controller = new WindowController(win, {
+    preferencesStore: preferencesWithHudWindow({ width: 1, height: 1 }),
+    screenModule: hudDisplay(),
+  });
+
+  controller.setMode('recorder');
+
+  assert.deepEqual(win.getBounds(), { x: 408, y: 328, width: 72, height: 344 });
+  assert.deepEqual(win.calls.filter((call) => call[0] === 'minimumSize').at(-1), [
+    'minimumSize',
+    RECORDER_SIZE.width,
+    RECORDER_SIZE.height,
+  ]);
 });


### PR DESCRIPTION
## Summary

- disable Chromium page zoom shortcuts and Ctrl/Cmd-wheel gestures in the HUD and editor
- reset persisted page zoom to 100% when Electron windows load
- persist canonical HUD dimensions in `preferences.json` and repair missing, malformed, or unexpected values to `352x512` at startup
- hide editor UI-scaling controls from HUD preferences while keeping them available in the editor

## Validation

- `node --test test/browser-zoom-policy.test.cjs test/preferences/preferences-store.test.cjs test/window-controller.test.cjs test/editor-window.test.cjs` (52 passed)
- `bunx vitest run src/utils/browserZoomGuard.test.ts src/components/settings/AppearanceSettings.test.ts src/components/hud/tests/HudPreferences.test.ts` (29 passed)
- `bun run typecheck`
- `bun run typecheck:vue`
- targeted `oxfmt` and `oxlint`
- `bun run build`

## Platform note

The native macOS Ctrl/Cmd-wheel gesture still requires a physical macOS smoke test; deterministic policy and renderer event paths are covered by focused tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HUD window dimensions are now restored from preferences and automatically corrected when invalid.
  * Browser zoom is locked to the default level in the editor and HUD, while editor canvas and timeline zoom remain available.
  * HUD preferences no longer display the UI scaling control.

* **Documentation**
  * Added guidance on HUD sizing, UI scaling, browser zoom behavior, and transparent-margin interactions.

* **Tests**
  * Expanded coverage for window sizing, preference repair, browser zoom prevention, and UI scaling visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->