### PR TITLE
Fix camera device selection and black recordings

### DIFF
--- a/electron/camera/overlay-window.cjs
+++ b/electron/camera/overlay-window.cjs
@@ -10,6 +10,7 @@ function createCameraOverlayWindow({
   preferencesStore = null,
   platform = process.platform,
   canAcceptWork = () => true,
+  onWebContentsDestroyed = () => {},
 }) {
   let window = null;
   let currentState = null;
@@ -17,6 +18,36 @@ function createCameraOverlayWindow({
   let savePlacementTimer = null;
   let isHovered = false;
   let active = true;
+  let rendererReady = false;
+  let readyWaiters = [];
+
+  const settleReadyWaiters = (ready) => {
+    const waiters = readyWaiters;
+    readyWaiters = [];
+    for (const waiter of waiters) {
+      waiter.signal?.removeEventListener('abort', waiter.onAbort);
+      waiter.resolve(ready);
+    }
+  };
+
+  const waitForRenderer = (signal) =>
+    new Promise((resolve, reject) => {
+      if (signal?.aborted) {
+        reject(Object.assign(new Error('The camera recording command was cancelled.'), { name: 'AbortError' }));
+        return;
+      }
+      const waiter = {
+        resolve,
+        reject,
+        signal,
+        onAbort: () => {
+          readyWaiters = readyWaiters.filter((entry) => entry !== waiter);
+          reject(Object.assign(new Error('The camera recording command was cancelled.'), { name: 'AbortError' }));
+        },
+      };
+      signal?.addEventListener('abort', waiter.onAbort, { once: true });
+      readyWaiters.push(waiter);
+    });
 
   const readSavedPlacement = () => {
     const saved = preferencesStore?.read()?.extras?.cameraOverlay;
@@ -151,6 +182,7 @@ function createCameraOverlayWindow({
         sandbox: false,
       },
     });
+    rendererReady = false;
     window.setContentProtection(true);
     window.setAlwaysOnTop(true, 'floating');
     window.on('move', schedulePlacementSave);
@@ -163,9 +195,13 @@ function createCameraOverlayWindow({
     });
     window.on('closed', () => {
       flushPlacementSave();
+      rendererReady = false;
+      settleReadyWaiters(false);
       window = null;
       stopHoverTracking();
     });
+    const contents = window.webContents;
+    contents.once('destroyed', () => onWebContentsDestroyed(contents));
     window.webContents.once('did-finish-load', () => {
       if (currentState) window?.webContents.send('camera-overlay:state', currentState);
     });
@@ -226,11 +262,34 @@ function createCameraOverlayWindow({
     };
   };
 
+  const markRendererReady = (sender) => {
+    if (!window || window.isDestroyed() || sender !== window.webContents) return false;
+    rendererReady = true;
+    settleReadyWaiters(true);
+    if (currentState) window.webContents.send('camera-overlay:state', currentState);
+    return true;
+  };
+
+  const sendRecordingCommand = async (command, { signal } = {}) => {
+    const target = create();
+    if (!target) throw new Error('The camera overlay is unavailable.');
+    const ready = rendererReady || (await waitForRenderer(signal));
+    if (signal?.aborted)
+      throw Object.assign(new Error('The camera recording command was cancelled.'), { name: 'AbortError' });
+    if (!ready || target !== window || target.isDestroyed()) throw new Error('The camera overlay was closed.');
+    target.webContents.send('camera-overlay:recording-command', command);
+  };
+
+  const isRenderer = (sender) => Boolean(window && !window.isDestroyed() && sender === window.webContents);
+
   return {
     configure,
     setActive,
     resetPlacement,
     state,
+    markRendererReady,
+    sendRecordingCommand,
+    isRenderer,
     destroy: () => {
       flushPlacementSave();
       stopHoverTracking();

--- a/electron/camera/recording-control.cjs
+++ b/electron/camera/recording-control.cjs
@@ -1,0 +1,199 @@
+const crypto = require('node:crypto');
+
+const CAMERA_PREFIX = 'camera:chromium:';
+const ACTIONS = new Set(['prepare', 'start', 'pause', 'resume', 'stop', 'fail']);
+
+function assertText(value, name, maxLength = 500) {
+  if (typeof value !== 'string' || !value.trim() || value.length > maxLength) throw new Error(`Invalid ${name}.`);
+}
+
+function assertTimestamp(value, name) {
+  if (!Number.isSafeInteger(value) || value < 0) throw new Error(`Invalid ${name}.`);
+}
+
+function validateAppearance(value) {
+  if (value === undefined) return;
+  if (
+    !value ||
+    !['none', 'sm', 'md', 'lg'].includes(value.shadowSize) ||
+    !['none', 'sm', 'md', 'lg', 'full'].includes(value.cornerRadius)
+  )
+    throw new Error('Invalid camera appearance.');
+}
+
+function validatePlacement(value) {
+  if (value === undefined) return;
+  if (
+    !value ||
+    !['x', 'y', 'width', 'height'].every((key) => Number.isFinite(value[key])) ||
+    value.x < 0 ||
+    value.y < 0 ||
+    value.width <= 0 ||
+    value.height <= 0 ||
+    value.x + value.width > 1 ||
+    value.y + value.height > 1
+  )
+    throw new Error('Invalid camera placement.');
+}
+
+function validFormat(value) {
+  return (
+    value?.codec === 'vp8' &&
+    ['width', 'height', 'nominalFps'].every((key) => Number.isSafeInteger(value[key]) && value[key] > 0)
+  );
+}
+
+function validateControl(value) {
+  if (!value || typeof value !== 'object' || !ACTIONS.has(value.action)) throw new Error('Invalid camera action.');
+  if (value.action === 'prepare') {
+    assertText(value.sourceId, 'camera source', 2_000);
+    if (!value.sourceId.startsWith(CAMERA_PREFIX) || value.sourceId.length === CAMERA_PREFIX.length)
+      throw new Error('Invalid camera source.');
+    return value;
+  }
+  assertText(value.recordingId, 'camera recording identifier', 100);
+  if (value.action === 'start') {
+    assertText(value.sessionId, 'capture session identifier', 100);
+    assertTimestamp(value.startNs, 'camera segment start');
+    validateAppearance(value.appearance);
+    validatePlacement(value.placement);
+  } else if (value.action === 'resume') {
+    assertText(value.sessionId, 'capture session identifier', 100);
+    assertTimestamp(value.startNs, 'camera segment start');
+  } else if (value.action === 'fail') {
+    assertText(value.sessionId, 'capture session identifier', 100);
+    assertText(value.reason, 'camera failure reason');
+  } else assertTimestamp(value.endNs, 'camera segment end');
+  return value;
+}
+
+function createCameraRecordingControl({ ipcMain, cameraOverlay, hudWebContents, timeoutMs = 30_000 }) {
+  const pending = new Map();
+  let activeRecordingId = null;
+  let activeSessionId = null;
+  let activePhase = 'idle';
+
+  const dispatch = (command) =>
+    new Promise((resolve, reject) => {
+      const abort = new AbortController();
+      const timeout = setTimeout(() => {
+        pending.delete(command.commandId);
+        abort.abort();
+        reject(new Error('The camera overlay did not answer in time.'));
+      }, timeoutMs);
+      pending.set(command.commandId, { resolve, reject, timeout, abort });
+      void cameraOverlay.sendRecordingCommand(command, { signal: abort.signal }).catch((error) => {
+        const entry = pending.get(command.commandId);
+        if (!entry) return;
+        clearTimeout(entry.timeout);
+        pending.delete(command.commandId);
+        entry.reject(error);
+      });
+    });
+
+  ipcMain.handle('camera-overlay:recording-control', async (event, rawControl) => {
+    if (event.sender !== hudWebContents) throw new Error('Camera recording commands are restricted to the HUD.');
+    const control = validateControl(rawControl);
+    const preparing = control.action === 'prepare';
+    if (preparing) {
+      if (activeRecordingId) throw new Error('Another camera recording is already active.');
+      activeRecordingId = crypto.randomUUID();
+      activeSessionId = null;
+      activePhase = 'preparing';
+      cameraOverlay.configure({ cameraId: control.sourceId });
+    } else if (control.recordingId !== activeRecordingId) {
+      throw new Error('The camera recording is no longer active.');
+    } else if (control.action === 'start' && activePhase !== 'prepared') {
+      throw new Error('The camera recording is not ready to start.');
+    } else if (control.action === 'pause' && activePhase !== 'recording') {
+      throw new Error('The camera recording is not active.');
+    } else if (control.action === 'resume' && activePhase !== 'paused') {
+      throw new Error('The camera recording is not paused.');
+    } else if ((control.action === 'resume' || control.action === 'fail') && activeSessionId !== control.sessionId) {
+      throw new Error('The camera recording session does not match.');
+    }
+    const command = { commandId: crypto.randomUUID(), recordingId: activeRecordingId, control };
+    try {
+      const result = await dispatch(command);
+      if (preparing) {
+        if (
+          !result ||
+          result.recordingId !== activeRecordingId ||
+          result.sourceId !== control.sourceId ||
+          !validFormat(result.format)
+        )
+          throw new Error('The camera overlay returned an invalid preparation result.');
+        activePhase = 'prepared';
+      } else if (control.action === 'start') {
+        activeSessionId = control.sessionId;
+        activePhase = 'recording';
+      } else if (control.action === 'pause') activePhase = 'paused';
+      else if (control.action === 'resume') activePhase = 'recording';
+      return result;
+    } catch (error) {
+      if (preparing) {
+        activeRecordingId = null;
+        activePhase = 'idle';
+      }
+      throw error;
+    } finally {
+      if (control.action === 'stop' || control.action === 'fail') {
+        activeRecordingId = null;
+        activeSessionId = null;
+        activePhase = 'idle';
+      }
+    }
+  });
+
+  ipcMain.on('camera-overlay:renderer-ready', (event) => cameraOverlay.markRendererReady(event.sender));
+  ipcMain.on('camera-overlay:recording-result', (event, result) => {
+    if (!cameraOverlay.isRenderer(event.sender) || !result || typeof result !== 'object') return;
+    const entry = pending.get(result.commandId);
+    if (!entry) return;
+    clearTimeout(entry.timeout);
+    entry.abort.abort();
+    pending.delete(result.commandId);
+    if (result.ok) entry.resolve(result.value);
+    else {
+      const name = typeof result.error?.name === 'string' ? result.error.name : 'Error';
+      const message = typeof result.error?.message === 'string' ? result.error.message : 'Camera command failed.';
+      entry.reject(Object.assign(new Error(`${name}: ${message}`), { name }));
+    }
+  });
+  ipcMain.on('camera-overlay:recording-failure', (event, failure) => {
+    if (
+      !cameraOverlay.isRenderer(event.sender) ||
+      !failure ||
+      failure.recordingId !== activeRecordingId ||
+      typeof failure.message !== 'string'
+    )
+      return;
+    hudWebContents.send('camera-overlay:recording-failure', {
+      recordingId: activeRecordingId,
+      message: failure.message.slice(0, 500),
+    });
+    activeRecordingId = null;
+    activeSessionId = null;
+    activePhase = 'idle';
+  });
+
+  return (reason = 'Camera recording control was closed.') => {
+    if (activeRecordingId && (typeof hudWebContents.isDestroyed !== 'function' || !hudWebContents.isDestroyed())) {
+      hudWebContents.send('camera-overlay:recording-failure', {
+        recordingId: activeRecordingId,
+        message: reason.slice(0, 500),
+      });
+    }
+    activeRecordingId = null;
+    activeSessionId = null;
+    activePhase = 'idle';
+    for (const entry of pending.values()) {
+      clearTimeout(entry.timeout);
+      entry.abort.abort();
+      entry.reject(new Error('Camera recording control was closed.'));
+    }
+    pending.clear();
+  };
+}
+
+module.exports = { createCameraRecordingControl, validateControl };

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -34,6 +34,7 @@ const { createEditorWindowManager } = require('./window/editor-window.cjs');
 const { createOnboardingWindowManager } = require('./window/onboarding-window.cjs');
 const { registerExportIpc } = require('./export/export-ipc.cjs');
 const { createCameraOverlayWindow } = require('./camera/overlay-window.cjs');
+const { createCameraRecordingControl } = require('./camera/recording-control.cjs');
 const { createCountdownWindow } = require('./countdown-window.cjs');
 const { createScreenRegionOverlayWindow } = require('./screen-region-overlay.cjs');
 const { createCameraStorage, registerCameraIpc } = require('./camera-ipc.cjs');
@@ -383,10 +384,15 @@ function initializeApplication() {
       isPackaged: app.isPackaged,
       canAcceptWork: () => coordinator.canAcceptWork(),
     };
+    let cameraRecordingCleanup = () => {};
     const cameraOverlay = createCameraOverlayWindow({
       ...lifecycleOptions,
       preferencesStore,
       platform: process.platform,
+      onWebContentsDestroyed: (contents) => {
+        if (contents) cameraStorage.cleanupOwner(contents.id);
+        cameraRecordingCleanup('The camera overlay was closed while recording.');
+      },
     });
     const countdownOverlay = createCountdownWindow(lifecycleOptions);
     const screenRegionOverlay = createScreenRegionOverlayWindow({
@@ -394,7 +400,16 @@ function initializeApplication() {
       platform: process.platform,
       screen,
     });
-    applicationIpc.on('camera-overlay:configure', (_event, state) => cameraOverlay.configure(state));
+    applicationIpc.on('camera-overlay:configure', (event, state) => {
+      const fromOverlay = cameraOverlay.isRenderer(event.sender);
+      cameraOverlay.configure(state);
+      if (fromOverlay) {
+        for (const target of BrowserWindow.getAllWindows()) {
+          if (!target.isDestroyed() && target.webContents !== event.sender)
+            target.webContents.send('camera-overlay:state', cameraOverlay.state());
+        }
+      }
+    });
     applicationIpc.on('camera-overlay:set-active', (_event, active) => cameraOverlay.setActive(active));
     applicationIpc.on('camera-overlay:reset-placement', () => cameraOverlay.resetPlacement());
     applicationIpc.handle('countdown:set', (_event, seconds) => {
@@ -457,6 +472,11 @@ function initializeApplication() {
       if (coordinator.canAcceptWork()) app.quit();
     });
     const win = createWindow(preferencesStore, appIconPath);
+    cameraRecordingCleanup = createCameraRecordingControl({
+      ipcMain: applicationIpc,
+      cameraOverlay,
+      hudWebContents: win.webContents,
+    });
     win.webContents.once('did-finish-load', () => {
       shortcutReady = true;
       for (const id of pendingExternalShortcuts.splice(0)) externalShortcutHandler(id);
@@ -520,6 +540,7 @@ function initializeApplication() {
     coordinator.registerCleanup({ id: 'spell-check-context-menu', cleanup: spellCheckContextMenuCleanup });
     coordinator.registerCleanup({ id: 'countdown', cleanup: () => countdownOverlay.destroy() });
     coordinator.registerCleanup({ id: 'camera-overlay', cleanup: () => cameraOverlay.destroy() });
+    coordinator.registerCleanup({ id: 'camera-recording-control', cleanup: cameraRecordingCleanup });
     coordinator.registerCleanup({ id: 'screen-region', cleanup: () => screenRegionOverlay.destroy() });
     coordinator.registerCleanup({ id: 'preferences', cleanup: preferencesCleanup });
 

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -212,6 +212,20 @@ contextBridge.exposeInMainWorld(
       ipcRenderer.on('camera-overlay:hover', callback);
       return () => ipcRenderer.removeListener('camera-overlay:hover', callback);
     },
+    controlCameraOverlayRecording: (control) => ipcRenderer.invoke('camera-overlay:recording-control', control),
+    onCameraOverlayRecordingCommand: (listener) => {
+      const callback = (_event, command) => listener(command);
+      ipcRenderer.on('camera-overlay:recording-command', callback);
+      return () => ipcRenderer.removeListener('camera-overlay:recording-command', callback);
+    },
+    completeCameraOverlayRecordingCommand: (result) => ipcRenderer.send('camera-overlay:recording-result', result),
+    notifyCameraOverlayReady: () => ipcRenderer.send('camera-overlay:renderer-ready'),
+    reportCameraRecordingFailure: (failure) => ipcRenderer.send('camera-overlay:recording-failure', failure),
+    onCameraRecordingFailure: (listener) => {
+      const callback = (_event, failure) => listener(failure);
+      ipcRenderer.on('camera-overlay:recording-failure', callback);
+      return () => ipcRenderer.removeListener('camera-overlay:recording-failure', callback);
+    },
     onCameraShadow: (listener) => {
       const callback = (_event, state) => listener(state);
       ipcRenderer.on('camera-shadow:state', callback);

--- a/src/App.vue
+++ b/src/App.vue
@@ -199,7 +199,6 @@ const startRecording = async (configuration: RecordingConfiguration) => {
 
 const cancelOrStopRecording = async () => {
   const wasStartup = recording.phase.value === 'countdown' || recording.phase.value === 'starting';
-  if (!wasStartup) capture.setCameraOverlayActive(false);
   await recording.stop();
   if (!wasStartup && recording.phase.value !== 'idle') capture.setCameraOverlayActive(true);
   if (wasStartup) returnToHud();

--- a/src/api/camera-frame-ready.ts
+++ b/src/api/camera-frame-ready.ts
@@ -1,0 +1,46 @@
+type FrameReadyOptions = { signal?: AbortSignal; timeoutMs?: number };
+
+const namedError = (name: string, message: string) => Object.assign(new Error(message), { name });
+
+export function waitForFirstCameraFrame(video: HTMLVideoElement, options: FrameReadyOptions = {}): Promise<void> {
+  const { signal, timeoutMs = 5_000 } = options;
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let frameCallbackId: number | null = null;
+    const finish = (reason?: Error) => {
+      if (settled) return;
+      settled = true;
+      window.clearTimeout(timeout);
+      signal?.removeEventListener('abort', onAbort);
+      video.removeEventListener('error', onError);
+      video.removeEventListener('loadeddata', onLoadedData);
+      if (frameCallbackId !== null && typeof video.cancelVideoFrameCallback === 'function')
+        video.cancelVideoFrameCallback(frameCallbackId);
+      if (reason) reject(reason);
+      else resolve();
+    };
+    const hasDimensions = (width = video.videoWidth, height = video.videoHeight) => width > 0 && height > 0;
+    const onAbort = () => finish(namedError('AbortError', 'Camera frame wait was cancelled.'));
+    const onError = () => finish(namedError('NotReadableError', 'The selected camera failed before its first frame.'));
+    const onLoadedData = () => {
+      if (hasDimensions()) finish();
+    };
+    const timeout = window.setTimeout(
+      () => finish(namedError('NotReadableError', 'The selected camera did not produce a video frame.')),
+      timeoutMs,
+    );
+
+    if (signal?.aborted) return onAbort();
+    signal?.addEventListener('abort', onAbort, { once: true });
+    video.addEventListener('error', onError, { once: true });
+    if (typeof video.requestVideoFrameCallback === 'function') {
+      frameCallbackId = video.requestVideoFrameCallback((_now, metadata) => {
+        if (hasDimensions(metadata.width, metadata.height)) finish();
+        else onError();
+      });
+    } else {
+      video.addEventListener('loadeddata', onLoadedData);
+      if (video.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA && hasDimensions()) finish();
+    }
+  });
+}

--- a/src/api/camera-recorder.ts
+++ b/src/api/camera-recorder.ts
@@ -1,14 +1,19 @@
 import type { CaptureSource } from './types/capture-api';
+import { waitForFirstCameraFrame } from './camera-frame-ready';
+import type {
+  CameraAppearance,
+  CameraFormat,
+  CameraPlacement,
+  CameraRecordingControl,
+  CameraRecordingControlResult,
+  CameraRecordingFailure,
+} from './types/camera-recording';
+
+export type { CameraAppearance, CameraFormat, CameraPlacement } from './types/camera-recording';
 
 const MIME_TYPE = 'video/webm;codecs=vp8';
 const CAMERA_PREFIX = 'camera:chromium:';
 
-export type CameraPlacement = { x: number; y: number; width: number; height: number };
-type CameraFormat = { codec: 'vp8'; width: number; height: number; nominalFps: number };
-export type CameraAppearance = {
-  shadowSize: 'none' | 'sm' | 'md' | 'lg';
-  cornerRadius: 'none' | 'sm' | 'md' | 'lg' | 'full';
-};
 type CameraSegmentApi = {
   beginCameraSegment(payload: {
     sessionId: string;
@@ -19,6 +24,8 @@ type CameraSegmentApi = {
   writeCameraSegment(payload: { jobId: string; sequence: number; data: Uint8Array }): Promise<void>;
   finalizeCameraSegment(payload: { jobId: string; endNs: number; metrics: Record<string, number> }): Promise<void>;
   failCamera(payload: { sessionId: string; reason: string }): Promise<void>;
+  controlCameraOverlayRecording(control: CameraRecordingControl): Promise<CameraRecordingControlResult>;
+  onCameraRecordingFailure(listener: (failure: CameraRecordingFailure) => void): () => void;
 };
 
 function api(): CameraSegmentApi {
@@ -32,11 +39,16 @@ function deviceId(sourceId: string) {
   return sourceId.slice(CAMERA_PREFIX.length);
 }
 
+export function cameraVideoConstraints(sourceId: string): MediaTrackConstraints {
+  return { deviceId: { exact: deviceId(sourceId) } };
+}
+
 export function isCameraUnavailableError(error: unknown) {
   const name = typeof error === 'object' && error !== null && 'name' in error ? String(error.name) : '';
   const message = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
   return (
     ['NotFoundError', 'NotReadableError', 'OverconstrainedError'].includes(name) ||
+    ['notfounderror', 'notreadableerror', 'overconstrainederror'].some((entry) => message.includes(entry)) ||
     message.includes('could not start video source') ||
     message.includes('hardware resources') ||
     message.includes('0xc00d3704') ||
@@ -48,15 +60,23 @@ function positive(value: number | undefined, fallback: number) {
   return Number.isFinite(value) && value! > 0 ? Math.round(value!) : fallback;
 }
 
-export async function validateCameraAccess(sourceId: string): Promise<void> {
-  if (!sourceId || sourceId === 'off') return;
-  if (!navigator.mediaDevices?.getUserMedia) throw new Error('Camera access is unavailable in this Chromium build.');
-  const rawId = deviceId(sourceId);
-  const stream = await navigator.mediaDevices.getUserMedia({
-    audio: false,
-    video: rawId ? { deviceId: { ideal: rawId } } : true,
-  });
-  stream.getTracks().forEach((track) => track.stop());
+async function waitForCameraStream(stream: MediaStream) {
+  const video = document.createElement('video');
+  const abort = new AbortController();
+  video.muted = true;
+  video.playsInline = true;
+  video.srcObject = stream;
+  const firstFrame = waitForFirstCameraFrame(video, { signal: abort.signal });
+  try {
+    await Promise.all([video.play(), firstFrame]);
+  } catch (error) {
+    abort.abort();
+    await firstFrame.catch(() => undefined);
+    throw error;
+  } finally {
+    video.pause();
+    video.srcObject = null;
+  }
 }
 
 export async function listBrowserCameras(): Promise<CaptureSource[]> {
@@ -90,19 +110,26 @@ export class BrowserCameraRecorder {
   readonly format: CameraFormat;
   private readonly stream: MediaStream;
   private readonly track: MediaStreamTrack;
+  private readonly ownsStream: boolean;
+  private readonly trackEndedHandler = () =>
+    this.reportFatal(new Error('The selected camera was disconnected or stopped.'));
+  private readonly beforeUnloadHandler = () => this.release();
 
-  private constructor(stream: MediaStream, sourceId: string, track: MediaStreamTrack, format: CameraFormat) {
+  private constructor(
+    stream: MediaStream,
+    sourceId: string,
+    track: MediaStreamTrack,
+    format: CameraFormat,
+    ownsStream: boolean,
+  ) {
     this.stream = stream;
     this.sourceId = sourceId;
     this.track = track;
     this.format = format;
-    this.track.addEventListener(
-      'ended',
-      () => this.reportFatal(new Error('The selected camera was disconnected or stopped.')),
-      { once: true },
-    );
+    this.ownsStream = ownsStream;
+    this.track.addEventListener('ended', this.trackEndedHandler, { once: true });
     if (typeof window !== 'undefined') {
-      window.addEventListener('beforeunload', () => this.release(), { once: true });
+      window.addEventListener('beforeunload', this.beforeUnloadHandler, { once: true });
     }
   }
 
@@ -110,25 +137,47 @@ export class BrowserCameraRecorder {
     if (!navigator.mediaDevices?.getUserMedia) throw new Error('Camera access is unavailable in this Chromium build.');
     if (!MediaRecorder.isTypeSupported(MIME_TYPE))
       throw new Error('This Chromium build cannot record VP8 WebM camera video.');
-    // Keep the request permissive. Windows Media Foundation can reject an
-    // otherwise valid camera when a preferred resolution/fps combination
-    // cannot be allocated, especially after another camera stream was closed.
+    // Require the chosen device, but leave its format unconstrained. Windows
+    // Media Foundation can reject otherwise valid resolution/fps preferences.
     const stream = await navigator.mediaDevices.getUserMedia({
       audio: false,
-      video: { deviceId: { ideal: deviceId(sourceId) } },
+      video: cameraVideoConstraints(sourceId),
     });
-    const track = stream.getVideoTracks()[0];
-    if (!track) {
+    if (!stream.getVideoTracks()[0]) {
       stream.getTracks().forEach((entry) => entry.stop());
       throw new Error('The selected camera did not provide a video track.');
     }
+    try {
+      await waitForCameraStream(stream);
+    } catch (error) {
+      stream.getTracks().forEach((entry) => entry.stop());
+      throw error;
+    }
+    return BrowserCameraRecorder.fromReadyStream(sourceId, stream, true);
+  }
+
+  static fromReadyStream(sourceId: string, stream: MediaStream, ownsStream = false) {
+    if (!MediaRecorder.isTypeSupported(MIME_TYPE))
+      throw new Error('This Chromium build cannot record VP8 WebM camera video.');
+    deviceId(sourceId);
+    const track = stream.getVideoTracks()[0];
+    if (!track) {
+      if (ownsStream) stream.getTracks().forEach((entry) => entry.stop());
+      throw new Error('The selected camera did not provide a video track.');
+    }
     const settings = track.getSettings();
-    return new BrowserCameraRecorder(stream, sourceId, track, {
-      codec: 'vp8',
-      width: positive(settings.width, 1920),
-      height: positive(settings.height, 1080),
-      nominalFps: positive(settings.frameRate, 30),
-    });
+    return new BrowserCameraRecorder(
+      stream,
+      sourceId,
+      track,
+      {
+        codec: 'vp8',
+        width: positive(settings.width, 1920),
+        height: positive(settings.height, 1080),
+        nominalFps: positive(settings.frameRate, 30),
+      },
+      ownsStream,
+    );
   }
 
   onFatal(handler: (error: Error) => void) {
@@ -140,20 +189,21 @@ export class BrowserCameraRecorder {
     appearance?: CameraAppearance,
     placement?: CameraPlacement,
     timelineStartedAt = performance.now(),
+    startNs?: number,
   ) {
     this.appearance = appearance;
     this.placement = placement;
     this.timelineStartedAt = timelineStartedAt;
     this.startFrameCounter();
-    await this.startSegment(sessionId, 0);
+    await this.startSegment(sessionId, startNs ?? this.nowNs());
   }
 
   async pause(endNs = this.nowNs()) {
     await this.finishSegment(endNs);
   }
 
-  async resume(sessionId: string) {
-    await this.startSegment(sessionId, this.nowNs());
+  async resume(sessionId: string, startNs = this.nowNs()) {
+    await this.startSegment(sessionId, startNs);
   }
 
   async stop(endNs = this.nowNs()) {
@@ -269,10 +319,125 @@ export class BrowserCameraRecorder {
 
   private release() {
     this.stopped = true;
+    this.track.removeEventListener('ended', this.trackEndedHandler);
+    if (typeof window !== 'undefined') window.removeEventListener('beforeunload', this.beforeUnloadHandler);
     this.video?.pause();
     if (this.video) this.video.srcObject = null;
     this.video = null;
-    this.stream.getTracks().forEach((entry) => entry.stop());
+    if (this.ownsStream) this.stream.getTracks().forEach((entry) => entry.stop());
+  }
+}
+
+export interface CameraRecorderHandle {
+  readonly sourceId: string;
+  readonly format: CameraFormat;
+  onFatal(handler: (error: Error) => void): void;
+  start(
+    sessionId: string,
+    appearance?: CameraAppearance,
+    placement?: CameraPlacement,
+    timelineStartedAt?: number,
+  ): Promise<void>;
+  pause(endNs?: number): Promise<void>;
+  resume(sessionId: string): Promise<void>;
+  stop(endNs?: number): Promise<void>;
+  fail(sessionId: string, reason: string): Promise<void>;
+}
+
+export class CameraOverlayRecorder implements CameraRecorderHandle {
+  private fatalHandler: ((error: Error) => void) | null = null;
+  private removeFailureListener: (() => void) | null = null;
+  private controlQueue = Promise.resolve();
+  private timelineStartedAt = performance.now();
+  private stopped = false;
+  readonly recordingId: string;
+  readonly sourceId: string;
+  readonly format: CameraFormat;
+
+  private constructor(recordingId: string, sourceId: string, format: CameraFormat) {
+    this.recordingId = recordingId;
+    this.sourceId = sourceId;
+    this.format = format;
+    this.removeFailureListener = api().onCameraRecordingFailure((failure) => {
+      if (this.stopped || failure.recordingId !== this.recordingId) return;
+      const handler = this.fatalHandler;
+      this.release();
+      handler?.(new Error(failure.message));
+    });
+  }
+
+  static async request(sourceId: string) {
+    const prepared = await api().controlCameraOverlayRecording({ action: 'prepare', sourceId });
+    if (!prepared) throw new Error('The camera overlay returned an invalid preparation result.');
+    return new CameraOverlayRecorder(prepared.recordingId, prepared.sourceId, prepared.format);
+  }
+
+  onFatal(handler: (error: Error) => void) {
+    this.fatalHandler = handler;
+  }
+
+  async start(
+    sessionId: string,
+    appearance?: CameraAppearance,
+    placement?: CameraPlacement,
+    timelineStartedAt = performance.now(),
+  ) {
+    this.timelineStartedAt = timelineStartedAt;
+    await this.control({
+      action: 'start',
+      recordingId: this.recordingId,
+      sessionId,
+      startNs: this.nowNs(),
+      appearance,
+      placement,
+    });
+  }
+
+  async pause(endNs = this.nowNs()) {
+    await this.control({ action: 'pause', recordingId: this.recordingId, endNs });
+  }
+
+  async resume(sessionId: string) {
+    await this.control({ action: 'resume', recordingId: this.recordingId, sessionId, startNs: this.nowNs() });
+  }
+
+  async stop(endNs = this.nowNs()) {
+    if (this.stopped) return;
+    try {
+      await this.control({ action: 'stop', recordingId: this.recordingId, endNs });
+    } finally {
+      this.release();
+    }
+  }
+
+  async fail(sessionId: string, reason: string) {
+    if (this.stopped) return;
+    try {
+      await this.control({ action: 'fail', recordingId: this.recordingId, sessionId, reason });
+    } finally {
+      this.release();
+    }
+  }
+
+  private async control(control: CameraRecordingControl) {
+    if (this.stopped) throw new Error('Camera recording has already stopped.');
+    const operation = this.controlQueue.then(() => api().controlCameraOverlayRecording(control));
+    this.controlQueue = operation.then(
+      () => undefined,
+      () => undefined,
+    );
+    await operation;
+  }
+
+  private nowNs() {
+    return Math.max(0, Math.round((performance.now() - this.timelineStartedAt) * 1_000_000));
+  }
+
+  private release() {
+    this.stopped = true;
+    this.removeFailureListener?.();
+    this.removeFailureListener = null;
+    this.fatalHandler = null;
   }
 }
 

--- a/src/api/tests/camera-frame-ready.test.ts
+++ b/src/api/tests/camera-frame-ready.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { waitForFirstCameraFrame } from '../camera-frame-ready';
+
+type FrameCallback = (now: number, metadata: { width: number; height: number }) => void;
+
+const requestVideoFrameCallbackDescriptor = Object.getOwnPropertyDescriptor(
+  HTMLVideoElement.prototype,
+  'requestVideoFrameCallback',
+);
+const cancelVideoFrameCallbackDescriptor = Object.getOwnPropertyDescriptor(
+  HTMLVideoElement.prototype,
+  'cancelVideoFrameCallback',
+);
+
+const defineDimensions = (video: HTMLVideoElement, width = 1280, height = 720) => {
+  Object.defineProperty(video, 'videoWidth', { configurable: true, value: width });
+  Object.defineProperty(video, 'videoHeight', { configurable: true, value: height });
+};
+
+const restoreDescriptor = (target: object, key: string, descriptor: PropertyDescriptor | undefined) => {
+  if (descriptor) Object.defineProperty(target, key, descriptor);
+  else delete (target as Record<string, unknown>)[key];
+};
+
+describe('waitForFirstCameraFrame', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    restoreDescriptor(HTMLVideoElement.prototype, 'requestVideoFrameCallback', requestVideoFrameCallbackDescriptor);
+    restoreDescriptor(HTMLVideoElement.prototype, 'cancelVideoFrameCallback', cancelVideoFrameCallbackDescriptor);
+  });
+
+  it('waits for a positive-dimension requestVideoFrameCallback frame and cancels the callback on cleanup', async () => {
+    const video = document.createElement('video');
+    const callbacks = new Map<number, FrameCallback>();
+    const requestVideoFrameCallback = vi.fn((callback: FrameCallback) => {
+      const id = callbacks.size + 1;
+      callbacks.set(id, callback);
+      return id;
+    });
+    const cancelVideoFrameCallback = vi.fn((id: number) => callbacks.delete(id));
+    Object.defineProperty(video, 'requestVideoFrameCallback', { configurable: true, value: requestVideoFrameCallback });
+    Object.defineProperty(video, 'cancelVideoFrameCallback', { configurable: true, value: cancelVideoFrameCallback });
+
+    const promise = waitForFirstCameraFrame(video, { timeoutMs: 100 });
+    await Promise.resolve();
+    expect(requestVideoFrameCallback).toHaveBeenCalledOnce();
+    expect(callbacks.size).toBe(1);
+
+    callbacks.get(1)?.(0, { width: 1280, height: 720 });
+    await expect(promise).resolves.toBeUndefined();
+    expect(cancelVideoFrameCallback).toHaveBeenCalledWith(1);
+  });
+
+  it('rejects when the selected camera does not produce a frame before the timeout', async () => {
+    const video = document.createElement('video');
+    const cancelVideoFrameCallback = vi.fn();
+    Object.defineProperty(video, 'requestVideoFrameCallback', {
+      configurable: true,
+      value: vi.fn(() => 7),
+    });
+    Object.defineProperty(video, 'cancelVideoFrameCallback', { configurable: true, value: cancelVideoFrameCallback });
+
+    const result = expect(waitForFirstCameraFrame(video, { timeoutMs: 250 })).rejects.toMatchObject({
+      name: 'NotReadableError',
+    });
+    await vi.advanceTimersByTimeAsync(250);
+    await result;
+    expect(cancelVideoFrameCallback).toHaveBeenCalledWith(7);
+  });
+
+  it('rejects with AbortError and removes the pending frame callback when cancelled', async () => {
+    const video = document.createElement('video');
+    const controller = new AbortController();
+    const cancelVideoFrameCallback = vi.fn();
+    Object.defineProperty(video, 'requestVideoFrameCallback', {
+      configurable: true,
+      value: vi.fn(() => 11),
+    });
+    Object.defineProperty(video, 'cancelVideoFrameCallback', { configurable: true, value: cancelVideoFrameCallback });
+
+    const promise = waitForFirstCameraFrame(video, { signal: controller.signal, timeoutMs: 250 });
+    controller.abort();
+
+    await expect(promise).rejects.toMatchObject({ name: 'AbortError' });
+    expect(cancelVideoFrameCallback).toHaveBeenCalledWith(11);
+  });
+
+  it('uses loadeddata as a fallback when requestVideoFrameCallback is unavailable', async () => {
+    const video = document.createElement('video');
+    defineDimensions(video);
+    Object.defineProperty(video, 'readyState', { configurable: true, value: 0 });
+
+    const promise = waitForFirstCameraFrame(video, { timeoutMs: 100 });
+    video.dispatchEvent(new Event('loadeddata'));
+
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  it('rejects a callback that reports no video dimensions', async () => {
+    const video = document.createElement('video');
+    let callback: FrameCallback | undefined;
+    Object.defineProperty(video, 'requestVideoFrameCallback', {
+      configurable: true,
+      value: vi.fn((next: FrameCallback) => {
+        callback = next;
+        return 13;
+      }),
+    });
+
+    const promise = waitForFirstCameraFrame(video, { timeoutMs: 100 });
+    await Promise.resolve();
+    callback?.(0, { width: 0, height: 0 });
+
+    await expect(promise).rejects.toMatchObject({ name: 'NotReadableError' });
+  });
+});

--- a/src/api/tests/camera-recorder.branches.test.ts
+++ b/src/api/tests/camera-recorder.branches.test.ts
@@ -9,6 +9,13 @@ class FakeTrack {
     this.listeners.set(type, [...(this.listeners.get(type) ?? []), listener]);
   }
 
+  removeEventListener(type: string, listener: () => void) {
+    this.listeners.set(
+      type,
+      (this.listeners.get(type) ?? []).filter((entry) => entry !== listener),
+    );
+  }
+
   getSettings() {
     return { width: 1280, height: 720, frameRate: 30 };
   }
@@ -91,9 +98,13 @@ beforeEach(() => {
   vi.stubGlobal('MediaRecorder', FakeMediaRecorder);
   vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue(undefined);
   vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => undefined);
+  let frameCallbackCount = 0;
   Object.defineProperty(HTMLVideoElement.prototype, 'requestVideoFrameCallback', {
     configurable: true,
-    value: vi.fn(),
+    value: vi.fn((callback: VideoFrameRequestCallback) => {
+      if (frameCallbackCount++ === 0) callback(0, { width: 1280, height: 720 } as VideoFrameCallbackMetadata);
+      return frameCallbackCount;
+    }),
   });
 });
 

--- a/src/api/tests/camera-recorder.test.ts
+++ b/src/api/tests/camera-recorder.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { BrowserCameraRecorder, listBrowserCameras } from '../camera-recorder';
+import { BrowserCameraRecorder, CameraOverlayRecorder, listBrowserCameras } from '../camera-recorder';
 
 type Listener = (...args: unknown[]) => void;
 
@@ -31,6 +31,12 @@ const createTrack = (settings: MediaTrackSettings = {}) => {
     addEventListener: vi.fn((type: string, listener: Listener) =>
       listeners.set(type, [...(listeners.get(type) ?? []), listener]),
     ),
+    removeEventListener: vi.fn((type: string, listener: Listener) => {
+      listeners.set(
+        type,
+        (listeners.get(type) ?? []).filter((entry) => entry !== listener),
+      );
+    }),
     getSettings: vi.fn(() => settings),
     stop: vi.fn(),
     emit: (type: string) => listeners.get(type)?.forEach((listener) => listener()),
@@ -44,6 +50,8 @@ const capture = {
   writeCameraSegment: vi.fn(),
   finalizeCameraSegment: vi.fn(),
   failCamera: vi.fn(),
+  controlCameraOverlayRecording: vi.fn(),
+  onCameraRecordingFailure: vi.fn(),
 };
 
 beforeEach(() => {
@@ -60,11 +68,17 @@ beforeEach(() => {
   capture.writeCameraSegment.mockResolvedValue(undefined);
   capture.finalizeCameraSegment.mockResolvedValue(undefined);
   capture.failCamera.mockResolvedValue(undefined);
+  capture.controlCameraOverlayRecording.mockResolvedValue(undefined);
+  capture.onCameraRecordingFailure.mockReturnValue(() => undefined);
   vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue(undefined);
   vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => undefined);
+  let frameCallbackCount = 0;
   Object.defineProperty(HTMLVideoElement.prototype, 'requestVideoFrameCallback', {
     configurable: true,
-    value: vi.fn(),
+    value: vi.fn((callback: (now: number, metadata: { width: number; height: number }) => void) => {
+      if (frameCallbackCount++ === 0) callback(0, { width: 1280, height: 720 });
+      return frameCallbackCount;
+    }),
   });
 });
 
@@ -125,9 +139,15 @@ describe('BrowserCameraRecorder', () => {
     const stream = { getVideoTracks: () => [track], getTracks: () => [track] } as unknown as MediaStream;
     vi.mocked(navigator.mediaDevices.getUserMedia).mockResolvedValue(stream);
     const recorder = await BrowserCameraRecorder.request('camera:chromium:device-7');
-    await recorder.start('session', { shadowSize: 'md', cornerRadius: 'lg' }, { x: 1, y: 2, width: 3, height: 4 }, 50);
+    await recorder.start(
+      'session',
+      { shadowSize: 'md', cornerRadius: 'lg' },
+      { x: 1, y: 2, width: 3, height: 4 },
+      50,
+      0,
+    );
     expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledWith(
-      expect.objectContaining({ audio: false, video: expect.objectContaining({ deviceId: { ideal: 'device-7' } }) }),
+      expect.objectContaining({ audio: false, video: expect.objectContaining({ deviceId: { exact: 'device-7' } }) }),
     );
     expect(capture.beginCameraSegment).toHaveBeenCalledWith({
       sessionId: 'session',
@@ -141,6 +161,19 @@ describe('BrowserCameraRecorder', () => {
       startNs: 0,
     });
     expect(FakeMediaRecorder.instances[0].start).toHaveBeenCalledWith(1000);
+  });
+
+  it('records an existing ready stream without reacquiring or stopping the shared stream', async () => {
+    const track = createTrack({ width: 1280, height: 720, frameRate: 30 });
+    const stream = { getVideoTracks: () => [track], getTracks: () => [track] } as unknown as MediaStream;
+    const recorder = BrowserCameraRecorder.fromReadyStream('camera:chromium:shared', stream);
+
+    await recorder.start('session');
+    expect(navigator.mediaDevices.getUserMedia).not.toHaveBeenCalled();
+    expect(FakeMediaRecorder.instances[0].stream).toBe(stream);
+
+    await recorder.stop();
+    expect(track.stop).not.toHaveBeenCalled();
   });
 
   it('serializes chunks and finalizes using a non-negative monotonically bounded end time', async () => {
@@ -219,5 +252,87 @@ describe('BrowserCameraRecorder', () => {
     expect(capture.failCamera).toHaveBeenCalledWith({ sessionId: 'session', reason: 'lost permission' });
     expect(track.stop).toHaveBeenCalledOnce();
     await expect(recorder.resume('session')).rejects.toThrow('already stopped');
+  });
+});
+
+describe('CameraOverlayRecorder', () => {
+  it('drives the overlay-owned recorder without acquiring another camera stream', async () => {
+    capture.controlCameraOverlayRecording.mockResolvedValueOnce({
+      recordingId: 'recording-1',
+      sourceId: 'camera:chromium:shared',
+      format: { codec: 'vp8', width: 1280, height: 720, nominalFps: 30 },
+    });
+    const recorder = await CameraOverlayRecorder.request('camera:chromium:shared');
+
+    await recorder.start('session-1', { shadowSize: 'sm', cornerRadius: 'lg' }, undefined, performance.now());
+    await recorder.pause(100);
+    await recorder.resume('session-1');
+    await recorder.stop(300);
+
+    expect(navigator.mediaDevices.getUserMedia).not.toHaveBeenCalled();
+    expect(capture.controlCameraOverlayRecording.mock.calls.map(([control]) => control.action)).toEqual([
+      'prepare',
+      'start',
+      'pause',
+      'resume',
+      'stop',
+    ]);
+    expect(capture.controlCameraOverlayRecording).toHaveBeenLastCalledWith({
+      action: 'stop',
+      recordingId: 'recording-1',
+      endNs: 300,
+    });
+  });
+
+  it('sends the first overlay segment start relative to the supplied session timeline', async () => {
+    const now = vi.spyOn(performance, 'now').mockReturnValue(1_000);
+    capture.controlCameraOverlayRecording.mockResolvedValueOnce({
+      recordingId: 'recording-1',
+      sourceId: 'camera:chromium:shared',
+      format: { codec: 'vp8', width: 1280, height: 720, nominalFps: 30 },
+    });
+    const recorder = await CameraOverlayRecorder.request('camera:chromium:shared');
+
+    now.mockReturnValue(6_000);
+    await recorder.start('session-1', undefined, undefined, 1_000);
+
+    expect(capture.controlCameraOverlayRecording).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'start',
+        recordingId: 'recording-1',
+        sessionId: 'session-1',
+        startNs: 5_000_000_000,
+      }),
+    );
+    await recorder.stop(5_000_000_000);
+  });
+
+  it('forwards only matching fatal failures and unsubscribes after stop', async () => {
+    let failureListener!: (failure: { recordingId: string; message: string }) => void;
+    const unsubscribe = vi.fn();
+    capture.onCameraRecordingFailure.mockImplementation((listener) => {
+      failureListener = listener;
+      return unsubscribe;
+    });
+    capture.controlCameraOverlayRecording.mockResolvedValueOnce({
+      recordingId: 'recording-1',
+      sourceId: 'camera:chromium:shared',
+      format: { codec: 'vp8', width: 1280, height: 720, nominalFps: 30 },
+    });
+    const recorder = await CameraOverlayRecorder.request('camera:chromium:shared');
+    const fatal = vi.fn();
+    recorder.onFatal(fatal);
+
+    failureListener({ recordingId: 'other', message: 'ignored' });
+    expect(unsubscribe).not.toHaveBeenCalled();
+    failureListener({ recordingId: 'recording-1', message: 'camera disconnected' });
+    expect(fatal).toHaveBeenCalledOnce();
+    expect(fatal).toHaveBeenCalledWith(expect.objectContaining({ message: 'camera disconnected' }));
+    expect(unsubscribe).toHaveBeenCalledOnce();
+
+    await recorder.stop(0);
+    expect(unsubscribe).toHaveBeenCalledOnce();
+    failureListener({ recordingId: 'recording-1', message: 'late failure' });
+    expect(fatal).toHaveBeenCalledOnce();
   });
 });

--- a/src/api/types/camera-recording.ts
+++ b/src/api/types/camera-recording.ts
@@ -1,0 +1,40 @@
+export type CameraPlacement = { x: number; y: number; width: number; height: number };
+
+export type CameraFormat = { codec: 'vp8'; width: number; height: number; nominalFps: number };
+
+export type CameraAppearance = {
+  shadowSize: 'none' | 'sm' | 'md' | 'lg';
+  cornerRadius: 'none' | 'sm' | 'md' | 'lg' | 'full';
+};
+
+export type CameraRecordingControl =
+  | { action: 'prepare'; sourceId: string }
+  | {
+      action: 'start';
+      recordingId: string;
+      sessionId: string;
+      startNs: number;
+      appearance?: CameraAppearance;
+      placement?: CameraPlacement;
+    }
+  | { action: 'pause'; recordingId: string; endNs: number }
+  | { action: 'resume'; recordingId: string; sessionId: string; startNs: number }
+  | { action: 'stop'; recordingId: string; endNs: number }
+  | { action: 'fail'; recordingId: string; sessionId: string; reason: string };
+
+export type CameraRecordingControlResult = { recordingId: string; sourceId: string; format: CameraFormat } | undefined;
+
+export type CameraRecordingCommand = {
+  commandId: string;
+  recordingId: string;
+  control: CameraRecordingControl;
+};
+
+export type CameraRecordingCommandResult = {
+  commandId: string;
+  ok: boolean;
+  value?: CameraRecordingControlResult;
+  error?: { name: string; message: string };
+};
+
+export type CameraRecordingFailure = { recordingId: string; message: string };

--- a/src/api/types/capture-api.ts
+++ b/src/api/types/capture-api.ts
@@ -28,6 +28,13 @@ import type {
   RecorderLauncherContext,
 } from './editor-window';
 import type { AppearanceSettings } from '~/types/appearance';
+import type {
+  CameraRecordingCommand,
+  CameraRecordingCommandResult,
+  CameraRecordingControl,
+  CameraRecordingControlResult,
+  CameraRecordingFailure,
+} from './camera-recording';
 
 export type * from './capture-config';
 export type * from './screen-region';
@@ -193,6 +200,12 @@ export interface DesktopCaptureApi extends CaptureApi {
   ): () => void;
   onCameraOverlayHover(listener: (hovered: boolean) => void): () => void;
   onCameraShadow(listener: (state: { shadowSize: string; cornerRadius: string }) => void): () => void;
+  controlCameraOverlayRecording(control: CameraRecordingControl): Promise<CameraRecordingControlResult>;
+  onCameraOverlayRecordingCommand(listener: (command: CameraRecordingCommand) => void): () => void;
+  completeCameraOverlayRecordingCommand(result: CameraRecordingCommandResult): void;
+  notifyCameraOverlayReady(): void;
+  reportCameraRecordingFailure(failure: CameraRecordingFailure): void;
+  onCameraRecordingFailure(listener: (failure: CameraRecordingFailure) => void): () => void;
   beginExport(options: {
     projectName: string;
     format: 'webm' | 'mp4';

--- a/src/components/hud/HUD.vue
+++ b/src/components/hud/HUD.vue
@@ -3,12 +3,7 @@ import { computed, defineAsyncComponent, onBeforeUnmount, onMounted, ref, watch 
 import { capture } from '../../api/capture';
 import { rememberCaptureCatalog } from '../../api/capture-diagnostics';
 import { linuxInteractionGuidance, linuxRequirementGuidance } from '../../api/linux-requirement-guidance';
-import {
-  BrowserCameraRecorder,
-  listBrowserCameras,
-  validateCameraAccess,
-  isCameraUnavailableError,
-} from '../../api/camera-recorder';
+import { BrowserCameraRecorder, listBrowserCameras } from '../../api/camera-recorder';
 import {
   BrowserMicrophoneRecorder,
   listBrowserMicrophones,
@@ -246,23 +241,13 @@ watch([selectedCameraId, selectedMicId, systemAudioMode], () => {
 });
 watch(
   [selectedCameraId],
-  async () => {
+  () => {
     if (props.embedded) return;
-    const camId = selectedCameraId.value;
+    // The overlay owns the preview stream. Probing from the HUD would open the
+    // same hardware concurrently, which some Windows camera drivers cannot do.
     capture.configureCameraOverlay({
-      cameraId: camId,
+      cameraId: selectedCameraId.value,
     });
-    if (camId && camId !== 'off') {
-      try {
-        await validateCameraAccess(camId);
-      } catch (err) {
-        if (isCameraUnavailableError(err)) {
-          selectedCameraId.value = 'off';
-          errorMessage.value =
-            'Camera is unavailable: hardware resources are locked by another application or Windows Media Foundation (0xC00D3704).';
-        }
-      }
-    }
   },
   { immediate: true },
 );
@@ -913,6 +898,7 @@ const discoverSources = async () => {
 
 let unsubscribeShortcut: (() => void) | null = null;
 let unsubscribeTeleprompterVisibility: (() => void) | null = null;
+let unsubscribeCameraOverlayState: (() => void) | null = null;
 
 const handleLauncherKeydown = (event: KeyboardEvent) => {
   if (event.key !== 'Escape' || !props.recorderLauncherContext || activeDropdowns.value > 0) return;
@@ -930,6 +916,11 @@ const toggleTeleprompter = () => {
 onMounted(async () => {
   window.addEventListener('keydown', handleLauncherKeydown);
   if (props.embedded) return;
+  unsubscribeCameraOverlayState = capture.onCameraOverlayState((state) => {
+    if (state.cameraId !== 'off' || selectedCameraId.value === 'off') return;
+    selectedCameraId.value = 'off';
+    errorMessage.value = 'The selected camera could not produce a usable video stream.';
+  });
   const preferences = await capture.getPreferences();
   savedDevices = preferences.devices as unknown as SavedDevices;
   const savedRegion = preferences.extras?.screenRegion;
@@ -991,6 +982,7 @@ onBeforeUnmount(() => {
   if (regionConfirmationTimeout) clearTimeout(regionConfirmationTimeout);
   unsubscribeShortcut?.();
   unsubscribeTeleprompterVisibility?.();
+  unsubscribeCameraOverlayState?.();
   stopTimer();
   void activeCamera?.stop();
   void activeMicrophone?.stop();

--- a/src/components/hud/camera/CameraOverlayApp.vue
+++ b/src/components/hud/camera/CameraOverlayApp.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
-import { onBeforeUnmount, onMounted, ref } from 'vue';
+import { nextTick, onBeforeUnmount, onMounted, ref } from 'vue';
 import { capture } from '../../../api/capture';
+import { BrowserCameraRecorder } from '../../../api/camera-recorder';
+import type { CameraRecordingCommand, CameraRecordingCommandResult } from '../../../api/types/camera-recording';
 import { useThemeStore } from '../../../stores/theme';
 import CameraPreviewOverlay from './CameraPreviewOverlay.vue';
 
@@ -8,9 +10,104 @@ const theme = useThemeStore();
 const cameraId = ref('off');
 const isRecording = ref(false);
 const isHovered = ref(false);
+const cameraPreview = ref<{ readyStream(sourceId: string): Promise<MediaStream> } | null>(null);
 let unsubscribe: (() => void) | null = null;
 let unsubscribeHover: (() => void) | null = null;
+let unsubscribeRecording: (() => void) | null = null;
 let statusTimer: number | null = null;
+let recorder: BrowserCameraRecorder | null = null;
+let activeRecordingId: string | null = null;
+let activeSessionId: string | null = null;
+let recordingQueue = Promise.resolve();
+
+const queueRecordingOperation = (operation: () => Promise<void>) => {
+  const pending = recordingQueue.then(operation);
+  recordingQueue = pending.catch(() => undefined);
+};
+
+const matchingRecorder = (recordingId: string) => {
+  if (!recorder || activeRecordingId !== recordingId) throw new Error('The camera recording is no longer active.');
+  return recorder;
+};
+
+const handleRecordingCommand = async ({ recordingId, control }: CameraRecordingCommand) => {
+  if (control.action === 'prepare') {
+    if (recorder) {
+      if (activeSessionId) throw new Error('Another camera recording is already active.');
+      await recorder.stop(0);
+      recorder = null;
+      activeRecordingId = null;
+    }
+    cameraId.value = control.sourceId;
+    await nextTick();
+    const stream = await cameraPreview.value?.readyStream(control.sourceId);
+    if (!stream) throw Object.assign(new Error('The camera preview is not ready.'), { name: 'NotReadableError' });
+    recorder = BrowserCameraRecorder.fromReadyStream(control.sourceId, stream);
+    activeRecordingId = recordingId;
+    const preparedRecorder = recorder;
+    recorder.onFatal((reason) => {
+      queueRecordingOperation(async () => {
+        if (recorder !== preparedRecorder) return;
+        try {
+          if (activeSessionId) await preparedRecorder.fail(activeSessionId, reason.message);
+          else await preparedRecorder.stop(0);
+        } finally {
+          recorder = null;
+          activeRecordingId = null;
+          activeSessionId = null;
+          capture.configureCameraOverlay({ cameraId: 'off' });
+          capture.reportCameraRecordingFailure({ recordingId, message: reason.message });
+        }
+      });
+    });
+    return { recordingId, sourceId: recorder.sourceId, format: recorder.format };
+  }
+  const current = matchingRecorder(control.recordingId);
+  if (control.action === 'start') {
+    activeSessionId = control.sessionId;
+    const timelineStartedAt = performance.now() - control.startNs / 1_000_000;
+    await current.start(control.sessionId, control.appearance, control.placement, timelineStartedAt, control.startNs);
+  } else if (control.action === 'pause') await current.pause(control.endNs);
+  else if (control.action === 'resume') await current.resume(control.sessionId, control.startNs);
+  else if (control.action === 'stop') {
+    try {
+      await current.stop(control.endNs);
+    } catch (error) {
+      if (activeSessionId) await current.fail(activeSessionId, error instanceof Error ? error.message : String(error));
+      throw error;
+    } finally {
+      recorder = null;
+      activeRecordingId = null;
+      activeSessionId = null;
+    }
+  } else {
+    try {
+      await current.fail(control.sessionId, control.reason);
+    } finally {
+      recorder = null;
+      activeRecordingId = null;
+      activeSessionId = null;
+    }
+  }
+};
+
+const executeRecordingCommand = async (command: CameraRecordingCommand) => {
+  let result: CameraRecordingCommandResult;
+  try {
+    const value = await handleRecordingCommand(command);
+    result = { commandId: command.commandId, ok: true, value };
+  } catch (error) {
+    result = {
+      commandId: command.commandId,
+      ok: false,
+      error: {
+        name: error instanceof Error ? error.name : 'Error',
+        message: error instanceof Error ? error.message : String(error),
+      },
+    };
+  }
+  capture.completeCameraOverlayRecordingCommand(result);
+};
 
 const refreshRecordingState = async () => {
   try {
@@ -28,6 +125,10 @@ onMounted(async () => {
   unsubscribeHover = capture.onCameraOverlayHover((hovered) => {
     isHovered.value = hovered;
   });
+  unsubscribeRecording = capture.onCameraOverlayRecordingCommand((command) => {
+    queueRecordingOperation(() => executeRecordingCommand(command));
+  });
+  capture.notifyCameraOverlayReady();
   const saved = await capture.getCameraOverlayState();
   if (saved) cameraId.value = saved.cameraId;
   await refreshRecordingState();
@@ -39,12 +140,18 @@ onMounted(async () => {
 onBeforeUnmount(() => {
   unsubscribe?.();
   unsubscribeHover?.();
+  unsubscribeRecording?.();
+  if (recorder) {
+    if (activeSessionId) void recorder.fail(activeSessionId, 'The camera overlay was closed.');
+    else void recorder.stop(0);
+  }
   if (statusTimer !== null) window.clearInterval(statusTimer);
 });
 </script>
 
 <template>
   <CameraPreviewOverlay
+    ref="cameraPreview"
     :camera-id="cameraId"
     :is-recording="isRecording"
     :is-hovered="isHovered"

--- a/src/components/hud/camera/CameraPreviewOverlay.vue
+++ b/src/components/hud/camera/CameraPreviewOverlay.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import { onBeforeUnmount, onMounted, ref, watch, type WatchStopHandle } from 'vue';
 import { Video } from '@lucide/vue';
-import { isCameraUnavailableError } from '../../../api/camera-recorder';
+import { cameraVideoConstraints } from '../../../api/camera-recorder';
+import { waitForFirstCameraFrame } from '../../../api/camera-frame-ready';
 import { useTranslate } from '~/i18n/useTranslate';
 import { capture } from '../../../api/capture';
 
@@ -23,17 +24,21 @@ const cameraStream = ref<MediaStream | null>(null);
 const streamError = ref<string | null>(null);
 const isLoading = ref(false);
 let cameraRequest = 0;
-let initialLoadTimer: number | null = null;
+let cameraLoadQueue = Promise.resolve();
+let stopCameraWatch: WatchStopHandle | null = null;
+let frameWaitAbort: AbortController | null = null;
+let readyCameraId: string | null = null;
 
 const stopCameraStream = () => {
   videoRef.value?.pause();
   if (videoRef.value) videoRef.value.srcObject = null;
   cameraStream.value?.getTracks().forEach((track) => track.stop());
   cameraStream.value = null;
+  readyCameraId = null;
 };
 
-const loadCamera = async (cameraId: string) => {
-  const request = ++cameraRequest;
+const loadCamera = async (cameraId: string, request: number) => {
+  if (request !== cameraRequest) return;
   stopCameraStream();
   if (!cameraId || cameraId === 'off') {
     isLoading.value = false;
@@ -42,46 +47,69 @@ const loadCamera = async (cameraId: string) => {
   try {
     streamError.value = null;
     isLoading.value = true;
-    const deviceId = cameraId.replace('camera:chromium:', '');
     const stream = await navigator.mediaDevices.getUserMedia({
       audio: false,
-      video: deviceId ? { deviceId: { ideal: deviceId } } : true,
+      video: cameraVideoConstraints(cameraId),
     });
     if (request !== cameraRequest) {
       stream.getTracks().forEach((track) => track.stop());
       return;
     }
     cameraStream.value = stream;
-    if (videoRef.value) {
-      videoRef.value.srcObject = stream;
-      await videoRef.value.play();
+    const video = videoRef.value;
+    if (!video) throw new Error('The camera preview is unavailable.');
+    video.srcObject = stream;
+    frameWaitAbort = new AbortController();
+    const firstFrame = waitForFirstCameraFrame(video, { signal: frameWaitAbort.signal });
+    try {
+      await Promise.all([video.play(), firstFrame]);
+    } catch (error) {
+      frameWaitAbort.abort();
+      await firstFrame.catch(() => undefined);
+      throw error;
     }
+    readyCameraId = cameraId;
   } catch (error) {
     if (request === cameraRequest) {
+      stopCameraStream();
       streamError.value = error instanceof Error ? error.message : t('unableToStartCamera');
-      if (isCameraUnavailableError(error)) capture.configureCameraOverlay({ cameraId: 'off' });
+      capture.configureCameraOverlay({ cameraId: 'off' });
     }
   } finally {
-    if (request === cameraRequest) isLoading.value = false;
+    if (request === cameraRequest) {
+      frameWaitAbort = null;
+      isLoading.value = false;
+    }
   }
 };
 
-watch(
-  () => props.cameraId,
-  (cameraId) => {
-    void loadCamera(cameraId);
-  },
-);
+const scheduleCameraLoad = (cameraId: string) => {
+  const request = ++cameraRequest;
+  frameWaitAbort?.abort();
+  // Some camera drivers are exclusive. Wait for an obsolete request to settle
+  // and release its stream before asking Chromium for the next device.
+  cameraLoadQueue = cameraLoadQueue.then(() => loadCamera(cameraId, request));
+};
+
+const readyStream = async (sourceId: string) => {
+  await cameraLoadQueue;
+  if (readyCameraId !== sourceId || !cameraStream.value)
+    throw Object.assign(new Error(streamError.value || 'The selected camera is not ready.'), {
+      name: 'NotReadableError',
+    });
+  return cameraStream.value;
+};
+
+defineExpose({ readyStream });
 
 onMounted(() => {
-  initialLoadTimer = window.setTimeout(() => {
-    void loadCamera(props.cameraId);
-  }, 0);
+  stopCameraWatch = watch(() => props.cameraId, scheduleCameraLoad, { immediate: true });
 });
 
 onBeforeUnmount(() => {
   cameraRequest += 1;
-  if (initialLoadTimer !== null) window.clearTimeout(initialLoadTimer);
+  frameWaitAbort?.abort();
+  stopCameraWatch?.();
   stopCameraStream();
 });
 </script>

--- a/src/components/hud/recorder/useDeviceToggles.ts
+++ b/src/components/hud/recorder/useDeviceToggles.ts
@@ -1,10 +1,11 @@
 import {
-  BrowserCameraRecorder,
+  CameraOverlayRecorder,
   isCameraUnavailableError,
   listBrowserCameras,
   type CameraAppearance,
   type CameraPlacement,
 } from '../../../api/camera-recorder';
+import { capture } from '../../../api/capture';
 import { BrowserMicrophoneRecorder, listBrowserMicrophones } from '../../../api/microphone-recorder';
 import { BrowserSystemAudioRecorder } from '../../../api/system-audio-recorder';
 import type { RecordingConfiguration } from './recording-types';
@@ -12,7 +13,7 @@ import type { RecordingConfiguration } from './recording-types';
 const inactiveCamera = 'off';
 const inactiveMicrophone = 'no-audio';
 
-type Recorder = BrowserCameraRecorder | BrowserMicrophoneRecorder | BrowserSystemAudioRecorder;
+type Recorder = CameraOverlayRecorder | BrowserMicrophoneRecorder | BrowserSystemAudioRecorder;
 
 export interface DeviceToggleContext {
   getConfiguration(): RecordingConfiguration | null;
@@ -20,8 +21,8 @@ export interface DeviceToggleContext {
   setConfigurationMicrophoneId(id: string): void;
   getSessionId(): string | null;
   getSessionTimelineStartedAt(): number;
-  getCamera(): BrowserCameraRecorder | null;
-  setCamera(recorder: BrowserCameraRecorder | null): void;
+  getCamera(): CameraOverlayRecorder | null;
+  setCamera(recorder: CameraOverlayRecorder | null): void;
   getMicrophone(): BrowserMicrophoneRecorder | null;
   setMicrophone(recorder: BrowserMicrophoneRecorder | null): void;
   getSystemAudio(): BrowserSystemAudioRecorder | null;
@@ -76,13 +77,20 @@ export function useDeviceToggles(ctx: DeviceToggleContext) {
       await stopRecorder(ctx.getCamera());
       ctx.setCamera(null);
       ctx.setCameraEnabled(false);
+      capture.configureCameraOverlay({ cameraId: inactiveCamera });
       return;
     }
     try {
       const sourceId = await resolveCameraSourceId();
       if (!sourceId) throw new Error('No camera is available.');
       const { appearance, placement } = await ctx.cameraMetadata();
-      const nextCamera = await BrowserCameraRecorder.request(sourceId);
+      const nextCamera = await CameraOverlayRecorder.request(sourceId);
+      nextCamera.onFatal((reason) => {
+        if (ctx.getCamera() !== nextCamera) return;
+        ctx.setCamera(null);
+        ctx.setCameraEnabled(false);
+        ctx.setError(`Camera recording stopped: ${reason.message}`);
+      });
       try {
         await nextCamera.start(sessionId, appearance, placement, ctx.getSessionTimelineStartedAt());
       } catch (reason) {

--- a/src/components/hud/recorder/useRecordingController.test.ts
+++ b/src/components/hud/recorder/useRecordingController.test.ts
@@ -5,7 +5,7 @@ const mocks = vi.hoisted(() => {
   const makeRecorder = () => ({
     onFatal: vi.fn(),
     start: vi.fn(async () => undefined),
-    stop: vi.fn(async () => undefined),
+    stop: vi.fn<() => Promise<void>>(async () => undefined),
     pause: vi.fn(async () => undefined),
     resume: vi.fn(async () => undefined),
   });
@@ -31,6 +31,7 @@ const mocks = vi.hoisted(() => {
       status: vi.fn(async () => ({ state: 'recording', screenAvailable: true })),
       pause: vi.fn(async () => ({ sessionId: 'session-1' })),
       resume: vi.fn(async () => ({ sessionId: 'session-1' })),
+      configureCameraOverlay: vi.fn(),
       setTeleprompterSession: vi.fn(),
       showScreenRegionOverlay: vi.fn(),
       hideScreenRegionOverlay: vi.fn(),
@@ -40,7 +41,7 @@ const mocks = vi.hoisted(() => {
 
 vi.mock('../../../api/capture', () => ({ capture: mocks.capture }));
 vi.mock('../../../api/camera-recorder', () => ({
-  BrowserCameraRecorder: { request: vi.fn(async () => mocks.cameraRecorder) },
+  CameraOverlayRecorder: { request: vi.fn(async () => mocks.cameraRecorder) },
   isCameraUnavailableError: (error: unknown) => (error as Error)?.name === 'NotFoundError',
   listBrowserCameras: vi.fn(async () => []),
 }));
@@ -266,6 +267,76 @@ describe('useRecordingController countdown', () => {
 });
 
 describe('useRecordingController startup', () => {
+  it('drives the overlay camera proxy lifecycle without acquiring media in the HUD', async () => {
+    const getUserMedia = vi.fn();
+    const previousMediaDevices = navigator.mediaDevices;
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: { getUserMedia },
+    });
+
+    try {
+      const controller = useRecordingController(vi.fn());
+      await controller.start({ ...fullConfig, microphoneId: 'no-audio', systemAudio: false });
+      await vi.waitFor(() => expect(controller.phase.value).toBe('recording'));
+
+      expect(mocks.cameraRecorder.onFatal).toHaveBeenCalledOnce();
+      expect(getUserMedia).not.toHaveBeenCalled();
+
+      await controller.togglePause();
+      expect(controller.phase.value).toBe('paused');
+      expect(mocks.cameraRecorder.pause).toHaveBeenCalledWith(expect.any(Number));
+
+      await controller.togglePause();
+      expect(controller.phase.value).toBe('recording');
+      expect(mocks.cameraRecorder.resume).toHaveBeenCalledWith('session-1');
+
+      await controller.stop();
+      expect(mocks.cameraRecorder.stop).toHaveBeenCalledWith(expect.any(Number));
+    } finally {
+      Object.defineProperty(navigator, 'mediaDevices', { configurable: true, value: previousMediaDevices });
+    }
+  });
+
+  it('keeps the camera enabled until the overlay recorder finishes stopping', async () => {
+    let finishStop!: () => void;
+    const stopFinished = new Promise<void>((resolve) => {
+      finishStop = resolve;
+    });
+    const controller = useRecordingController(vi.fn());
+
+    await controller.start({ ...fullConfig, microphoneId: 'no-audio', systemAudio: false });
+    await vi.waitFor(() => expect(controller.phase.value).toBe('recording'));
+
+    mocks.cameraRecorder.stop.mockReturnValueOnce(stopFinished);
+    const disabling = controller.toggleCamera();
+    await vi.waitFor(() => expect(mocks.cameraRecorder.stop).toHaveBeenCalledOnce());
+    expect(controller.cameraEnabled.value).toBe(true);
+    expect(mocks.capture.configureCameraOverlay).not.toHaveBeenCalled();
+
+    finishStop();
+    await disabling;
+    expect(controller.cameraEnabled.value).toBe(false);
+    expect(mocks.capture.configureCameraOverlay).toHaveBeenCalledWith({ cameraId: 'off' });
+  });
+
+  it('handles an overlay camera fatal event without restoring the camera state', async () => {
+    let fatal!: (reason: Error) => void;
+    mocks.cameraRecorder.onFatal.mockImplementationOnce((handler: (reason: Error) => void) => {
+      fatal = handler;
+    });
+    const controller = useRecordingController(vi.fn());
+
+    await controller.start({ ...fullConfig, microphoneId: 'no-audio', systemAudio: false });
+    await vi.waitFor(() => expect(controller.phase.value).toBe('recording'));
+
+    fatal(new Error('overlay camera failed'));
+
+    expect(controller.cameraEnabled.value).toBe(false);
+    expect(controller.error.value).toBe('Camera recording stopped: overlay camera failed');
+    expect(controller.phase.value).toBe('recording');
+  });
+
   it('uses native Linux system audio during prepare and start without Chromium capture', async () => {
     mocks.capture.platform = 'linux';
     const controller = useRecordingController(vi.fn());

--- a/src/components/hud/recorder/useRecordingController.ts
+++ b/src/components/hud/recorder/useRecordingController.ts
@@ -1,6 +1,6 @@
 import { computed, ref } from 'vue';
 import { capture } from '../../../api/capture';
-import { BrowserCameraRecorder, isCameraUnavailableError } from '../../../api/camera-recorder';
+import { CameraOverlayRecorder, isCameraUnavailableError } from '../../../api/camera-recorder';
 import { BrowserMicrophoneRecorder } from '../../../api/microphone-recorder';
 import { BrowserSystemAudioRecorder } from '../../../api/system-audio-recorder';
 import { useDeviceToggles } from './useDeviceToggles';
@@ -8,20 +8,13 @@ import { useRecordingHealth } from './useRecordingHealth';
 import { useNativeSystemAudioLevel } from './useNativeSystemAudioLevel';
 import { recordingCameraMetadata } from './recording-camera-metadata';
 import { formatRecordingTime, isRecordingActivePhase } from './recording-types';
-import type {
-  RecordingConfiguration,
-  RecordingPhase,
-  RecordingSessionResult,
-  RecordingStartFailure,
-  RecordingStartStage,
-  StartupSidecarState,
-} from './recording-types';
+import type { RecordingConfiguration, RecordingPhase, RecordingSessionResult } from './recording-types';
+import type { RecordingStartFailure, RecordingStartStage, StartupSidecarState } from './recording-types';
 
-type Recorder = BrowserCameraRecorder | BrowserMicrophoneRecorder | BrowserSystemAudioRecorder;
+type Recorder = CameraOverlayRecorder | BrowserMicrophoneRecorder | BrowserSystemAudioRecorder;
 type SidecarKind = 'camera' | 'microphone' | 'systemAudio';
 type SidecarStates = Record<SidecarKind, StartupSidecarState>;
-const inactiveCamera = 'off';
-const inactiveMicrophone = 'no-audio';
+const [inactiveCamera, inactiveMicrophone] = ['off', 'no-audio'];
 export function useRecordingController(
   onComplete: (session: RecordingSessionResult) => void,
   onStartupFailure?: (failure: RecordingStartFailure) => void,
@@ -45,7 +38,7 @@ export function useRecordingController(
   let timer: number | null = null;
   let sessionId: string | null = null;
   let projectId: string | null = null;
-  let camera: BrowserCameraRecorder | null = null;
+  let camera: CameraOverlayRecorder | null = null;
   let microphone: BrowserMicrophoneRecorder | null = null;
   let systemAudio: BrowserSystemAudioRecorder | null = null;
   let sessionTimelineStartedAt = 0;
@@ -134,7 +127,15 @@ export function useRecordingController(
     if (!configuration) return;
     if (configuration.cameraId !== inactiveCamera) {
       try {
-        camera = await BrowserCameraRecorder.request(configuration.cameraId);
+        camera = await CameraOverlayRecorder.request(configuration.cameraId);
+        const preparedCamera = camera;
+        preparedCamera.onFatal((reason) => {
+          if (camera !== preparedCamera) return;
+          camera = null;
+          cameraEnabled.value = false;
+          sidecarStates.camera = 'failed';
+          error.value = `Camera recording stopped: ${reason.message}`;
+        });
         sidecarStates.camera = 'prepared';
       } catch (reason) {
         sidecarStates.camera = 'failed';
@@ -287,8 +288,7 @@ export function useRecordingController(
       elapsedTenths.value = 0;
       startTimer();
       phase.value = 'recording';
-      // The native engine handles commands serially. Polling status while
-      // prepare/start is still running can time out and terminate the engine.
+      // Avoid status polling while the single-threaded native prepare/start is running.
       recordingHealth.start();
     } catch (reason) {
       if (generation !== recordingGeneration) {

--- a/src/components/hud/tests/CameraOverlayApp.test.ts
+++ b/src/components/hud/tests/CameraOverlayApp.test.ts
@@ -1,29 +1,126 @@
 import { mount } from '@vue/test-utils';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CameraRecordingCommand } from '../../../api/types/camera-recording';
+import { defineComponent, h } from 'vue';
 
 const capture = vi.hoisted(() => ({
   status: vi.fn(),
   getCameraOverlayState: vi.fn(),
   onCameraOverlayState: vi.fn(),
   onCameraOverlayHover: vi.fn(),
+  onCameraOverlayRecordingCommand: vi.fn(),
+  completeCameraOverlayRecordingCommand: vi.fn(),
+  notifyCameraOverlayReady: vi.fn(),
+  configureCameraOverlay: vi.fn(),
+  reportCameraRecordingFailure: vi.fn(),
+  beginCameraSegment: vi.fn(),
+  writeCameraSegment: vi.fn(),
+  finalizeCameraSegment: vi.fn(),
+  failCamera: vi.fn(),
 }));
 vi.mock('../../../api/capture', () => ({ capture }));
 vi.mock('../../../stores/theme', () => ({ useThemeStore: () => ({ theme: 'dark' }) }));
 
 import CameraOverlayApp from '../camera/CameraOverlayApp.vue';
 
-const CameraPreviewOverlay = {
+const readyStream = vi.fn();
+
+const CameraPreviewOverlay = defineComponent({
   props: ['cameraId', 'isRecording', 'isHovered'],
-  template: '<div class="camera-preview-stub">{{ cameraId }}</div>',
+  setup(props, { expose }) {
+    expose({ readyStream });
+    return () => h('div', { class: 'camera-preview-stub' }, props.cameraId);
+  },
+});
+
+type Listener = (...args: unknown[]) => void;
+
+class FakeMediaRecorder extends EventTarget {
+  static instances: FakeMediaRecorder[] = [];
+  static isTypeSupported = vi.fn(() => true);
+  readonly stream: MediaStream;
+  readonly options: MediaRecorderOptions;
+  readonly start = vi.fn();
+  readonly stop = vi.fn(() => this.dispatchEvent(new Event('stop')));
+
+  constructor(stream: MediaStream, options: MediaRecorderOptions) {
+    super();
+    this.stream = stream;
+    this.options = options;
+    FakeMediaRecorder.instances.push(this);
+  }
+}
+
+const createTrack = () => {
+  const listeners = new Map<string, Listener[]>();
+  return {
+    addEventListener: vi.fn((type: string, listener: Listener) => {
+      listeners.set(type, [...(listeners.get(type) ?? []), listener]);
+    }),
+    removeEventListener: vi.fn((type: string, listener: Listener) => {
+      listeners.set(
+        type,
+        (listeners.get(type) ?? []).filter((entry) => entry !== listener),
+      );
+    }),
+    getSettings: vi.fn(() => ({ width: 1280, height: 720, frameRate: 30 })),
+    stop: vi.fn(),
+    emit: (type: string) => listeners.get(type)?.forEach((listener) => listener()),
+  };
 };
+
+let recordingCommand!: (command: CameraRecordingCommand) => void;
+let sharedTrack: ReturnType<typeof createTrack>;
+let sharedStream: MediaStream;
+let previousMediaDevices: MediaDevices | undefined;
+let previousCapture: typeof window.capture | undefined;
 
 describe('CameraOverlayApp', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    FakeMediaRecorder.instances = [];
+    sharedTrack = createTrack();
+    sharedStream = {
+      getVideoTracks: () => [sharedTrack],
+      getTracks: () => [sharedTrack],
+    } as unknown as MediaStream;
+    readyStream.mockResolvedValue(sharedStream);
+    previousMediaDevices = navigator.mediaDevices;
+    previousCapture = window.capture;
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: { getUserMedia: vi.fn() },
+    });
+    Object.defineProperty(window, 'capture', { configurable: true, value: capture });
+    vi.stubGlobal('MediaRecorder', FakeMediaRecorder);
+    vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue(undefined);
+    vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => undefined);
     capture.status.mockResolvedValue({ state: 'recording' });
     capture.getCameraOverlayState.mockResolvedValue({ cameraId: 'camera:front' });
     capture.onCameraOverlayState.mockReturnValue(() => undefined);
     capture.onCameraOverlayHover.mockReturnValue(() => undefined);
+    capture.onCameraOverlayRecordingCommand.mockImplementation(
+      (listener: (command: CameraRecordingCommand) => void) => {
+        recordingCommand = listener;
+        return () => undefined;
+      },
+    );
+    capture.completeCameraOverlayRecordingCommand.mockReset();
+    capture.notifyCameraOverlayReady.mockReset();
+    capture.configureCameraOverlay.mockReset();
+    capture.reportCameraRecordingFailure.mockReset();
+    capture.beginCameraSegment.mockResolvedValue({ jobId: 'camera-job-1' });
+    capture.writeCameraSegment.mockResolvedValue(undefined);
+    capture.finalizeCameraSegment.mockResolvedValue(undefined);
+    capture.failCamera.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'mediaDevices', { configurable: true, value: previousMediaDevices });
+    if (previousCapture) Object.defineProperty(window, 'capture', { configurable: true, value: previousCapture });
+    else delete (window as { capture?: unknown }).capture;
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
   });
 
   it('loads state and tracks recording state', async () => {
@@ -48,6 +145,7 @@ describe('CameraOverlayApp', () => {
     wrapper.unmount();
     expect(stopState).toHaveBeenCalledOnce();
     expect(stopHover).toHaveBeenCalledOnce();
+    expect(capture.notifyCameraOverlayReady).toHaveBeenCalledOnce();
   });
 
   it('clears recording state when the native status call fails', async () => {
@@ -55,6 +153,124 @@ describe('CameraOverlayApp', () => {
     capture.getCameraOverlayState.mockResolvedValue(null);
     const wrapper = mount(CameraOverlayApp, { global: { stubs: { CameraPreviewOverlay } } });
     await vi.waitFor(() => expect(capture.status).toHaveBeenCalled());
+    wrapper.unmount();
+  });
+
+  it('runs every camera command on the preview stream without opening a second media stream', async () => {
+    capture.beginCameraSegment
+      .mockResolvedValueOnce({ jobId: 'camera-job-1' })
+      .mockResolvedValueOnce({ jobId: 'camera-job-2' });
+    const wrapper = mount(CameraOverlayApp, { global: { stubs: { CameraPreviewOverlay } } });
+    await vi.waitFor(() => expect(capture.notifyCameraOverlayReady).toHaveBeenCalledOnce());
+
+    const send = async (control: CameraRecordingCommand['control'], commandId: string) => {
+      recordingCommand({ commandId, recordingId: 'recording-1', control });
+      await vi.waitFor(() =>
+        expect(capture.completeCameraOverlayRecordingCommand).toHaveBeenCalledWith(
+          expect.objectContaining({ commandId, ok: true }),
+        ),
+      );
+    };
+
+    await send({ action: 'prepare', sourceId: 'camera:chromium:front' }, 'command-prepare');
+    await send(
+      { action: 'start', recordingId: 'recording-1', sessionId: 'session-1', startNs: 5_000_000_000 },
+      'command-start',
+    );
+    await send({ action: 'pause', recordingId: 'recording-1', endNs: 100 }, 'command-pause');
+    await send(
+      { action: 'resume', recordingId: 'recording-1', sessionId: 'session-1', startNs: 200 },
+      'command-resume',
+    );
+    await send({ action: 'stop', recordingId: 'recording-1', endNs: 300 }, 'command-stop');
+
+    expect(readyStream).toHaveBeenCalledOnce();
+    expect(FakeMediaRecorder.instances).toHaveLength(2);
+    expect(FakeMediaRecorder.instances[0].stream).toBe(sharedStream);
+    expect(FakeMediaRecorder.instances[1].stream).toBe(sharedStream);
+    expect(navigator.mediaDevices.getUserMedia).not.toHaveBeenCalled();
+    expect(capture.beginCameraSegment).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ sessionId: 'session-1', startNs: 5_000_000_000 }),
+    );
+    expect(capture.finalizeCameraSegment).toHaveBeenCalledTimes(2);
+    expect(capture.finalizeCameraSegment).toHaveBeenLastCalledWith(
+      expect.objectContaining({ jobId: 'camera-job-2', endNs: 300 }),
+    );
+    expect(sharedTrack.stop).not.toHaveBeenCalled();
+
+    wrapper.unmount();
+  });
+
+  it('reports a fatal camera event and fails the active segment without stopping the shared preview track', async () => {
+    const wrapper = mount(CameraOverlayApp, { global: { stubs: { CameraPreviewOverlay } } });
+    await vi.waitFor(() => expect(capture.notifyCameraOverlayReady).toHaveBeenCalledOnce());
+
+    const send = async (control: CameraRecordingCommand['control'], commandId: string) => {
+      recordingCommand({ commandId, recordingId: 'recording-1', control });
+      await vi.waitFor(() =>
+        expect(capture.completeCameraOverlayRecordingCommand).toHaveBeenCalledWith(
+          expect.objectContaining({ commandId, ok: true }),
+        ),
+      );
+    };
+    await send({ action: 'prepare', sourceId: 'camera:chromium:front' }, 'command-prepare');
+    await send({ action: 'start', recordingId: 'recording-1', sessionId: 'session-1', startNs: 0 }, 'command-start');
+
+    sharedTrack.emit('ended');
+
+    await vi.waitFor(() =>
+      expect(capture.reportCameraRecordingFailure).toHaveBeenCalledWith({
+        recordingId: 'recording-1',
+        message: 'The selected camera was disconnected or stopped.',
+      }),
+    );
+    expect(capture.failCamera).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      reason: 'The selected camera was disconnected or stopped.',
+    });
+    expect(capture.configureCameraOverlay).toHaveBeenCalledWith({ cameraId: 'off' });
+    expect(sharedTrack.stop).not.toHaveBeenCalled();
+
+    wrapper.unmount();
+  });
+
+  it('continues processing commands when fatal camera cleanup rejects', async () => {
+    capture.failCamera.mockRejectedValueOnce(new Error('native cleanup failed'));
+    const wrapper = mount(CameraOverlayApp, { global: { stubs: { CameraPreviewOverlay } } });
+    await vi.waitFor(() => expect(capture.notifyCameraOverlayReady).toHaveBeenCalledOnce());
+
+    const send = async (control: CameraRecordingCommand['control'], commandId: string) => {
+      recordingCommand({ commandId, recordingId: 'recording-1', control });
+      await vi.waitFor(() =>
+        expect(capture.completeCameraOverlayRecordingCommand).toHaveBeenCalledWith(
+          expect.objectContaining({ commandId, ok: true }),
+        ),
+      );
+    };
+    await send({ action: 'prepare', sourceId: 'camera:chromium:front' }, 'command-prepare');
+    await send({ action: 'start', recordingId: 'recording-1', sessionId: 'session-1', startNs: 0 }, 'command-start');
+
+    sharedTrack.emit('ended');
+    await vi.waitFor(() =>
+      expect(capture.reportCameraRecordingFailure).toHaveBeenCalledWith(
+        expect.objectContaining({ recordingId: 'recording-1' }),
+      ),
+    );
+
+    recordingCommand({
+      commandId: 'command-reprepare',
+      recordingId: 'recording-2',
+      control: { action: 'prepare', sourceId: 'camera:chromium:second' },
+    });
+    await vi.waitFor(() =>
+      expect(capture.completeCameraOverlayRecordingCommand).toHaveBeenCalledWith({
+        commandId: 'command-reprepare',
+        ok: true,
+        value: expect.objectContaining({ sourceId: 'camera:chromium:second' }),
+      }),
+    );
+
     wrapper.unmount();
   });
 });

--- a/src/components/hud/tests/CameraPreviewOverlay.test.ts
+++ b/src/components/hud/tests/CameraPreviewOverlay.test.ts
@@ -1,6 +1,8 @@
 import { mount } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+type FrameCallback = (now: number, metadata: { width: number; height: number }) => void;
+
 const { capture } = vi.hoisted(() => ({
   capture: { configureCameraOverlay: vi.fn() },
 }));
@@ -12,13 +14,69 @@ class FakeTrack {
   stop = vi.fn();
 }
 
+const requestVideoFrameCallbackDescriptor = Object.getOwnPropertyDescriptor(
+  HTMLVideoElement.prototype,
+  'requestVideoFrameCallback',
+);
+const cancelVideoFrameCallbackDescriptor = Object.getOwnPropertyDescriptor(
+  HTMLVideoElement.prototype,
+  'cancelVideoFrameCallback',
+);
+const mediaDevicesDescriptor = Object.getOwnPropertyDescriptor(navigator, 'mediaDevices');
+
 let getUserMedia: ReturnType<typeof vi.fn>;
 let track: FakeTrack;
 let stream: MediaStream;
+let requestVideoFrameCallback: ReturnType<typeof vi.fn>;
+let cancelVideoFrameCallback: ReturnType<typeof vi.fn>;
+let frameCallbacks: Map<number, FrameCallback>;
+let nextFrameCallbackId: number;
+
+const flushPromises = async () => {
+  for (let index = 0; index < 8; index += 1) await Promise.resolve();
+};
+
+const expectEventually = async (assertion: () => void) => {
+  for (let index = 0; index < 20; index += 1) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      if (index === 19) throw error;
+      await Promise.resolve();
+    }
+  }
+};
+
+const emitFirstFrame = (width = 1280, height = 720) => {
+  [...frameCallbacks.values()].forEach((callback) => callback(0, { width, height }));
+};
+
+const restoreDescriptor = (target: object, key: string, descriptor: PropertyDescriptor | undefined) => {
+  if (descriptor) Object.defineProperty(target, key, descriptor);
+  else delete (target as Record<string, unknown>)[key];
+};
 
 beforeEach(() => {
   vi.useFakeTimers();
   vi.clearAllMocks();
+  frameCallbacks = new Map();
+  nextFrameCallbackId = 0;
+  requestVideoFrameCallback = vi.fn((callback: FrameCallback) => {
+    const id = ++nextFrameCallbackId;
+    frameCallbacks.set(id, callback);
+    return id;
+  });
+  cancelVideoFrameCallback = vi.fn((id: number) => frameCallbacks.delete(id));
+  Object.defineProperty(HTMLVideoElement.prototype, 'requestVideoFrameCallback', {
+    configurable: true,
+    value: requestVideoFrameCallback,
+  });
+  Object.defineProperty(HTMLVideoElement.prototype, 'cancelVideoFrameCallback', {
+    configurable: true,
+    value: cancelVideoFrameCallback,
+  });
+
   track = new FakeTrack();
   stream = { getTracks: () => [track] } as unknown as MediaStream;
   getUserMedia = vi.fn().mockResolvedValue(stream);
@@ -37,22 +95,29 @@ beforeEach(() => {
 afterEach(() => {
   vi.useRealTimers();
   vi.restoreAllMocks();
+  restoreDescriptor(HTMLVideoElement.prototype, 'requestVideoFrameCallback', requestVideoFrameCallbackDescriptor);
+  restoreDescriptor(HTMLVideoElement.prototype, 'cancelVideoFrameCallback', cancelVideoFrameCallbackDescriptor);
+  restoreDescriptor(navigator, 'mediaDevices', mediaDevicesDescriptor);
   delete window.capture;
 });
 
 describe('CameraPreviewOverlay', () => {
-  it('loads a camera and cleans up the stream', async () => {
+  it('loads a camera only after its first frame and cleans up the stream', async () => {
     const wrapper = mount(CameraPreviewOverlay, {
       props: { cameraId: 'camera:chromium:front', isHovered: true },
     });
-    await vi.runAllTimersAsync();
-    await vi.waitFor(() =>
+    await expectEventually(() =>
       expect(getUserMedia).toHaveBeenCalledWith({
         audio: false,
-        video: { deviceId: { ideal: 'front' } },
+        video: { deviceId: { exact: 'front' } },
       }),
     );
+    expect(requestVideoFrameCallback).toHaveBeenCalledOnce();
     expect(wrapper.get('.camera-overlay-container').classes()).toContain('is-hovered');
+    expect(wrapper.find('.camera-overlay-skeleton').exists()).toBe(true);
+
+    emitFirstFrame();
+    await flushPromises();
     expect(wrapper.find('.camera-overlay-skeleton').exists()).toBe(false);
 
     wrapper.unmount();
@@ -60,26 +125,39 @@ describe('CameraPreviewOverlay', () => {
     expect(HTMLMediaElement.prototype.pause).toHaveBeenCalled();
   });
 
+  it('requests a camera only once when the selection arrives during initial mounting', async () => {
+    const wrapper = mount(CameraPreviewOverlay, { props: { cameraId: 'off' } });
+
+    await wrapper.setProps({ cameraId: 'camera:chromium:front' });
+    await expectEventually(() => expect(getUserMedia).toHaveBeenCalled());
+
+    expect(getUserMedia).toHaveBeenCalledTimes(1);
+    expect(getUserMedia).toHaveBeenCalledWith({
+      audio: false,
+      video: { deviceId: { exact: 'front' } },
+    });
+    emitFirstFrame();
+    await flushPromises();
+
+    wrapper.unmount();
+  });
+
   it('does not request the disabled camera and shows hardware errors', async () => {
     const wrapper = mount(CameraPreviewOverlay, { props: { cameraId: 'off' } });
-    await vi.runAllTimersAsync();
+    await flushPromises();
     expect(getUserMedia).not.toHaveBeenCalled();
 
     getUserMedia.mockRejectedValueOnce(new DOMException('Could not start video source', 'NotReadableError'));
     await wrapper.setProps({ cameraId: 'camera:chromium:broken' });
-    await vi.waitFor(() => expect(wrapper.find('.camera-overlay-error').exists()).toBe(true));
-    expect(capture.configureCameraOverlay).toHaveBeenCalledWith({
-      cameraId: 'off',
-    });
+    await expectEventually(() => expect(wrapper.find('.camera-overlay-error').exists()).toBe(true));
+    expect(capture.configureCameraOverlay).toHaveBeenCalledWith({ cameraId: 'off' });
     wrapper.unmount();
   });
 
   it('stops a stale stream when the selected camera changes while loading', async () => {
     let resolveRequest!: (value: MediaStream) => void;
     const staleTrack = new FakeTrack();
-    const staleStream = {
-      getTracks: () => [staleTrack],
-    } as unknown as MediaStream;
+    const staleStream = { getTracks: () => [staleTrack] } as unknown as MediaStream;
     getUserMedia.mockImplementationOnce(
       () =>
         new Promise<MediaStream>((resolve) => {
@@ -89,11 +167,94 @@ describe('CameraPreviewOverlay', () => {
     const wrapper = mount(CameraPreviewOverlay, {
       props: { cameraId: 'camera:chromium:first' },
     });
-    await vi.runAllTimersAsync();
+    await expectEventually(() => expect(getUserMedia).toHaveBeenCalledTimes(1));
+
     await wrapper.setProps({ cameraId: 'off' });
     resolveRequest(staleStream);
-    await Promise.resolve();
-    expect(staleTrack.stop).toHaveBeenCalledOnce();
+    await expectEventually(() => expect(staleTrack.stop).toHaveBeenCalledOnce());
     wrapper.unmount();
+  });
+
+  it('serializes camera requests when the selection changes during an in-flight request', async () => {
+    let resolveFirst!: (value: MediaStream) => void;
+    const firstTrack = new FakeTrack();
+    const firstStream = { getTracks: () => [firstTrack] } as unknown as MediaStream;
+    const secondTrack = new FakeTrack();
+    const secondStream = { getTracks: () => [secondTrack] } as unknown as MediaStream;
+    getUserMedia.mockImplementationOnce(
+      () =>
+        new Promise<MediaStream>((resolve) => {
+          resolveFirst = resolve;
+        }),
+    );
+    getUserMedia.mockResolvedValueOnce(secondStream);
+
+    const wrapper = mount(CameraPreviewOverlay, {
+      props: { cameraId: 'camera:chromium:first' },
+    });
+    await expectEventually(() => expect(getUserMedia).toHaveBeenCalledTimes(1));
+
+    await wrapper.setProps({ cameraId: 'camera:chromium:second' });
+    expect(getUserMedia).toHaveBeenCalledTimes(1);
+
+    resolveFirst(firstStream);
+    await expectEventually(() => expect(getUserMedia).toHaveBeenCalledTimes(2));
+    expect(getUserMedia).toHaveBeenNthCalledWith(2, {
+      audio: false,
+      video: { deviceId: { exact: 'second' } },
+    });
+    expect(firstTrack.stop).toHaveBeenCalledOnce();
+    emitFirstFrame();
+    await flushPromises();
+
+    wrapper.unmount();
+  });
+
+  it('aborts a pending first frame before opening a changed camera and stops the old track', async () => {
+    const firstTrack = new FakeTrack();
+    const firstStream = { getTracks: () => [firstTrack] } as unknown as MediaStream;
+    const secondTrack = new FakeTrack();
+    const secondStream = { getTracks: () => [secondTrack] } as unknown as MediaStream;
+    getUserMedia.mockResolvedValueOnce(firstStream).mockResolvedValueOnce(secondStream);
+
+    const wrapper = mount(CameraPreviewOverlay, {
+      props: { cameraId: 'camera:chromium:first' },
+    });
+    await expectEventually(() => expect(requestVideoFrameCallback).toHaveBeenCalledTimes(1));
+
+    await wrapper.setProps({ cameraId: 'camera:chromium:second' });
+    await expectEventually(() => expect(getUserMedia).toHaveBeenCalledTimes(2));
+    expect(cancelVideoFrameCallback).toHaveBeenCalledOnce();
+    expect(firstTrack.stop).toHaveBeenCalledOnce();
+
+    emitFirstFrame();
+    await flushPromises();
+    expect(requestVideoFrameCallback).toHaveBeenCalledTimes(2);
+    wrapper.unmount();
+    expect(secondTrack.stop).toHaveBeenCalledOnce();
+  });
+
+  it('exposes readyStream only after the selected stream has produced its first frame', async () => {
+    const wrapper = mount(CameraPreviewOverlay, {
+      props: { cameraId: 'camera:chromium:front' },
+    });
+    await expectEventually(() => expect(requestVideoFrameCallback).toHaveBeenCalledOnce());
+
+    const readyStream = (wrapper.vm as unknown as { readyStream(sourceId: string): Promise<MediaStream> }).readyStream;
+    const ready = readyStream('camera:chromium:front');
+    let settled = false;
+    void ready.then(() => {
+      settled = true;
+    });
+    await flushPromises();
+    expect(settled).toBe(false);
+
+    emitFirstFrame();
+    const resolvedStream = await ready;
+    expect(resolvedStream.getTracks()).toEqual([track]);
+    await expect(readyStream('camera:chromium:other')).rejects.toMatchObject({ name: 'NotReadableError' });
+
+    wrapper.unmount();
+    expect(track.stop).toHaveBeenCalledOnce();
   });
 });

--- a/src/components/hud/tests/HUD.test.ts
+++ b/src/components/hud/tests/HUD.test.ts
@@ -5,6 +5,8 @@ import { browserCameraMock } from './camera-recorder.mock';
 import { browserMicrophoneMock } from './microphone-recorder.mock';
 import { browserSystemAudioMock } from './system-audio-recorder.mock';
 
+const validateCameraAccessMock = vi.hoisted(() => vi.fn());
+
 vi.mock('../../../api/capture', async () => ({ capture: (await import('./capture.mock')).captureMock }));
 vi.mock('../../../api/camera-recorder', async () => {
   const camera = await import('./camera-recorder.mock');
@@ -12,6 +14,7 @@ vi.mock('../../../api/camera-recorder', async () => {
     BrowserCameraRecorder: camera.BrowserCameraRecorder,
     listBrowserCameras: camera.listBrowserCameras,
     isCameraUnavailableError: camera.isCameraUnavailableError,
+    validateCameraAccess: validateCameraAccessMock,
   };
 });
 vi.mock('../../../api/microphone-recorder', async () => {
@@ -101,6 +104,7 @@ describe('HUD', () => {
       status: 'ready',
     }));
     Object.values(browserCameraMock).forEach((mock) => mock.mockReset());
+    validateCameraAccessMock.mockReset().mockResolvedValue(undefined);
     Object.values(browserMicrophoneMock).forEach((mock) => mock.mockReset());
     Object.values(browserSystemAudioMock).forEach((mock) => mock.mockReset());
     capture.getPreferences.mockResolvedValue({
@@ -188,6 +192,28 @@ describe('HUD', () => {
       ],
     ]);
   });
+  it('configures the camera overlay when a camera is selected without probing access', async () => {
+    browserCameraMock.listBrowserCameras.mockResolvedValue([
+      { id: 'camera:chromium:device-1', kind: 'camera', label: 'Cam 1', isDefault: true },
+      { id: 'camera:chromium:device-2', kind: 'camera', label: 'Cam 2', isDefault: false },
+    ]);
+    const wrapper = mount(HUD, { global: { stubs } });
+    await ready();
+
+    capture.configureCameraOverlay.mockClear();
+    validateCameraAccessMock.mockClear();
+
+    const camera = wrapper
+      .findAll('[data-option-value]')
+      .find((option) => option.attributes('data-option-value') === 'camera:chromium:device-2');
+    expect(camera).toBeDefined();
+    await camera!.trigger('click');
+    await ready();
+
+    expect(capture.configureCameraOverlay).toHaveBeenCalledWith({ cameraId: 'camera:chromium:device-2' });
+    expect(validateCameraAccessMock).not.toHaveBeenCalled();
+  });
+
   it('shows actionable errors when discovery or recording fails', async () => {
     capture.discover.mockRejectedValueOnce(new Error('permission denied'));
     const wrapper = mount(HUD, { global: { stubs } });

--- a/src/components/hud/tests/useRecordingControllerBranches.test.ts
+++ b/src/components/hud/tests/useRecordingControllerBranches.test.ts
@@ -6,6 +6,7 @@ const { capture, cameraApi, microphoneApi, systemApi } = vi.hoisted(() => ({
   capture: {
     platform: 'darwin',
     getCameraOverlayState: vi.fn(),
+    configureCameraOverlay: vi.fn(),
     setCountdown: vi.fn().mockResolvedValue(undefined),
     prepareRecordingSurface: vi.fn().mockResolvedValue(undefined),
     hideScreenRegionOverlay: vi.fn(),
@@ -29,7 +30,7 @@ const { capture, cameraApi, microphoneApi, systemApi } = vi.hoisted(() => ({
 
 vi.mock('../../../api/capture', () => ({ capture }));
 vi.mock('../../../api/camera-recorder', () => ({
-  BrowserCameraRecorder: { request: cameraApi.request },
+  CameraOverlayRecorder: { request: cameraApi.request },
   listBrowserCameras: cameraApi.list,
   isCameraUnavailableError: (reason: unknown) => (reason as { code?: string })?.code === 'camera-unavailable',
 }));

--- a/src/tests/App.test.ts
+++ b/src/tests/App.test.ts
@@ -235,6 +235,31 @@ describe('App', () => {
     expect(wrapper.find('.mock-hud').exists()).toBe(true);
   });
 
+  it('keeps the camera overlay active until recording stop succeeds', async () => {
+    await wrapper.get('.start').trigger('click');
+    await settle();
+    mocks.capture.setCameraOverlayActive.mockClear();
+
+    let finishStop!: () => void;
+    const stopFinished = new Promise<void>((resolve) => {
+      finishStop = () => {
+        mocks.controller.recording.phase.value = 'idle';
+        mocks.controller.onComplete?.({ videoSrc: 'project.mp4', sessionId: 'session-stop' });
+        resolve();
+      };
+    });
+    mocks.controller.recording.stop.mockReturnValueOnce(stopFinished);
+
+    const stopping = wrapper.get('.stop').trigger('click');
+    await nextTick();
+    expect(mocks.capture.setCameraOverlayActive).not.toHaveBeenCalledWith(false);
+
+    finishStop();
+    await stopping;
+    await settle();
+    expect(mocks.capture.setCameraOverlayActive).toHaveBeenCalledWith(false);
+  });
+
   it('routes tray stop and the global start/stop shortcut to an active recording', async () => {
     await wrapper.get('.start').trigger('click');
     await settle();

--- a/test/camera-overlay-window.test.cjs
+++ b/test/camera-overlay-window.test.cjs
@@ -25,6 +25,12 @@ function createElectronFixture(savedExtras = {}) {
       this.webContents = {
         getURL: () => 'http://localhost:6500/?cameraOverlay=1',
         once: (event, listener) => this.contentListeners.set(event, listener),
+        emit: (event, ...args) => {
+          const listener = this.contentListeners.get(event);
+          if (!listener) return;
+          this.contentListeners.delete(event);
+          listener(...args);
+        },
         send: (...args) => calls.push(['send', ...args]),
       };
       windows.push(this);
@@ -105,6 +111,7 @@ function createElectronFixture(savedExtras = {}) {
     destroy() {
       this.destroyed = true;
       this.emit('closed');
+      this.webContents.emit('destroyed');
     }
   }
 
@@ -239,6 +246,136 @@ test('keeps a valid top-left camera overlay placement instead of discarding zero
       height: 300,
     });
     overlay.destroy();
+  } finally {
+    fixture.restore();
+  }
+});
+
+test('waits for the overlay renderer before forwarding recording commands', async () => {
+  const fixture = createElectronFixture();
+  try {
+    const { createCameraOverlayWindow } = loadOverlayWindow();
+    const overlay = createCameraOverlayWindow({
+      applicationRoot: '/app',
+      isPackaged: false,
+      platform: 'win32',
+      preferencesStore: fixture.preferencesStore,
+    });
+    const command = { commandId: 'command-1', recordingId: 'recording-1', control: { action: 'prepare' } };
+
+    overlay.configure({ cameraId: 'camera:front' });
+    const window = fixture.windows[0];
+    let settled = false;
+    const pending = overlay.sendRecordingCommand(command).then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    assert.equal(settled, false);
+    assert.equal(overlay.markRendererReady({}), false);
+    assert.equal(overlay.markRendererReady(window.webContents), true);
+    await pending;
+    assert.equal(settled, true);
+    assert.deepEqual(
+      fixture.calls.filter((call) => call[0] === 'send' && call[1] === 'camera-overlay:recording-command').at(-1),
+      ['send', 'camera-overlay:recording-command', command],
+    );
+    overlay.destroy();
+  } finally {
+    fixture.restore();
+  }
+});
+
+test('rejects a command waiting for readiness when the overlay closes', async () => {
+  const fixture = createElectronFixture();
+  try {
+    const { createCameraOverlayWindow } = loadOverlayWindow();
+    const overlay = createCameraOverlayWindow({ applicationRoot: '/app', isPackaged: false, platform: 'win32' });
+    overlay.configure({ cameraId: 'camera:front' });
+    const pending = overlay.sendRecordingCommand({ commandId: 'command-1' });
+    fixture.windows[0].destroy();
+    await assert.rejects(pending, /camera overlay was closed/);
+  } finally {
+    fixture.restore();
+  }
+});
+
+test('does not forward a stale command after an aborted readiness wait and a new renderer becomes ready', async () => {
+  const fixture = createElectronFixture();
+  try {
+    const { createCameraOverlayWindow } = loadOverlayWindow();
+    const overlay = createCameraOverlayWindow({ applicationRoot: '/app', isPackaged: false, platform: 'win32' });
+    const staleCommand = { commandId: 'stale-command', recordingId: 'recording-1' };
+
+    overlay.configure({ cameraId: 'camera:first' });
+    const firstWindow = fixture.windows[0];
+    const pending = overlay.sendRecordingCommand(staleCommand);
+    firstWindow.destroy();
+    await assert.rejects(pending, /camera overlay was closed/);
+
+    overlay.configure({ cameraId: 'camera:second' });
+    const secondWindow = fixture.windows[1];
+    assert.equal(overlay.markRendererReady(secondWindow.webContents), true);
+    await Promise.resolve();
+
+    assert.deepEqual(
+      fixture.calls.filter((call) => call[0] === 'send' && call[1] === 'camera-overlay:recording-command'),
+      [],
+    );
+    overlay.destroy();
+  } finally {
+    fixture.restore();
+  }
+});
+
+test('does not forward an explicitly aborted command when the same renderer becomes ready later', async () => {
+  const fixture = createElectronFixture();
+  let overlay;
+  try {
+    const { createCameraOverlayWindow } = loadOverlayWindow();
+    overlay = createCameraOverlayWindow({ applicationRoot: '/app', isPackaged: false, platform: 'win32' });
+    const staleCommand = { commandId: 'aborted-command', recordingId: 'recording-1' };
+    const abort = new AbortController();
+
+    overlay.configure({ cameraId: 'camera:first' });
+    const window = fixture.windows[0];
+    const pending = overlay.sendRecordingCommand(staleCommand, { signal: abort.signal });
+    const outcome = pending.then(
+      () => 'resolved',
+      () => 'rejected',
+    );
+    abort.abort();
+    const outcomeBeforeReady = await Promise.race([
+      outcome,
+      new Promise((resolve) => setTimeout(() => resolve('pending'), 25)),
+    ]);
+    assert.equal(overlay.markRendererReady(window.webContents), true);
+    await pending.catch(() => undefined);
+    assert.equal(outcomeBeforeReady, 'rejected');
+    assert.deepEqual(
+      fixture.calls.filter((call) => call[0] === 'send' && call[1] === 'camera-overlay:recording-command'),
+      [],
+    );
+  } finally {
+    overlay?.destroy();
+    fixture.restore();
+  }
+});
+
+test('notifies the main process when the overlay web contents are destroyed', () => {
+  const fixture = createElectronFixture();
+  const destroyed = [];
+  try {
+    const { createCameraOverlayWindow } = loadOverlayWindow();
+    const overlay = createCameraOverlayWindow({
+      applicationRoot: '/app',
+      isPackaged: false,
+      platform: 'win32',
+      onWebContentsDestroyed: (contents) => destroyed.push(contents),
+    });
+    overlay.configure({ cameraId: 'camera:front' });
+    const contents = fixture.windows[0].webContents;
+    fixture.windows[0].destroy();
+    assert.deepEqual(destroyed, [contents]);
   } finally {
     fixture.restore();
   }

--- a/test/camera-recording-control.test.cjs
+++ b/test/camera-recording-control.test.cjs
@@ -1,0 +1,307 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { createCameraRecordingControl, validateControl } = require('../electron/camera/recording-control.cjs');
+
+const sourceId = 'camera:chromium:camera-1';
+const sessionId = '019f84dd-4d9d-7f61-ac30-5da50169ecbc';
+const preparedValue = (command) => ({
+  recordingId: command.recordingId,
+  sourceId,
+  format: { codec: 'vp8', width: 1280, height: 720, nominalFps: 30 },
+});
+
+function createFixture({ timeoutMs = 100 } = {}) {
+  const handlers = new Map();
+  const listeners = new Map();
+  const commands = [];
+  const configureCalls = [];
+  const rendererReadyCalls = [];
+  const hudMessages = [];
+  const hudWebContents = { id: 1, send: (...message) => hudMessages.push(message) };
+  const overlayWebContents = { id: 2 };
+  const otherWebContents = { id: 3 };
+
+  const ipcMain = {
+    handle(channel, listener) {
+      handlers.set(channel, listener);
+    },
+    on(channel, listener) {
+      listeners.set(channel, listener);
+    },
+  };
+  const cameraOverlay = {
+    configure(state) {
+      configureCalls.push(state);
+    },
+    sendRecordingCommand(command) {
+      commands.push(command);
+      return Promise.resolve();
+    },
+    markRendererReady(sender) {
+      rendererReadyCalls.push(sender);
+      return sender === overlayWebContents;
+    },
+    isRenderer(sender) {
+      return sender === overlayWebContents;
+    },
+  };
+  const cleanup = createCameraRecordingControl({
+    ipcMain,
+    cameraOverlay,
+    hudWebContents,
+    timeoutMs,
+  });
+
+  return {
+    handlers,
+    listeners,
+    commands,
+    configureCalls,
+    rendererReadyCalls,
+    hudMessages,
+    hudWebContents,
+    overlayWebContents,
+    otherWebContents,
+    cleanup,
+    invoke(sender, control) {
+      return handlers.get('camera-overlay:recording-control')({ sender }, control);
+    },
+    emit(channel, sender, payload) {
+      listeners.get(channel)?.({ sender }, payload);
+    },
+  };
+}
+
+async function prepare(fixture) {
+  const resultPromise = fixture.invoke(fixture.hudWebContents, { action: 'prepare', sourceId });
+  await Promise.resolve();
+  const command = fixture.commands.at(-1);
+  fixture.emit('camera-overlay:recording-result', fixture.overlayWebContents, {
+    commandId: command.commandId,
+    ok: true,
+    value: preparedValue(command),
+  });
+  return { result: await resultPromise, command };
+}
+
+async function completeControl(fixture, control, value) {
+  const resultPromise = fixture.invoke(fixture.hudWebContents, control);
+  await Promise.resolve();
+  const command = fixture.commands.at(-1);
+  fixture.emit('camera-overlay:recording-result', fixture.overlayWebContents, {
+    commandId: command.commandId,
+    ok: true,
+    value,
+  });
+  return { result: await resultPromise, command };
+}
+
+test('accepts recording control only from the canonical HUD sender', async () => {
+  const fixture = createFixture();
+
+  await assert.rejects(
+    fixture.invoke(fixture.otherWebContents, { action: 'prepare', sourceId }),
+    /restricted to the HUD/,
+  );
+  assert.deepEqual(fixture.commands, []);
+  assert.deepEqual(fixture.configureCalls, []);
+});
+
+test('rejects malformed controls before dispatching to the overlay', () => {
+  assert.throws(() => validateControl(null), /Invalid camera action/);
+  assert.throws(() => validateControl({ action: 'prepare', sourceId: 'camera:other:1' }), /Invalid camera source/);
+  assert.throws(() => validateControl({ action: 'prepare', sourceId: 'camera:chromium:' }), /Invalid camera source/);
+  assert.throws(() => validateControl({ action: 'start', recordingId: 'recording-1' }), /capture session identifier/);
+  assert.throws(
+    () => validateControl({ action: 'pause', recordingId: 'recording-1', endNs: Number.POSITIVE_INFINITY }),
+    /camera segment end/,
+  );
+  assert.throws(
+    () => validateControl({ action: 'fail', recordingId: 'recording-1', sessionId, reason: 'x'.repeat(501) }),
+    /camera failure reason/,
+  );
+});
+
+test('correlates results to the pending command and ignores other renderers or command ids', async () => {
+  const fixture = createFixture();
+  const resultPromise = fixture.invoke(fixture.hudWebContents, { action: 'prepare', sourceId });
+  await Promise.resolve();
+  const command = fixture.commands[0];
+  let settled = false;
+  void resultPromise.then(
+    () => {
+      settled = true;
+    },
+    () => {
+      settled = true;
+    },
+  );
+
+  fixture.emit('camera-overlay:recording-result', fixture.otherWebContents, {
+    commandId: command.commandId,
+    ok: true,
+    value: preparedValue(command),
+  });
+  fixture.emit('camera-overlay:recording-result', fixture.overlayWebContents, {
+    commandId: 'unrelated-command',
+    ok: true,
+    value: preparedValue(command),
+  });
+  await Promise.resolve();
+  assert.equal(settled, false);
+
+  fixture.emit('camera-overlay:recording-result', fixture.overlayWebContents, {
+    commandId: command.commandId,
+    ok: true,
+    value: preparedValue(command),
+  });
+  assert.deepEqual(await resultPromise, preparedValue(command));
+});
+
+test('forwards renderer-ready only through the overlay identity and forwards fatal failures to the HUD', async () => {
+  const fixture = createFixture();
+
+  fixture.emit('camera-overlay:renderer-ready', fixture.otherWebContents);
+  fixture.emit('camera-overlay:renderer-ready', fixture.overlayWebContents);
+  assert.deepEqual(fixture.rendererReadyCalls, [fixture.otherWebContents, fixture.overlayWebContents]);
+
+  const { result, command } = await prepare(fixture);
+  assert.equal(result.recordingId, command.recordingId);
+  fixture.emit('camera-overlay:recording-failure', fixture.otherWebContents, {
+    recordingId: command.recordingId,
+    message: 'ignored',
+  });
+  assert.deepEqual(fixture.hudMessages, []);
+
+  fixture.emit('camera-overlay:recording-failure', fixture.overlayWebContents, {
+    recordingId: command.recordingId,
+    message: 'camera disconnected',
+  });
+  assert.deepEqual(fixture.hudMessages, [
+    ['camera-overlay:recording-failure', { recordingId: command.recordingId, message: 'camera disconnected' }],
+  ]);
+
+  await assert.rejects(
+    fixture.invoke(fixture.hudWebContents, { action: 'stop', recordingId: command.recordingId, endNs: 1 }),
+    /no longer active/,
+  );
+});
+
+test('clears the active recording after stop and allows a new preparation', async () => {
+  const fixture = createFixture();
+  const { command } = await prepare(fixture);
+
+  const stopPromise = fixture.invoke(fixture.hudWebContents, {
+    action: 'stop',
+    recordingId: command.recordingId,
+    endNs: 1,
+  });
+  await Promise.resolve();
+  const stopCommand = fixture.commands.at(-1);
+  fixture.emit('camera-overlay:recording-result', fixture.overlayWebContents, {
+    commandId: stopCommand.commandId,
+    ok: true,
+  });
+  assert.equal(await stopPromise, undefined);
+
+  const next = await prepare(fixture);
+  assert.notEqual(next.command.recordingId, command.recordingId);
+});
+
+test('runs the camera recording control state machine with the session timeline', async () => {
+  const fixture = createFixture();
+  const { command: prepareCommand } = await prepare(fixture);
+  const recordingId = prepareCommand.recordingId;
+
+  const start = await completeControl(fixture, {
+    action: 'start',
+    recordingId,
+    sessionId,
+    startNs: 0,
+  });
+  assert.deepEqual(start.command.control, {
+    action: 'start',
+    recordingId,
+    sessionId,
+    startNs: 0,
+  });
+
+  const pause = await completeControl(fixture, { action: 'pause', recordingId, endNs: 1_000_000_000 });
+  assert.deepEqual(pause.command.control, { action: 'pause', recordingId, endNs: 1_000_000_000 });
+
+  const commandCountBeforeMismatchedResume = fixture.commands.length;
+  await assert.rejects(
+    fixture.invoke(fixture.hudWebContents, {
+      action: 'resume',
+      recordingId,
+      sessionId: '019f84dd-4d9d-7f61-ac30-5da50169ecbd',
+      startNs: 2_000_000_000,
+    }),
+    /session does not match/,
+  );
+  assert.equal(fixture.commands.length, commandCountBeforeMismatchedResume);
+
+  const resume = await completeControl(fixture, {
+    action: 'resume',
+    recordingId,
+    sessionId,
+    startNs: 2_000_000_000,
+  });
+  assert.deepEqual(resume.command.control, {
+    action: 'resume',
+    recordingId,
+    sessionId,
+    startNs: 2_000_000_000,
+  });
+
+  const stop = await completeControl(fixture, { action: 'stop', recordingId, endNs: 3_000_000_000 });
+  assert.deepEqual(stop.command.control, { action: 'stop', recordingId, endNs: 3_000_000_000 });
+  assert.equal(stop.result, undefined);
+});
+
+test('rejects a pending command on timeout and permits a later preparation', async () => {
+  const fixture = createFixture({ timeoutMs: 5 });
+
+  await assert.rejects(
+    fixture.invoke(fixture.hudWebContents, { action: 'prepare', sourceId }),
+    /did not answer in time/,
+  );
+  const next = await prepare(fixture);
+  assert.equal(next.result.sourceId, sourceId);
+});
+
+test('cleanup rejects pending commands and clears the active recording', async () => {
+  const fixture = createFixture({ timeoutMs: 1_000 });
+  const pending = fixture.invoke(fixture.hudWebContents, { action: 'prepare', sourceId });
+  await Promise.resolve();
+  fixture.cleanup();
+
+  await assert.rejects(pending, /control was closed/);
+  await assert.rejects(
+    fixture.invoke(fixture.hudWebContents, { action: 'stop', recordingId: fixture.commands[0].recordingId, endNs: 1 }),
+    /no longer active/,
+  );
+});
+
+test('cleanup notifies the HUD once for an active recording and rejects pending work', async () => {
+  const fixture = createFixture({ timeoutMs: 1_000 });
+  const { command } = await prepare(fixture);
+  const pendingStop = fixture.invoke(fixture.hudWebContents, {
+    action: 'stop',
+    recordingId: command.recordingId,
+    endNs: 1,
+  });
+  await Promise.resolve();
+
+  fixture.cleanup();
+  fixture.cleanup();
+
+  await assert.rejects(pendingStop, /control was closed/);
+  assert.deepEqual(fixture.hudMessages, [
+    [
+      'camera-overlay:recording-failure',
+      { recordingId: command.recordingId, message: 'Camera recording control was closed.' },
+    ],
+  ]);
+});


### PR DESCRIPTION
## Summary

- require the exact selected camera so Continuity Camera cannot fall back to the Mac camera
- share one camera stream between preview and recording to avoid Windows driver contention and black output
- wait for a real first frame and clean up camera failures, timeouts, toggles, and overlay shutdown
- keep camera segment timestamps aligned when enabling the camera during a recording

## Validation

- 132 focused Vitest tests passed
- 17 focused Electron/Node tests passed
- TypeScript and Vue typechecks passed
- targeted lint passed with no camera errors
- Rust artifact and Vite production build passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recording camera video through the camera overlay, including prepare, start, pause, resume, stop, and failure handling.
  * Camera startup now waits for the first usable video frame before becoming ready.
  * Added camera recording status and failure notifications between the overlay and recording controls.
  * Camera selection now uses exact device matching and improved stream lifecycle handling.

* **Bug Fixes**
  * The camera overlay remains active until recording stops successfully.
  * Improved handling of camera failures, aborted operations, and overlay closure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->