### PR TITLE
Show recording shortcuts below countdown

### DIFF
--- a/docs/electron_window.md
+++ b/docs/electron_window.md
@@ -29,7 +29,7 @@ Electron clips painting outside the BrowserWindow. A CSS shadow around an elemen
 - Keep the HUD card at `320 × 480` pixels, with a `352 × 512` BrowserWindow and a 16 px inset.
 - When HUD content changes height or width, include the 32 px outer allowance in the Electron `setSize` request.
 - Do not solve a clipped shadow by increasing the shadow token. Prefer reserving physical renderer space first.
-- The countdown uses the same rule: its circle is inset by 16 px in a larger transparent window so its border and shadow remain intact.
+- The countdown uses a centered `560 × 256` transparent window: its `160 × 160` circle and shortcut-hint row keep at least 16 px of outer room so the border and shadow remain intact.
 
 ## Mouse pass-through and focus stealing
 

--- a/electron/countdown-window.cjs
+++ b/electron/countdown-window.cjs
@@ -11,7 +11,8 @@ function createCountdownWindow({
   let window = null;
   let seconds = null;
   let ready = false;
-  const size = 192;
+  const width = 560;
+  const height = 256;
   const isWayland =
     platform === 'linux' &&
     (String(environment.XDG_SESSION_TYPE || '').toLowerCase() === 'wayland' || Boolean(environment.WAYLAND_DISPLAY));
@@ -19,8 +20,8 @@ function createCountdownWindow({
     if (isWayland) return;
     const display = screen.getDisplayNearestPoint(screen.getCursorScreenPoint());
     window?.setPosition(
-      display.workArea.x + Math.round((display.workArea.width - size) / 2),
-      display.workArea.y + Math.round((display.workArea.height - size) / 2),
+      display.workArea.x + Math.max(0, Math.round((display.workArea.width - width) / 2)),
+      display.workArea.y + Math.max(0, Math.round((display.workArea.height - height) / 2)),
     );
   };
   const create = () => {
@@ -29,8 +30,8 @@ function createCountdownWindow({
     if (!window || window.isDestroyed()) {
       ready = false;
       window = new BrowserWindow({
-        width: size,
-        height: size,
+        width,
+        height,
         center: isWayland,
         show: false,
         frame: false,

--- a/src/App.vue
+++ b/src/App.vue
@@ -28,6 +28,7 @@ let removeRecorderLauncherListener: (() => void) | null = null;
 let removeEditorLoadingListener: (() => void) | null = null;
 let removeTrayStopListener: (() => void) | null = null;
 let removeRecordingShortcutListener: (() => void) | null = null;
+let pauseShortcutPending = false;
 
 const handleMouseMove = (e: MouseEvent) => {
   if (currentView.value !== 'hud' && recording.phase.value === 'idle') return;
@@ -164,9 +165,18 @@ onMounted(() => {
       void cancelOrStopRecording();
     }) ?? null;
   removeRecordingShortcutListener = capture.onPreferenceShortcut((actionId) => {
-    if (actionId !== 'hud.startStopRecording') return;
-    if (!['countdown', 'starting', 'recording', 'paused'].includes(recording.phase.value)) return;
-    void cancelOrStopRecording();
+    if (actionId === 'hud.startStopRecording') {
+      if (!['countdown', 'starting', 'recording', 'paused'].includes(recording.phase.value)) return;
+      void cancelOrStopRecording();
+    } else if (actionId === 'hud.playPause' && ['recording', 'paused'].includes(recording.phase.value)) {
+      if (pauseShortcutPending) return;
+      pauseShortcutPending = true;
+      void Promise.resolve(recording.togglePause())
+        .catch((error) => console.error('Failed to toggle recording pause from shortcut:', error))
+        .finally(() => {
+          pauseShortcutPending = false;
+        });
+    }
   });
 });
 

--- a/src/components/hud/recorder/CountdownOverlay.vue
+++ b/src/components/hud/recorder/CountdownOverlay.vue
@@ -1,26 +1,86 @@
 <script setup lang="ts">
-import { onBeforeUnmount, onMounted, ref } from 'vue';
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
 import { capture } from '../../../api/capture';
+import type { PreferenceSettings } from '../../../api/types/capture-api';
+import KeyboardChip from '../../ui/Kbd/KeyboardChip.vue';
+import { useTranslate } from '../../../i18n/useTranslate';
 
+const { t } = useTranslate('RecorderBar');
 const seconds = ref<number | null>(null);
-let unsubscribe: (() => void) | null = null;
+const startStopShortcut = ref('');
+const pauseResumeShortcut = ref('');
+const hasShortcutHints = computed(() => Boolean(startStopShortcut.value || pauseResumeShortcut.value));
+let unsubscribeCountdown: (() => void) | null = null;
+let unsubscribePreferences: (() => void) | null = null;
+let receivedPreferenceUpdate = false;
+let mounted = false;
+
+const shortcutKeys = (preferences: PreferenceSettings, id: string) => {
+  const shortcut = preferences.shortcuts[id];
+  return shortcut?.scope === 'global' ? shortcut.keys.trim() : '';
+};
+const applyPreferences = (preferences: PreferenceSettings) => {
+  startStopShortcut.value = shortcutKeys(preferences, 'hud.startStopRecording');
+  pauseResumeShortcut.value = shortcutKeys(preferences, 'hud.playPause');
+};
+
 onMounted(() => {
-  unsubscribe = capture.onCountdown((value) => {
+  mounted = true;
+  unsubscribeCountdown = capture.onCountdown((value) => {
     seconds.value = value;
   });
+  unsubscribePreferences = capture.onPreferencesChanged((preferences) => {
+    receivedPreferenceUpdate = true;
+    applyPreferences(preferences);
+  });
+  void capture
+    .getPreferences()
+    .then((preferences) => {
+      if (mounted && !receivedPreferenceUpdate) applyPreferences(preferences);
+    })
+    .catch(() => undefined);
 });
-onBeforeUnmount(() => unsubscribe?.());
+onBeforeUnmount(() => {
+  mounted = false;
+  unsubscribeCountdown?.();
+  unsubscribePreferences?.();
+});
 </script>
 
 <template>
-  <main class="countdown" aria-live="assertive">{{ seconds ?? '' }}</main>
+  <main class="countdown-overlay">
+    <div class="countdown" role="timer" aria-live="assertive" aria-atomic="true">{{ seconds ?? '' }}</div>
+    <div v-if="hasShortcutHints" class="shortcut-hints" role="group" :aria-label="t('recordingControls')">
+      <div v-if="startStopShortcut" class="shortcut-hint">
+        <span>{{ t('stopRecording') }}</span>
+        <KeyboardChip :shortcut="startStopShortcut" size="sm" />
+      </div>
+      <span v-if="startStopShortcut && pauseResumeShortcut" class="shortcut-separator" aria-hidden="true">·</span>
+      <div v-if="pauseResumeShortcut" class="shortcut-hint">
+        <span>{{ t('pauseRecording') }}</span>
+        <KeyboardChip :shortcut="pauseResumeShortcut" size="sm" />
+      </div>
+    </div>
+  </main>
 </template>
 
 <style scoped>
-.countdown {
+.countdown-overlay {
   width: calc(100vw - 32px);
   height: calc(100vh - 32px);
   margin: 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  pointer-events: none;
+  user-select: none;
+}
+.countdown {
+  width: 160px;
+  height: 160px;
+  flex: 0 0 160px;
   display: grid;
   place-items: center;
   border: 1px solid var(--color-border);
@@ -31,5 +91,39 @@ onBeforeUnmount(() => unsubscribe?.());
   font-weight: 750;
   font-variant-numeric: tabular-nums;
   box-shadow: var(--shadow-lg);
+}
+.shortcut-hints,
+.shortcut-hint {
+  display: flex;
+  align-items: center;
+}
+.shortcut-hints {
+  width: max-content;
+  max-width: 100%;
+  min-height: 34px;
+  justify-content: center;
+  gap: 10px;
+  overflow: hidden;
+  padding: 8px 12px;
+  box-sizing: border-box;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full);
+  background: var(--color-bg-surface);
+  box-shadow: var(--shadow-md);
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+.shortcut-hint {
+  min-width: 0;
+  gap: 6px;
+}
+.shortcut-hint > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.shortcut-separator {
+  color: var(--text-muted);
 }
 </style>

--- a/src/components/hud/tests/CountdownOverlay.test.ts
+++ b/src/components/hud/tests/CountdownOverlay.test.ts
@@ -1,20 +1,43 @@
-import { mount } from '@vue/test-utils';
+import { flushPromises, mount } from '@vue/test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { capture } = vi.hoisted(() => ({ capture: { onCountdown: vi.fn() } }));
+const { capture } = vi.hoisted(() => ({
+  capture: {
+    onCountdown: vi.fn(),
+    onPreferencesChanged: vi.fn(),
+    getPreferences: vi.fn(),
+  },
+}));
 vi.mock('../../../api/capture', () => ({ capture }));
 
 import CountdownOverlay from '../recorder/CountdownOverlay.vue';
 
+const preferences = (shortcuts: Record<string, string> = {}) => ({
+  shortcuts: Object.fromEntries(
+    Object.entries(shortcuts).map(([id, keys]) => [id, { keys, scope: 'global', category: 'recording' }]),
+  ),
+});
+
 describe('CountdownOverlay', () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capture.onCountdown.mockReturnValue(vi.fn());
+    capture.onPreferencesChanged.mockReturnValue(vi.fn());
+    capture.getPreferences.mockResolvedValue(preferences());
+  });
 
   it('displays countdown events and unsubscribes on unmount', async () => {
     let listener: ((value: number | null) => void) | undefined;
-    const unsubscribe = vi.fn();
+    let preferenceListener: ((value: ReturnType<typeof preferences>) => void) | undefined;
+    const unsubscribeCountdown = vi.fn();
+    const unsubscribePreferences = vi.fn();
     capture.onCountdown.mockImplementation((next: (value: number | null) => void) => {
       listener = next;
-      return unsubscribe;
+      return unsubscribeCountdown;
+    });
+    capture.onPreferencesChanged.mockImplementation((next: (value: ReturnType<typeof preferences>) => void) => {
+      preferenceListener = next;
+      return unsubscribePreferences;
     });
     const wrapper = mount(CountdownOverlay);
     expect(wrapper.get('.countdown').text()).toBe('');
@@ -25,6 +48,91 @@ describe('CountdownOverlay', () => {
     await wrapper.vm.$nextTick();
     expect(wrapper.get('.countdown').text()).toBe('');
     wrapper.unmount();
-    expect(unsubscribe).toHaveBeenCalledOnce();
+    expect(unsubscribeCountdown).toHaveBeenCalledOnce();
+    expect(unsubscribePreferences).toHaveBeenCalledOnce();
+    expect(preferenceListener).toBeDefined();
+  });
+
+  it('loads user shortcuts and updates both hints when preferences change live', async () => {
+    let preferenceListener: ((value: ReturnType<typeof preferences>) => void) | undefined;
+    capture.getPreferences.mockResolvedValueOnce(
+      preferences({ 'hud.startStopRecording': 'Ctrl+Shift+R', 'hud.playPause': 'Ctrl+P' }),
+    );
+    capture.onPreferencesChanged.mockImplementation((next: (value: ReturnType<typeof preferences>) => void) => {
+      preferenceListener = next;
+      return vi.fn();
+    });
+
+    const wrapper = mount(CountdownOverlay);
+    await flushPromises();
+    await wrapper.vm.$nextTick();
+
+    expect(capture.getPreferences).toHaveBeenCalledOnce();
+    expect(wrapper.findAll('.shortcut-hint')).toHaveLength(2);
+    expect(wrapper.find('.shortcut-hints').text()).toContain('Stop recording');
+    expect(wrapper.find('.shortcut-hints').text()).toContain('Pause recording');
+    expect(wrapper.findAll('kbd').map((chip) => chip.text())).toEqual(['Ctrl', 'Shift', 'R', 'Ctrl', 'P']);
+
+    preferenceListener?.(preferences({ 'hud.startStopRecording': 'Alt+S' }));
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.findAll('.shortcut-hint')).toHaveLength(1);
+    expect(wrapper.find('.shortcut-hint').text()).toContain('Stop recording');
+    expect(wrapper.find('.shortcut-hint').text()).not.toContain('Pause recording');
+    expect(wrapper.findAll('kbd').map((chip) => chip.text())).toEqual(['Alt', 'S']);
+    expect(wrapper.find('.shortcut-separator').exists()).toBe(false);
+    wrapper.unmount();
+  });
+
+  it('omits missing shortcut entries without rendering empty hint containers', async () => {
+    capture.getPreferences.mockResolvedValueOnce(preferences({ 'hud.playPause': 'Ctrl+P' }));
+    const wrapper = mount(CountdownOverlay);
+
+    await flushPromises();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.findAll('.shortcut-hint')).toHaveLength(1);
+    expect(wrapper.find('.shortcut-hint').text()).toContain('Pause recording');
+    expect(wrapper.find('.shortcut-separator').exists()).toBe(false);
+    expect(wrapper.findAll('kbd').map((chip) => chip.text())).toEqual(['Ctrl', 'P']);
+    wrapper.unmount();
+  });
+
+  it('ignores application-scoped shortcuts while keeping global translated labels', async () => {
+    capture.getPreferences.mockResolvedValueOnce({
+      shortcuts: {
+        'hud.startStopRecording': { keys: 'Ctrl+Shift+R', scope: 'application', category: 'recording' },
+        'hud.playPause': { keys: 'Ctrl+P', scope: 'global', category: 'recording' },
+      },
+    });
+    const wrapper = mount(CountdownOverlay);
+
+    await flushPromises();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.findAll('.shortcut-hint')).toHaveLength(1);
+    expect(wrapper.find('.shortcut-hint').text()).toContain('Pause recording');
+    expect(wrapper.find('.shortcut-hint').text()).not.toContain('Stop recording');
+    expect(wrapper.findAll('kbd').map((chip) => chip.text())).toEqual(['Ctrl', 'P']);
+    wrapper.unmount();
+  });
+
+  it('keeps the countdown usable when loading preferences fails', async () => {
+    let countdownListener: ((value: number | null) => void) | undefined;
+    capture.getPreferences.mockRejectedValueOnce(new Error('preferences unavailable'));
+    capture.onCountdown.mockImplementation((next: (value: number | null) => void) => {
+      countdownListener = next;
+      return vi.fn();
+    });
+    const wrapper = mount(CountdownOverlay);
+
+    await flushPromises();
+    expect(capture.getPreferences).toHaveBeenCalledOnce();
+    expect(wrapper.find('.shortcut-hints').exists()).toBe(false);
+
+    countdownListener?.(3);
+    await wrapper.vm.$nextTick();
+    expect(wrapper.get('.countdown').text()).toBe('3');
+    wrapper.unmount();
   });
 });

--- a/src/tests/App.test.ts
+++ b/src/tests/App.test.ts
@@ -272,6 +272,90 @@ describe('App', () => {
     expect(mocks.controller.recording.stop).toHaveBeenCalledTimes(2);
   });
 
+  it('routes the pause/resume shortcut only while recording or paused', async () => {
+    const shortcut = mocks.capture.onPreferenceShortcut.mock.calls[0]?.[0] as ((action: string) => void) | undefined;
+    expect(shortcut).toBeDefined();
+
+    for (const phase of ['idle', 'countdown', 'starting', 'finalizing'] as const) {
+      mocks.controller.recording.phase.value = phase;
+      shortcut?.('hud.playPause');
+    }
+    expect(mocks.controller.recording.togglePause).not.toHaveBeenCalled();
+
+    mocks.controller.recording.phase.value = 'recording';
+    shortcut?.('hud.playPause');
+    await settle();
+    mocks.controller.recording.phase.value = 'paused';
+    shortcut?.('hud.playPause');
+    await settle();
+    expect(mocks.controller.recording.togglePause).toHaveBeenCalledTimes(2);
+    expect(mocks.controller.recording.stop).not.toHaveBeenCalled();
+  });
+
+  it('ignores duplicate pause/resume shortcuts while pending and accepts the next event after resolving', async () => {
+    let resolveToggle!: () => void;
+    const pendingToggle = new Promise<void>((resolve) => {
+      resolveToggle = resolve;
+    });
+    mocks.controller.recording.togglePause.mockReturnValueOnce(pendingToggle);
+    mocks.controller.recording.phase.value = 'recording';
+    const shortcut = mocks.capture.onPreferenceShortcut.mock.calls[0]?.[0] as ((action: string) => void) | undefined;
+
+    shortcut?.('hud.playPause');
+    shortcut?.('hud.playPause');
+    expect(mocks.controller.recording.togglePause).toHaveBeenCalledOnce();
+
+    resolveToggle();
+    await settle();
+    shortcut?.('hud.playPause');
+    await settle();
+    expect(mocks.controller.recording.togglePause).toHaveBeenCalledTimes(2);
+  });
+
+  it('re-enables pause/resume shortcuts after a rejected toggle', async () => {
+    let rejectToggle!: (reason?: unknown) => void;
+    const pendingToggle = new Promise<void>((_, reject) => {
+      rejectToggle = reject;
+    });
+    const error = new Error('pause unavailable');
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    mocks.controller.recording.togglePause.mockReturnValueOnce(pendingToggle);
+    mocks.controller.recording.phase.value = 'paused';
+    const shortcut = mocks.capture.onPreferenceShortcut.mock.calls[0]?.[0] as ((action: string) => void) | undefined;
+
+    shortcut?.('hud.playPause');
+    shortcut?.('hud.playPause');
+    expect(mocks.controller.recording.togglePause).toHaveBeenCalledOnce();
+
+    rejectToggle(error);
+    await settle();
+    expect(errorSpy).toHaveBeenCalledWith('Failed to toggle recording pause from shortcut:', error);
+    shortcut?.('hud.playPause');
+    await settle();
+    expect(mocks.controller.recording.togglePause).toHaveBeenCalledTimes(2);
+  });
+
+  it('ignores unknown shortcut actions and keeps start/stop routing limited to valid phases', async () => {
+    const shortcut = mocks.capture.onPreferenceShortcut.mock.calls[0]?.[0] as ((action: string) => void) | undefined;
+    expect(shortcut).toBeDefined();
+
+    for (const phase of ['idle', 'finalizing'] as const) {
+      mocks.controller.recording.phase.value = phase;
+      shortcut?.('hud.startStopRecording');
+    }
+    mocks.controller.recording.phase.value = 'recording';
+    shortcut?.('hud.unknown');
+    expect(mocks.controller.recording.stop).not.toHaveBeenCalled();
+    expect(mocks.controller.recording.cancel).not.toHaveBeenCalled();
+
+    for (const phase of ['countdown', 'starting', 'recording', 'paused'] as const) {
+      mocks.controller.recording.phase.value = phase;
+      shortcut?.('hud.startStopRecording');
+    }
+    await settle();
+    expect(mocks.controller.recording.stop).toHaveBeenCalledTimes(4);
+  });
+
   it('opens projects, displays loading errors, and dismisses them', async () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
     mocks.capture.openEditor.mockRejectedValueOnce(new Error('project is unreadable'));

--- a/test/countdown-window.test.cjs
+++ b/test/countdown-window.test.cjs
@@ -3,7 +3,7 @@ const Module = require('node:module');
 const path = require('node:path');
 const test = require('node:test');
 
-function loadCountdownWindow({ platform, environment }) {
+function loadCountdownWindow({ platform, environment, workArea = { x: 0, y: 0, width: 1_000, height: 800 } }) {
   const calls = [];
   const screenCalls = [];
   let finishLoad;
@@ -47,7 +47,7 @@ function loadCountdownWindow({ platform, environment }) {
       },
       getDisplayNearestPoint: () => {
         screenCalls.push('getDisplayNearestPoint');
-        return { workArea: { x: 0, y: 0, width: 1_000, height: 800 } };
+        return { workArea };
       },
     },
   };
@@ -80,9 +80,12 @@ test('Wayland presents the countdown without unsupported global window operation
   });
   const constructor = fixture.calls.find((call) => call[0] === 'constructor');
 
+  assert.equal(constructor[1].width, 560);
+  assert.equal(constructor[1].height, 256);
   assert.equal(constructor[1].show, false);
   assert.equal(constructor[1].center, true);
   assert.equal(constructor[1].focusable, false);
+  assert.ok(fixture.calls.some((call) => call[0] === 'mouse' && call[1] === true));
   assert.deepEqual(fixture.screenCalls, []);
 
   fixture.overlay.show(3);
@@ -138,9 +141,12 @@ test('X11 positions and raises the countdown with the supported inactive path', 
   });
   const constructor = fixture.calls.find((call) => call[0] === 'constructor');
 
+  assert.equal(constructor[1].width, 560);
+  assert.equal(constructor[1].height, 256);
   assert.equal(constructor[1].show, false);
   assert.equal(constructor[1].center, false);
   assert.equal(constructor[1].focusable, false);
+  assert.ok(fixture.calls.some((call) => call[0] === 'mouse' && call[1] === true));
 
   fixture.overlay.show(3);
   assert.equal(
@@ -154,7 +160,13 @@ test('X11 positions and raises the countdown with the supported inactive path', 
 
   fixture.finishLoad();
   assert.ok(fixture.calls.some((call) => call[0] === 'send' && call[1] === 'countdown:state' && call[2] === 3));
-  assert.equal(fixture.calls.filter((call) => call[0] === 'position').length, 2);
+  assert.deepEqual(
+    fixture.calls.filter((call) => call[0] === 'position'),
+    [
+      ['position', 220, 272],
+      ['position', 220, 272],
+    ],
+  );
   assert.equal(fixture.calls.filter((call) => call[0] === 'showInactive').length, 1);
   assert.equal(fixture.calls.filter((call) => call[0] === 'top').length, 1);
   assert.deepEqual(fixture.screenCalls, [
@@ -171,4 +183,23 @@ test('X11 positions and raises the countdown with the supported inactive path', 
 
   fixture.overlay.show(null);
   assert.equal(fixture.calls.at(-1)[0], 'hide');
+});
+
+test('clamps countdown positioning to the work-area origin when the work area is smaller than the window', () => {
+  const fixture = loadCountdownWindow({
+    platform: 'linux',
+    environment: { XDG_SESSION_TYPE: 'x11' },
+    workArea: { x: 37, y: 19, width: 400, height: 180 },
+  });
+
+  fixture.overlay.show(3);
+  fixture.finishLoad();
+
+  assert.deepEqual(
+    fixture.calls.filter((call) => call[0] === 'position'),
+    [
+      ['position', 37, 19],
+      ['position', 37, 19],
+    ],
+  );
 });


### PR DESCRIPTION
## Summary

- display the configured stop and pause shortcuts below the countdown
- reuse translated RecorderBar labels and the themed KeyboardChip component
- make the existing pause/resume global shortcut functional and guard concurrent transitions
- preserve a centered, non-focusable, mouse-passthrough countdown window

## Validation

- 23 focused Vitest/Node tests passed
- TypeScript and Vue typechecks passed
- targeted lint and formatting passed
- production build passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Countdown overlays now display global stop and pause keyboard shortcuts.
  * Shortcut hints update automatically when preferences change.
  * Added support for pausing and resuming recording via keyboard shortcut.

* **Improvements**
  * Countdown windows are now centered rectangular overlays with improved sizing and positioning.
  * Shortcut handling prevents duplicate pause actions and recovers gracefully from errors.

* **Documentation**
  * Updated countdown window sizing and shadow guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->