### PR TITLE
fix(editor): preserve crop scale and position on apply

### DIFF
--- a/src/components/export/composition/tests/render-crop.test.ts
+++ b/src/components/export/composition/tests/render-crop.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { RenderableMedia } from '../render';
+import { renderCompositionFrame } from '../render';
+import type { VisualClip } from '~/media/shared/composition-types';
+import * as decoratedMedia from '../../../video-editor/composition/appearance/render-decorated-media';
+import { context, screenAppearance, snapshot } from './render.test-support';
+
+const source = (width = 100, height = 50): RenderableMedia => ({
+  source: {} as CanvasImageSource,
+  width,
+  height,
+});
+
+const bottomCrop = { x: 0, y: 0.75, width: 1, height: 0.25 } as const;
+
+const drawCall = (value: ReturnType<typeof snapshot>, media = source()) => {
+  const ctx = context();
+  const drawSpy = vi.spyOn(decoratedMedia, 'drawDecoratedMedia');
+  renderCompositionFrame(ctx, media, value, 0);
+  const options = drawSpy.mock.calls.at(-1)?.[1];
+  drawSpy.mockRestore();
+  return options;
+};
+
+describe('composition crop rendering', () => {
+  it('keeps a bottom screen crop at its original destination scale', () => {
+    const value = snapshot();
+    const screen = value.composition.clips[0];
+    if (screen.kind !== 'screen') throw new Error('screen fixture missing');
+
+    const uncropped = drawCall(value);
+    screen.crop = bottomCrop;
+    const cropped = drawCall(value);
+
+    expect(uncropped).toMatchObject({
+      sourceRect: { x: 0, y: 0, width: 100, height: 50 },
+      rect: { x: 0, y: 0, width: 100, height: 50 },
+    });
+    expect(cropped).toMatchObject({
+      sourceRect: { x: 0, y: 37.5, width: 100, height: 12.5 },
+      rect: { x: 0, y: 37.5, width: 100, height: 12.5 },
+    });
+  });
+
+  it.each([false, true] as const)('keeps the original screen media bounds with background=%s', (showBackground) => {
+    const value = snapshot();
+    value.canvas = { ...value.canvas, showBackground };
+    const screen = value.composition.clips[0];
+    if (screen.kind !== 'screen') throw new Error('screen fixture missing');
+    screen.crop = bottomCrop;
+
+    const cropped = drawCall(value);
+    const destination = showBackground
+      ? { x: 7, y: 35.75, width: 86, height: 10.75 }
+      : { x: 0, y: 37.5, width: 100, height: 12.5 };
+
+    expect(cropped).toMatchObject({
+      sourceRect: { x: 0, y: 37.5, width: 100, height: 12.5 },
+      rect: destination,
+    });
+  });
+
+  it('mirrors the destination crop while preserving source coordinates', () => {
+    const value = snapshot();
+    const screen = value.composition.clips[0];
+    if (screen.kind !== 'screen') throw new Error('screen fixture missing');
+    screen.crop = { x: 0.1, y: 0.25, width: 0.5, height: 0.25 };
+    screen.isMirrored = true;
+    screen.isMirroredY = true;
+
+    const cropped = drawCall(value);
+
+    expect(cropped).toMatchObject({
+      sourceRect: { x: 10, y: 12.5, width: 50, height: 12.5 },
+      rect: { x: 40, y: 25, width: 50, height: 12.5 },
+      mirrored: true,
+      mirroredY: true,
+    });
+  });
+
+  it('keeps an imported visual crop in place on the output canvas', () => {
+    const value = snapshot();
+    const image: VisualClip = {
+      id: 'image',
+      kind: 'image',
+      name: 'Image',
+      assetId: 'image-asset',
+      timelineStartMs: 0,
+      timelineDurationMs: 1_000,
+      sourceInMs: 0,
+      sourceDurationMs: 1_000,
+      playbackRate: 1,
+      enabled: true,
+      order: 0,
+      transform: { x: 0, y: 0, width: 1, height: 1 },
+      crop: bottomCrop,
+      appearance: screenAppearance,
+      isMirrored: false,
+      isMirroredY: false,
+    };
+    value.composition = {
+      ...value.composition,
+      assets: [
+        {
+          id: 'image-asset',
+          kind: 'image',
+          name: 'Image',
+          fileName: 'image.png',
+          durationMs: 1_000,
+          width: 100,
+          height: 50,
+          src: 'file:///image.png',
+          origin: 'project',
+        },
+      ],
+      clips: [image],
+    };
+    const visual = source();
+    const ctx = context();
+    const drawSpy = vi.spyOn(decoratedMedia, 'drawDecoratedMedia');
+
+    renderCompositionFrame(ctx, null, value, 0, null, undefined, new Map([['image', visual]]));
+
+    const cropped = drawSpy.mock.calls.at(-1)?.[1];
+    drawSpy.mockRestore();
+    expect(cropped).toMatchObject({
+      sourceRect: { x: 0, y: 37.5, width: 100, height: 12.5 },
+      rect: { x: 0, y: 37.5, width: 100, height: 12.5 },
+    });
+  });
+});

--- a/src/components/export/composition/tests/render.test.ts
+++ b/src/components/export/composition/tests/render.test.ts
@@ -71,7 +71,7 @@ describe('canonical composition rendering', () => {
     screen.crop = { x: 0.1, y: 0.2, width: 0.5, height: 0.4 };
     const ctx = context();
     renderCompositionFrame(ctx, { source: {}, width: 100, height: 50 } as RenderableMedia, value, 0);
-    expect(ctx.drawImage).toHaveBeenCalledWith(expect.anything(), 15, 10, 40, 20, 0, 0, 100, 50);
+    expect(ctx.drawImage).toHaveBeenCalledWith(expect.anything(), 10, 10, 50, 20, 10, 10, 50, 20);
   });
 
   it('draws an active imported visual from its canonical clip', () => {
@@ -243,19 +243,27 @@ describe('canonical composition rendering', () => {
       undefined,
       new Map([['webcam', source]]),
     );
-    expect(ctx.drawImage).toHaveBeenCalledWith(
+    expect(ctx.drawImage).toHaveBeenNthCalledWith(
+      1,
       source.source,
       10,
       10,
       50,
       30,
-      expect.closeTo(100, 0.001),
-      expect.closeTo(100, 0.001),
-      300,
-      200,
+      expect.closeTo(220, 0.001),
+      expect.closeTo(140, 0.001),
+      150,
+      120,
     );
     expect(ctx.scale).toHaveBeenCalledWith(-1, 1);
-    expect(ctx.roundRect).toHaveBeenCalledWith(100, expect.closeTo(100, 0.001), 300, 200, 42);
+    expect(ctx.roundRect).toHaveBeenNthCalledWith(
+      1,
+      expect.closeTo(220, 0.001),
+      expect.closeTo(140, 0.001),
+      150,
+      120,
+      42,
+    );
     expect(ctx.stroke).toHaveBeenCalled();
   });
 

--- a/src/components/video-editor/canvas/composables/cropped-layer-resize.ts
+++ b/src/components/video-editor/canvas/composables/cropped-layer-resize.ts
@@ -1,0 +1,35 @@
+import type { NormalizedTransform, VisualClip } from '~/media/shared/composition-types';
+import type { ResizeCorner } from '~/ui/ResizeHandle/types';
+import { isPhoneFrame } from '../../composition/appearance/phone-frames';
+import { mirrorCrop } from './layer-transform-geometry';
+
+/** Keep the visible crop edge under the pointer while resizing the full source. */
+export function resizeCroppedLayer(
+  clip: VisualClip,
+  initial: NormalizedTransform,
+  resized: NormalizedTransform,
+  corner?: ResizeCorner,
+  preserveAspect = false,
+): NormalizedTransform {
+  if (!clip.crop || (clip.cameraFramingPreset ?? 'custom') !== 'custom' || isPhoneFrame(clip.appearance.frame))
+    return resized;
+  const crop = mirrorCrop(clip.crop, Boolean(clip.isMirrored), Boolean(clip.isMirroredY));
+  const width = Math.min(4, Math.max(0.02, initial.width + (resized.width - initial.width) / crop.width));
+  const height = Math.min(
+    4,
+    Math.max(
+      0.02,
+      preserveAspect
+        ? (width * initial.height) / initial.width
+        : initial.height + (resized.height - initial.height) / crop.height,
+    ),
+  );
+  const widthDelta = width - initial.width;
+  const heightDelta = height - initial.height;
+  return {
+    x: initial.x - (crop.x + (corner?.includes('left') ? crop.width : 0)) * widthDelta,
+    y: initial.y - (crop.y + (corner?.includes('top') ? crop.height : 0)) * heightDelta,
+    width,
+    height,
+  };
+}

--- a/src/components/video-editor/canvas/composables/layer-display-layout.ts
+++ b/src/components/video-editor/canvas/composables/layer-display-layout.ts
@@ -31,7 +31,8 @@ export function transformClipDisplayLayout(options: {
   bounds: VideoWindowBounds;
   isCropping: boolean;
 }) {
-  const { clip, bounds, transform } = options;
+  const { bounds, transform } = options;
+  const clip = options.isCropping && isVisualClip(options.clip) ? { ...options.clip, crop: undefined } : options.clip;
   if (clip.kind === 'webcam')
     return webcamDisplayLayout(
       options.composition,

--- a/src/components/video-editor/canvas/composables/layer-transform-and-crop-types.ts
+++ b/src/components/video-editor/canvas/composables/layer-transform-and-crop-types.ts
@@ -1,0 +1,20 @@
+import type { ClipComposition, NormalizedCrop, NormalizedTransform } from '~/media/shared/composition-types';
+import type { CaptionTextMeasurer } from '~/media/shared/caption-text-layout';
+import type { TransformClip } from '../editor-canvas-types';
+import type { OutputCanvasSettings } from '../output-canvas';
+import type { VideoWindowBounds } from './useCameraZoom';
+
+export interface UseLayerTransformAndCropOptions {
+  composition: () => ClipComposition;
+  currentTime: () => number;
+  selectedTransformClip: () => TransformClip | null;
+  videoWindowBounds: () => VideoWindowBounds | null;
+  overlayWindowBounds: () => VideoWindowBounds | null;
+  isCropping: () => boolean | undefined;
+  outputCanvas: () => OutputCanvasSettings;
+  measureCaptionText?: CaptionTextMeasurer;
+  zoomScale?: () => number;
+  onUpdateTransform: (transform: NormalizedTransform) => void;
+  onUpdateCrop: (crop: NormalizedCrop) => void;
+  onSelectTransformClip: (clipId: string) => void;
+}

--- a/src/components/video-editor/canvas/composables/tests/cropped-layer-resize.test.ts
+++ b/src/components/video-editor/canvas/composables/tests/cropped-layer-resize.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import { createDefaultClipAppearance } from '~/media/shared/composition-defaults';
+import type { NormalizedCrop, NormalizedTransform, VisualClip } from '~/media/shared/composition-types';
+import { resizeCroppedLayer } from '../cropped-layer-resize';
+
+const crop: NormalizedCrop = { x: 0.2, y: 0.25, width: 0.5, height: 0.5 };
+
+const clipFor = (overrides: Partial<VisualClip> = {}): VisualClip => ({
+  id: 'clip',
+  kind: 'video',
+  name: 'Clip',
+  assetId: 'asset',
+  timelineStartMs: 0,
+  timelineDurationMs: 1_000,
+  sourceInMs: 0,
+  sourceDurationMs: 1_000,
+  playbackRate: 1,
+  enabled: true,
+  order: 0,
+  transform: { x: 0.2, y: 0.3, width: 0.4, height: 0.3 },
+  crop,
+  appearance: createDefaultClipAppearance('video'),
+  isMirrored: false,
+  isMirroredY: false,
+  cameraFramingPreset: 'custom',
+  ...overrides,
+});
+
+const expectTransform = (actual: NormalizedTransform, expected: NormalizedTransform) => {
+  expect(actual.x).toBeCloseTo(expected.x, 10);
+  expect(actual.y).toBeCloseTo(expected.y, 10);
+  expect(actual.width).toBeCloseTo(expected.width, 10);
+  expect(actual.height).toBeCloseTo(expected.height, 10);
+};
+
+describe('resizeCroppedLayer', () => {
+  it('expands the full layer by the crop fraction so the visible crop follows the pointer', () => {
+    const clip = clipFor();
+    const initial = { x: 0.2, y: 0.3, width: 0.4, height: 0.3 };
+    const resized = { x: 0.2, y: 0.3, width: 0.5, height: 0.4 };
+
+    expectTransform(resizeCroppedLayer(clip, initial, resized, 'bottom-right'), {
+      x: 0.16,
+      y: 0.25,
+      width: 0.6,
+      height: 0.5,
+    });
+  });
+
+  it.each([
+    ['top-left', { width: 0.5, height: 0.4 }, { x: 0.06, y: 0.15, width: 0.6, height: 0.5 }],
+    ['right', { width: 0.5, height: 0.3 }, { x: 0.16, y: 0.3, width: 0.6, height: 0.3 }],
+    ['bottom', { width: 0.4, height: 0.4 }, { x: 0.2, y: 0.25, width: 0.4, height: 0.5 }],
+    ['left', { width: 0.5, height: 0.3 }, { x: 0.06, y: 0.3, width: 0.6, height: 0.3 }],
+  ] as const)('keeps the opposite crop edge anchored for the %s resize', (corner, resizedSize, expected) => {
+    const initial = { x: 0.2, y: 0.3, width: 0.4, height: 0.3 };
+    const resized = { ...initial, ...resizedSize };
+
+    expectTransform(resizeCroppedLayer(clipFor(), initial, resized, corner), expected);
+  });
+
+  it('anchors against the mirrored crop coordinates on both axes', () => {
+    const clip = clipFor({ isMirrored: true, isMirroredY: true });
+    const initial = { x: 0.2, y: 0.3, width: 0.4, height: 0.3 };
+    const resized = { x: 0.2, y: 0.3, width: 0.5, height: 0.4 };
+
+    expectTransform(resizeCroppedLayer(clip, initial, resized, 'bottom-right'), {
+      x: 0.14,
+      y: 0.25,
+      width: 0.6,
+      height: 0.5,
+    });
+  });
+
+  it('preserves the original aspect ratio when a corner resize locks the aspect', () => {
+    const clip = clipFor();
+    const initial = { x: 0.2, y: 0.3, width: 0.4, height: 0.3 };
+    const resized = { x: 0.2, y: 0.3, width: 0.5, height: 0.8 };
+
+    expectTransform(resizeCroppedLayer(clip, initial, resized, 'bottom-right', true), {
+      x: 0.16,
+      y: 0.2625,
+      width: 0.6,
+      height: 0.45,
+    });
+  });
+
+  it.each([
+    ['minimum', { x: 0.2, y: 0.3, width: 0.01, height: 0.01 }, { width: 0.02, height: 0.02 }],
+    ['maximum', { x: 0.2, y: 0.3, width: 2.5, height: 2.5 }, { width: 4, height: 4 }],
+  ] as const)('clamps the resized full layer at its %s bounds', (_name, resized, expectedSize) => {
+    const initial = { x: 0.2, y: 0.3, width: 0.4, height: 0.3 };
+    const result = resizeCroppedLayer(clipFor(), initial, resized, 'bottom-right');
+
+    expect(result.width).toBe(expectedSize.width);
+    expect(result.height).toBe(expectedSize.height);
+    expect(result.width).toBeGreaterThanOrEqual(0.02);
+    expect(result.height).toBeGreaterThanOrEqual(0.02);
+    expect(result.width).toBeLessThanOrEqual(4);
+    expect(result.height).toBeLessThanOrEqual(4);
+  });
+
+  it.each([
+    ['without a crop', clipFor({ crop: undefined })],
+    ['with non-custom framing', clipFor({ cameraFramingPreset: 'fill' })],
+    [
+      'with a phone frame',
+      clipFor({ appearance: { ...createDefaultClipAppearance('video'), frame: 'iphone-16-max' } }),
+    ],
+  ] as const)('passes the requested transform through %s', (_name, clip) => {
+    const initial = { x: 0.2, y: 0.3, width: 0.4, height: 0.3 };
+    const resized = { x: 0.1, y: 0.2, width: 0.6, height: 0.5 };
+
+    expect(resizeCroppedLayer(clip, initial, resized, 'bottom-right')).toBe(resized);
+  });
+});

--- a/src/components/video-editor/canvas/composables/tests/layer-display-layout.test.ts
+++ b/src/components/video-editor/canvas/composables/tests/layer-display-layout.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  BlurClip,
+  CaptionClip,
+  ClipComposition,
+  ColorClip,
+  NormalizedTransform,
+  VisualClip,
+} from '~/media/shared/composition-types';
+import { createDefaultCaptionStyle, createDefaultClipAppearance } from '~/media/shared/composition-defaults';
+import { frameContentRect } from '../../../composition/appearance/frames';
+import { transformClipDisplayLayout } from '../layer-display-layout';
+import { projectCameraRect } from '../layer-transform-geometry';
+import type { VideoWindowBounds } from '../useCameraZoom';
+
+const transform: NormalizedTransform = { x: 0.25, y: 0.2, width: 0.5, height: 0.4 };
+const bounds: VideoWindowBounds = {
+  dx: 10,
+  dy: 20,
+  dw: 800,
+  dh: 450,
+  scale: 2,
+  focusX: 410,
+  focusY: 245,
+};
+
+const compositionFor = (assets: ClipComposition['assets'] = []): ClipComposition => ({
+  schemaVersion: 6,
+  keyboardCaptionSessions: [],
+  assets,
+  clips: [],
+});
+
+const asset = (width: number | null = 800, height: number | null = 600) => ({
+  id: 'asset',
+  kind: 'image' as const,
+  name: 'Asset',
+  fileName: 'asset.png',
+  durationMs: 1_000,
+  width,
+  height,
+  src: 'asset.png',
+  origin: 'project' as const,
+});
+
+const visual = (overrides: Partial<VisualClip> = {}): VisualClip => ({
+  id: 'image',
+  kind: 'image',
+  name: 'Image',
+  assetId: 'asset',
+  timelineStartMs: 0,
+  timelineDurationMs: 1_000,
+  sourceInMs: 0,
+  sourceDurationMs: 1_000,
+  playbackRate: 1,
+  enabled: true,
+  order: 0,
+  transform,
+  crop: { x: 0.1, y: 0.2, width: 0.7, height: 0.6 },
+  appearance: createDefaultClipAppearance('image'),
+  isMirrored: false,
+  isMirroredY: false,
+  cameraFramingPreset: 'custom',
+  ...overrides,
+});
+
+describe('transform clip display layout', () => {
+  it('uses the in-place crop for normal display and the full source box while editing', () => {
+    const clip = visual();
+    const composition = compositionFor([asset()]);
+
+    expect(transformClipDisplayLayout({ composition, clip, transform, bounds, isCropping: false })).toEqual({
+      left: 90,
+      top: 47,
+      width: 560,
+      height: 216,
+    });
+    expect(transformClipDisplayLayout({ composition, clip, transform, bounds, isCropping: true })).toEqual({
+      left: 10,
+      top: -25,
+      width: 800,
+      height: 360,
+    });
+  });
+
+  it('uses fallback dimensions for a missing visual asset and the fixed phone or desktop crop layout', () => {
+    const missingAsset = visual({ cameraFramingPreset: 'fit' });
+    expect(
+      transformClipDisplayLayout({
+        composition: compositionFor(),
+        clip: missingAsset,
+        transform,
+        bounds,
+        isCropping: false,
+      }),
+    ).toEqual({ left: 90, top: -25, width: 640, height: 360 });
+
+    const phone = visual({
+      appearance: { ...createDefaultClipAppearance('image'), frame: 'iphone-16-max' },
+    });
+    expect(
+      transformClipDisplayLayout({
+        composition: compositionFor([asset()]),
+        clip: phone,
+        transform,
+        bounds,
+        isCropping: true,
+      }),
+    ).toEqual({ left: 170, top: -25, width: 480, height: 360 });
+
+    const desktop = visual({
+      appearance: { ...createDefaultClipAppearance('image'), frame: 'safari' },
+    });
+    const layout = {
+      x: bounds.dx + transform.x * bounds.dw,
+      y: bounds.dy + transform.y * bounds.dh,
+      width: transform.width * bounds.dw,
+      height: transform.height * bounds.dh,
+    };
+    const content = frameContentRect(layout, 'safari', {
+      showMenu: true,
+      showScrollbars: true,
+      chromeScale: 1,
+    });
+    const expected = projectCameraRect(bounds, {
+      left: content.x,
+      top: content.y,
+      width: content.width,
+      height: content.height,
+    });
+    expect(
+      transformClipDisplayLayout({
+        composition: compositionFor([asset(null, null)]),
+        clip: desktop,
+        transform,
+        bounds,
+        isCropping: true,
+      }),
+    ).toEqual(expected);
+  });
+
+  it('keeps webcam crop display and crop editing on their respective rectangles', () => {
+    const clip: VisualClip = { ...visual(), kind: 'webcam', appearance: createDefaultClipAppearance('webcam') };
+    const composition = compositionFor([asset(320, 240)]);
+
+    const display = transformClipDisplayLayout({ composition, clip, transform, bounds, isCropping: false });
+    expect(display.left).toBeCloseTo(430, 10);
+    expect(display.top).toBeCloseTo(218, 10);
+    expect(display.width).toBeCloseTo(140, 10);
+    expect(display.height).toBeCloseTo(54, 10);
+
+    const editing = transformClipDisplayLayout({ composition, clip, transform, bounds, isCropping: true });
+    expect(editing.left).toBeCloseTo(410, 10);
+    expect(editing.top).toBeCloseTo(200, 10);
+    expect(editing.width).toBeCloseTo(200, 10);
+    expect(editing.height).toBeCloseTo(90, 10);
+  });
+
+  it('projects global nonvisual layers and leaves captions in their own coordinates', () => {
+    const color: ColorClip = {
+      id: 'color',
+      kind: 'color',
+      name: 'Color',
+      assetId: '',
+      timelineStartMs: 0,
+      timelineDurationMs: 1_000,
+      sourceInMs: 0,
+      sourceDurationMs: 1_000,
+      playbackRate: 1,
+      enabled: true,
+      order: 0,
+      transform: { x: 0.2, y: 0.3, width: 0.4, height: 0.2 },
+      fill: { kind: 'color', color: '#fff' },
+    };
+    const blur: BlurClip = {
+      id: 'blur',
+      kind: 'blur',
+      name: 'Blur',
+      assetId: '',
+      timelineStartMs: 0,
+      timelineDurationMs: 1_000,
+      sourceInMs: 0,
+      sourceDurationMs: 1_000,
+      playbackRate: 1,
+      enabled: true,
+      order: 0,
+      transform: { x: 0.2, y: 0.3, width: 0.4, height: 0.25 },
+      shape: 'circle',
+      mode: 'blur',
+      strength: 50,
+      feather: 0,
+      cornerRadius: 0,
+      tintOpacity: 0,
+      color: '#000',
+    };
+    const caption: CaptionClip = {
+      id: 'caption',
+      kind: 'caption',
+      name: 'Caption',
+      timelineStartMs: 0,
+      timelineDurationMs: 1_000,
+      sourceInMs: 0,
+      sourceDurationMs: 1_000,
+      playbackRate: 1,
+      enabled: true,
+      order: 0,
+      transform: { x: 0.1, y: 0.2, width: 0.3, height: 0.1 },
+      caption: { type: 'text', sentences: [], style: createDefaultCaptionStyle() },
+    };
+
+    expect(
+      transformClipDisplayLayout({
+        composition: compositionFor(),
+        clip: color,
+        transform: color.transform,
+        bounds,
+        isCropping: false,
+      }),
+    ).toEqual({
+      left: -70,
+      top: 65,
+      width: 640,
+      height: 180,
+    });
+    expect(
+      transformClipDisplayLayout({
+        composition: compositionFor(),
+        clip: blur,
+        transform: blur.transform,
+        bounds,
+        isCropping: false,
+      }),
+    ).toEqual({
+      left: 137.5,
+      top: 65,
+      width: 225,
+      height: 225,
+    });
+    expect(
+      transformClipDisplayLayout({
+        composition: compositionFor(),
+        clip: caption,
+        transform: caption.transform!,
+        bounds,
+        isCropping: false,
+      }),
+    ).toEqual({
+      left: 90,
+      top: 110,
+      width: 240,
+      height: 45,
+    });
+  });
+});

--- a/src/components/video-editor/canvas/composables/tests/useCameraZoom.test.ts
+++ b/src/components/video-editor/canvas/composables/tests/useCameraZoom.test.ts
@@ -353,7 +353,10 @@ describe('useCameraZoom', () => {
 
     expect(drawDecoratedMedia).toHaveBeenLastCalledWith(
       expect.anything(),
-      expect.objectContaining({ rect: { x: 200, y: 90, width: 400, height: 225 } }),
+      expect.objectContaining({
+        sourceRect: { x: 128, y: 72, width: 1024, height: 576 },
+        rect: { x: 240, y: 112.5, width: 320, height: 180 },
+      }),
     );
   });
 
@@ -506,7 +509,10 @@ describe('useCameraZoom', () => {
     expect(createEvaluator).toHaveBeenCalledTimes(evaluatorCount);
     expect(drawDecoratedMedia).toHaveBeenLastCalledWith(
       expect.anything(),
-      expect.objectContaining({ rect: { x: 80, y: 67.5, width: 560, height: 270 } }),
+      expect.objectContaining({
+        sourceRect: { x: 128, y: 72, width: 1024, height: 576 },
+        rect: { x: 136, y: 94.5, width: 448, height: 216 },
+      }),
     );
   });
 
@@ -839,6 +845,8 @@ describe('useCameraZoom', () => {
   it('selects screen or canvas targets and exposes camera-space drawing/reset', () => {
     mountComposable();
     const ctx = context();
+    Object.defineProperty(options.canvas, 'clientWidth', { configurable: true, value: 800 });
+    Object.defineProperty(options.canvas, 'clientHeight', { configurable: true, value: 450 });
     state.drawVideoWindow(ctx, 800, 450, frame());
     options.selected.value = null;
     const pointer = (x: number, y: number, pointerId: number) =>

--- a/src/components/video-editor/canvas/composables/tests/useCompositionMedia.test.ts
+++ b/src/components/video-editor/canvas/composables/tests/useCompositionMedia.test.ts
@@ -774,11 +774,66 @@ describe('useCompositionMedia', () => {
     });
     mounted.selected.value = mounted.compositionRef.value.clips.find((clip) => clip.id === 'image') as VisualClip;
     mounted.draft.value = { x: 0.4, y: 0.4, width: 0.2, height: 0.2 };
+    mounted.cropping.value = true;
     await nextTick();
     state.drawComposition(context(), { dx: 0, dy: 0, dw: 800, dh: 400 }, 'image');
     expect(drawDecoratedMedia).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ rect: { x: 320, y: 160, width: 160, height: 80 } }),
+      expect.objectContaining({
+        sourceRect: { x: 0, y: 0, width: 100, height: 80 },
+        rect: { x: 320, y: 160, width: 160, height: 80 },
+      }),
+    );
+  });
+
+  it('keeps a committed bottom crop at the source scale while reopening its full editing layout', async () => {
+    const mounted = mountComposable();
+    const image = state.images.get('image-asset')!;
+    Object.defineProperties(image, {
+      complete: { configurable: true, value: true },
+      naturalWidth: { configurable: true, value: 100 },
+      naturalHeight: { configurable: true, value: 80 },
+    });
+    const clip = mounted.compositionRef.value.clips.find((entry) => entry.id === 'image') as VisualClip;
+    clip.crop = { x: 0, y: 0.75, width: 1, height: 0.25 };
+    clip.isMirrored = false;
+    clip.isMirroredY = false;
+    mounted.selected.value = clip;
+    await nextTick();
+
+    const bounds = { dx: 0, dy: 0, dw: 800, dh: 400 };
+    const render = () => {
+      drawDecoratedMedia.mockClear();
+      state.drawComposition(context(), bounds, clip.id);
+      return drawDecoratedMedia.mock.calls.at(-1)?.[1] as {
+        rect: { x: number; y: number; width: number; height: number };
+        sourceRect?: { x: number; y: number; width: number; height: number };
+      };
+    };
+
+    expect(render()).toEqual(
+      expect.objectContaining({
+        sourceRect: { x: 0, y: 60, width: 100, height: 20 },
+        rect: { x: 80, y: 200, width: 400, height: 40 },
+      }),
+    );
+
+    mounted.cropping.value = true;
+    await nextTick();
+    expect(render()).toEqual(
+      expect.objectContaining({
+        sourceRect: { x: 0, y: 0, width: 100, height: 80 },
+        rect: { x: 80, y: 80, width: 400, height: 160 },
+      }),
+    );
+
+    mounted.cropping.value = false;
+    await nextTick();
+    expect(render()).toEqual(
+      expect.objectContaining({
+        sourceRect: { x: 0, y: 60, width: 100, height: 20 },
+        rect: { x: 80, y: 200, width: 400, height: 40 },
+      }),
     );
   });
 });

--- a/src/components/video-editor/canvas/composables/tests/useLayerTransformAndCrop.test.ts
+++ b/src/components/video-editor/canvas/composables/tests/useLayerTransformAndCrop.test.ts
@@ -1,7 +1,8 @@
 import { defineComponent, h, nextTick, ref } from 'vue';
 import { mount, type VueWrapper } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { useLayerTransformAndCrop, type UseLayerTransformAndCropOptions } from '../useLayerTransformAndCrop';
+import { useLayerTransformAndCrop } from '../useLayerTransformAndCrop';
+import type { UseLayerTransformAndCropOptions } from '../layer-transform-and-crop-types';
 import type {
   BlurClip,
   CaptionClip,
@@ -299,10 +300,10 @@ describe('useLayerTransformAndCrop', () => {
     mounted.selectedRef.value = imageClip();
     await nextTick();
     expect(mounted.state.transformHandleStyle.value).toMatchObject({
-      left: '0px',
-      top: '-45px',
-      width: '800px',
-      height: '360px',
+      left: '80px',
+      top: '27px',
+      width: '560px',
+      height: '216px',
     });
     expect(mounted.state.transformSelectionViewportStyle.value).toEqual({
       left: '10px',
@@ -319,14 +320,20 @@ describe('useLayerTransformAndCrop', () => {
     mounted.selectedRef.value = video;
     await nextTick();
     expect(mounted.state.transformHandleStyle.value).toMatchObject({
+      left: '80px',
+      top: '27px',
+      width: '560px',
+      height: '216px',
+    });
+
+    mounted.croppingRef.value = true;
+    await nextTick();
+    expect(mounted.state.transformHandleStyle.value).toMatchObject({
       left: '0px',
       top: '-45px',
       width: '800px',
       height: '360px',
     });
-
-    mounted.croppingRef.value = true;
-    await nextTick();
     expect(mounted.state.cropContainerStyle.value).toMatchObject({
       left: '10px',
       top: '-25px',
@@ -350,6 +357,61 @@ describe('useLayerTransformAndCrop', () => {
     mounted.selectedBounds.value = null;
     await nextTick();
     expect(mounted.state.transformHandleStyle.value).toEqual({ display: 'none' });
+  });
+
+  it('keeps an applied bottom crop positioned at source scale when crop mode is reopened', async () => {
+    const clip = imageClip();
+    const bottomCrop = { x: 0, y: 0.75, width: 1, height: 0.25 };
+    clip.crop = bottomCrop;
+    const scene = composition();
+    scene.clips = [screenClip(), clip];
+    const mounted = mountComposable(clip, true, scene);
+
+    expect(mounted.state.transformHandleStyle.value).toMatchObject({
+      left: '0px',
+      top: '-45px',
+      width: '800px',
+      height: '360px',
+    });
+    expect(mounted.state.cropContainerStyle.value).toEqual({
+      left: '10px',
+      top: '-25px',
+      width: '800px',
+      height: '360px',
+    });
+    expect(mounted.state.cropOverlayStyle.value).toEqual({
+      left: '0%',
+      top: '75%',
+      width: '100%',
+      height: '25%',
+    });
+
+    mounted.state.commitCrop();
+    expect(mounted.options.onUpdateCrop).toHaveBeenCalledWith(bottomCrop);
+
+    mounted.croppingRef.value = false;
+    await nextTick();
+    expect(mounted.state.transformHandleStyle.value).toMatchObject({
+      left: '0px',
+      top: '225px',
+      width: '800px',
+      height: '90px',
+    });
+
+    mounted.croppingRef.value = true;
+    await nextTick();
+    expect(mounted.state.cropContainerStyle.value).toEqual({
+      left: '10px',
+      top: '-25px',
+      width: '800px',
+      height: '360px',
+    });
+    expect(mounted.state.cropOverlayStyle.value).toEqual({
+      left: '0%',
+      top: '75%',
+      width: '100%',
+      height: '25%',
+    });
   });
 
   it('exposes a projected bbox, corners and all eight anchors for tilted selections while preserving the 2D path', async () => {

--- a/src/components/video-editor/canvas/composables/tests/webcam-transform-editing.test.ts
+++ b/src/components/video-editor/canvas/composables/tests/webcam-transform-editing.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import type { ClipComposition, NormalizedTransform, VisualClip } from '~/media/shared/composition-types';
+import { createDefaultClipAppearance } from '~/media/shared/composition-defaults';
+import type { VideoWindowBounds } from '../useCameraZoom';
+import {
+  clampEditedWebcamTransform,
+  editableWebcamTransform,
+  webcamDisplayLayout,
+  webcamResizePointerScale,
+} from '../webcam-transform-editing';
+
+const transform: NormalizedTransform = { x: 0.1, y: 0.2, width: 0.4, height: 0.3 };
+const crop = { x: 0.1, y: 0.1, width: 0.8, height: 0.8 };
+const bounds: VideoWindowBounds = { dx: 10, dy: 20, dw: 1_000, dh: 800, scale: 1 };
+
+const compositionFor = (assets: ClipComposition['assets'] = []): ClipComposition => ({
+  schemaVersion: 6,
+  keyboardCaptionSessions: [],
+  assets,
+  clips: [],
+});
+
+const asset = (width: number | null = 320, height: number | null = 240) => ({
+  id: 'webcam-asset',
+  kind: 'video' as const,
+  name: 'Webcam',
+  fileName: 'webcam.mp4',
+  durationMs: 1_000,
+  width,
+  height,
+  src: 'webcam.mp4',
+  origin: 'session' as const,
+});
+
+const webcam = (overrides: Partial<VisualClip> = {}): VisualClip => ({
+  id: 'webcam',
+  kind: 'webcam',
+  name: 'Webcam',
+  assetId: 'webcam-asset',
+  timelineStartMs: 0,
+  timelineDurationMs: 1_000,
+  sourceInMs: 0,
+  sourceDurationMs: 1_000,
+  playbackRate: 1,
+  enabled: true,
+  order: 0,
+  transform,
+  crop,
+  appearance: createDefaultClipAppearance('webcam'),
+  isMirrored: false,
+  isMirroredY: false,
+  cameraLayoutPreset: 'custom',
+  ...overrides,
+});
+
+describe('webcam transform editing helpers', () => {
+  it('shrinks regular custom crops while keeping a phone frame opening fixed', () => {
+    const composition = compositionFor([asset()]);
+    const regular = webcam();
+    const phone = webcam({ appearance: { ...regular.appearance, frame: 'iphone-16-max' } });
+
+    expect(webcamDisplayLayout(composition, regular, bounds, transform, 'custom')).toEqual({
+      left: 150,
+      top: 204,
+      width: 320,
+      height: 192,
+    });
+    expect(webcamDisplayLayout(composition, phone, bounds, transform, 'custom')).toEqual({
+      left: 110,
+      top: 180,
+      width: 400,
+      height: 240,
+    });
+  });
+
+  it.each([[[]], [[asset(null, null)]]])(
+    'uses layout dimensions when the webcam asset or its dimensions are missing',
+    (assets) => {
+      const clip = webcam({ cameraFramingPreset: 'fit' });
+      const composition = compositionFor(assets);
+
+      expect(webcamDisplayLayout(composition, clip, bounds, transform, 'fit')).toEqual({
+        left: 110,
+        top: 180,
+        width: 400,
+        height: 240,
+      });
+      const normalized = editableWebcamTransform(composition, clip, bounds, transform);
+      expect(normalized.x).toBeCloseTo(0.15, 10);
+      expect(normalized.y).toBeCloseTo(0.2, 10);
+      expect(normalized.width).toBeCloseTo(0.3, 10);
+      expect(normalized.height).toBeCloseTo(0.3, 10);
+    },
+  );
+
+  it('uses custom framing when the persisted framing preset is omitted', () => {
+    const clip = webcam({ cameraFramingPreset: undefined });
+    const malformed = { x: 1.2, y: -0.2, width: 1.5, height: 0.01 };
+
+    expect(editableWebcamTransform(compositionFor([asset()]), clip, bounds, malformed)).toEqual({
+      x: 0,
+      y: 0,
+      width: 1,
+      height: 0.02,
+    });
+  });
+
+  it('uses zoom reaction settings for pointer scaling and visible-bound clamping', () => {
+    const reacting = webcam({ cameraLayoutPreset: 'custom' });
+    const fixed = webcam({ cameraLayoutPreset: 'split-left' });
+    const malformed = { x: -1, y: -1, width: 0.5, height: 0.5 };
+
+    expect(webcamResizePointerScale(reacting, 2)).toBeCloseTo(0.5);
+    expect(webcamResizePointerScale(fixed, 2)).toBe(1);
+    expect(clampEditedWebcamTransform(reacting, malformed, 2)).toEqual({
+      x: -0.25,
+      y: -0.25,
+      width: 0.5,
+      height: 0.5,
+    });
+    expect(clampEditedWebcamTransform(fixed, malformed, 2)).toEqual({
+      x: 0,
+      y: 0,
+      width: 0.5,
+      height: 0.5,
+    });
+  });
+});

--- a/src/components/video-editor/canvas/composables/useLayerTransformAndCrop.ts
+++ b/src/components/video-editor/canvas/composables/useLayerTransformAndCrop.ts
@@ -1,6 +1,5 @@
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
 import type { ResizeCorner } from '~/ui/ResizeHandle/types';
-import type { VideoWindowBounds } from './useCameraZoom';
 import { activeClipsAt, sourceTimeAt } from '~/media/shared';
 import {
   getCaptionTransform,
@@ -8,7 +7,6 @@ import {
   isColorClip,
   isShapeClip,
   isVisualClip,
-  type ClipComposition,
   type CaptionClip,
   type NormalizedCrop,
   type NormalizedTransform,
@@ -19,9 +17,8 @@ import {
   captionTextAt,
   isCaptionWrapEnabled,
   layoutCaptionText,
-  type CaptionTextMeasurer,
 } from '~/media/shared/caption-text-layout';
-import type { OutputCanvasSettings } from '../output-canvas';
+import type { UseLayerTransformAndCropOptions } from './layer-transform-and-crop-types';
 
 import { computeCanvasAlignmentSnapping, type AlignmentGuide } from './canvas-alignment';
 import { clampNormalizedCrop, mirrorCrop } from './layer-transform-geometry';
@@ -35,26 +32,12 @@ import {
 import { topmostClipIdAtPoint } from './layer-hit-testing';
 import { transformClipDisplayLayout } from './layer-display-layout';
 import { layerSelectionPresentation, perspectivePointerDelta } from './layer-selection-presentation';
+import { resizeCroppedLayer } from './cropped-layer-resize';
 
 const TRANSFORM_MIN = -3;
 const TRANSFORM_MAX = 3;
 const SIZE_MAX = 4;
 type GlobalCameraClip = Exclude<TransformClip, CaptionClip>;
-
-export interface UseLayerTransformAndCropOptions {
-  composition: () => ClipComposition;
-  currentTime: () => number;
-  selectedTransformClip: () => TransformClip | null;
-  videoWindowBounds: () => VideoWindowBounds | null;
-  overlayWindowBounds: () => VideoWindowBounds | null;
-  isCropping: () => boolean | undefined;
-  outputCanvas: () => OutputCanvasSettings;
-  measureCaptionText?: CaptionTextMeasurer;
-  zoomScale?: () => number;
-  onUpdateTransform: (transform: NormalizedTransform) => void;
-  onUpdateCrop: (crop: NormalizedCrop) => void;
-  onSelectTransformClip: (clipId: string) => void;
-}
 
 export function useLayerTransformAndCrop(options: UseLayerTransformAndCropOptions) {
   const transformDraft = ref<NormalizedTransform | null>(null);
@@ -402,7 +385,10 @@ export function useLayerTransformAndCrop(options: UseLayerTransformAndCropOption
       width,
       height,
     };
-    transformDraft.value = clip.kind === 'webcam' ? clampEditedWebcamTransform(clip, resized, bounds.scale) : resized;
+    const cropped = isVisualClip(clip)
+      ? resizeCroppedLayer(clip, initial, resized, transformDrag.corner, corner && preserveAspect)
+      : resized;
+    transformDraft.value = clip.kind === 'webcam' ? clampEditedWebcamTransform(clip, cropped, bounds.scale) : cropped;
   };
 
   const moveTransformDrag = (event: PointerEvent) => {

--- a/src/components/video-editor/canvas/composables/webcam-transform-editing.ts
+++ b/src/components/video-editor/canvas/composables/webcam-transform-editing.ts
@@ -10,6 +10,7 @@ import {
   webcamSettingsForAppearance,
 } from '../../composition/webcam/webcam-zoom';
 import { resolveCameraFraming } from '../../composition/camera-layout';
+import { isPhoneFrame } from '../../composition/appearance/phone-frames';
 
 export function webcamDisplayLayout(
   composition: ClipComposition,
@@ -35,12 +36,15 @@ export function webcamDisplayLayout(
     asset?.width ?? layout.width,
     asset?.height ?? layout.height,
     clip.crop,
+    clip.isMirrored,
+    clip.isMirroredY,
   );
+  const rect = framingPreset === 'custom' && isPhoneFrame(clip.appearance.frame) ? layout : framing.rect;
   return {
-    left: bounds.dx + framing.rect.x,
-    top: bounds.dy + framing.rect.y,
-    width: framing.rect.width,
-    height: framing.rect.height,
+    left: bounds.dx + rect.x,
+    top: bounds.dy + rect.y,
+    width: rect.width,
+    height: rect.height,
   };
 }
 

--- a/src/components/video-editor/composition/camera-layout.test.ts
+++ b/src/components/video-editor/composition/camera-layout.test.ts
@@ -154,6 +154,152 @@ describe('camera layout geometry', () => {
     });
   });
 
+  it.each([
+    [false, false, { x: 180, y: 320 }],
+    [true, false, { x: 420, y: 320 }],
+    [false, true, { x: 180, y: 530 }],
+    [true, true, { x: 420, y: 530 }],
+  ] as const)(
+    'projects a custom crop into its destination bounds with mirrorX=%s and mirrorY=%s',
+    (mirrorX, mirrorY, origin) => {
+      const bounds = { x: 100, y: 200, width: 800, height: 600 };
+      const crop: NormalizedCrop = { x: 0.1, y: 0.2, width: 0.5, height: 0.25 };
+      const framing = resolveCameraFraming('custom', bounds, 2_000, 1_000, crop, mirrorX, mirrorY);
+
+      expectRectToMatch(framing.rect, { ...origin, width: 400, height: 150 });
+      expect(framing.sourceRect).toEqual({ x: 200, y: 200, width: 1_000, height: 250 });
+      expect(framing.circular).toBe(false);
+    },
+  );
+
+  it('keeps a bottom strip as a destination slice and the complete source crop', () => {
+    const bounds = { x: 80, y: 40, width: 640, height: 360 };
+    const crop: NormalizedCrop = { x: 0, y: 0.75, width: 1, height: 0.25 };
+    const framing = resolveCameraFraming('custom', bounds, 1_920, 1_080, crop);
+
+    expectRectToMatch(framing.rect, { x: 80, y: 310, width: 640, height: 90 });
+    expect(framing.sourceRect).toEqual({ x: 0, y: 810, width: 1_920, height: 270 });
+  });
+
+  it('keeps custom framing unzoomed for no crop and a full crop', () => {
+    const bounds = { x: 160, y: 60, width: 480, height: 300 };
+    const clip = { transform: { x: 0.2, y: 0.1, width: 0.6, height: 0.5 } } as VisualClip;
+    const fullSource = { x: 0, y: 0, width: 1_920, height: 1_080 };
+    const noCrop = resolveScreenRenderGeometry(
+      clip,
+      1_920,
+      1_080,
+      800,
+      600,
+      false,
+      clip.transform,
+      undefined,
+      'custom',
+    );
+    const fullCrop = resolveScreenRenderGeometry(
+      clip,
+      1_920,
+      1_080,
+      800,
+      600,
+      false,
+      clip.transform,
+      { x: 0, y: 0, width: 1, height: 1 },
+      'custom',
+    );
+
+    expect(noCrop.source).toEqual(fullSource);
+    expect(fullCrop.source).toEqual(fullSource);
+    expectRectToMatch(noCrop.positioned, bounds);
+    expectRectToMatch(fullCrop.positioned, bounds);
+    expectRectToMatch(noCrop.media, { x: 0, y: 0, width: 800, height: 600 });
+    expectRectToMatch(fullCrop.media, { x: 0, y: 0, width: 800, height: 600 });
+  });
+
+  it.each([false, true] as const)(
+    'projects a custom crop within uncropped media geometry when showBackground=%s',
+    (showBackground) => {
+      const sourceWidth = 1_920;
+      const sourceHeight = 1_080;
+      const canvasWidth = 800;
+      const canvasHeight = 600;
+      const transform = { x: 0.2, y: 0.1, width: 0.6, height: 0.5 };
+      const crop: NormalizedCrop = { x: 0.25, y: 0.125, width: 0.5, height: 0.75 };
+      const clip = { transform, isMirrored: false, isMirroredY: false } as VisualClip;
+      const geometry = resolveScreenRenderGeometry(
+        clip,
+        sourceWidth,
+        sourceHeight,
+        canvasWidth,
+        canvasHeight,
+        showBackground,
+        transform,
+        crop,
+        'custom',
+      );
+
+      expect(geometry.source).toEqual({ x: 480, y: 135, width: 960, height: 810 });
+      if (showBackground) {
+        expectRectToMatch(geometry.media, { x: 56, y: 106.5, width: 688, height: 387 });
+        expectRectToMatch(geometry.positioned, { x: 296.8, y: 169.3875, width: 206.4, height: 145.125 });
+      } else {
+        expectRectToMatch(geometry.media, { x: 0, y: 0, width: 800, height: 600 });
+        expectRectToMatch(geometry.positioned, { x: 280, y: 97.5, width: 240, height: 225 });
+      }
+    },
+  );
+
+  it.each([false, true] as const)(
+    'preserves source point scale when a custom crop is projected with showBackground=%s',
+    (showBackground) => {
+      const sourceWidth = 1_920;
+      const sourceHeight = 1_080;
+      const canvasWidth = 800;
+      const canvasHeight = 600;
+      const transform = { x: 0.2, y: 0.1, width: 0.6, height: 0.5 };
+      const clip = { transform } as VisualClip;
+      const crop: NormalizedCrop = { x: 0.25, y: 0.125, width: 0.5, height: 0.75 };
+      const uncropped = resolveScreenRenderGeometry(
+        clip,
+        sourceWidth,
+        sourceHeight,
+        canvasWidth,
+        canvasHeight,
+        showBackground,
+        transform,
+        undefined,
+        'custom',
+      );
+      const cropped = resolveScreenRenderGeometry(
+        clip,
+        sourceWidth,
+        sourceHeight,
+        canvasWidth,
+        canvasHeight,
+        showBackground,
+        transform,
+        crop,
+        'custom',
+      );
+      const point = { cx: 0.375, cy: 0.2 };
+      const uncroppedPoint = mapSourcePointToScreen(
+        point,
+        sourceWidth,
+        sourceHeight,
+        canvasWidth,
+        canvasHeight,
+        uncropped,
+      );
+      const croppedPoint = mapSourcePointToScreen(point, sourceWidth, sourceHeight, canvasWidth, canvasHeight, cropped);
+
+      expect(croppedPoint.cx).toBeCloseTo(uncroppedPoint.cx, 10);
+      expect(croppedPoint.cy).toBeCloseTo(uncroppedPoint.cy, 10);
+      const expectedPoint = showBackground ? { cx: 0.4355, cy: 0.3065 } : { cx: 0.425, cy: 0.2 };
+      expect(croppedPoint.cx).toBeCloseTo(expectedPoint.cx, 10);
+      expect(croppedPoint.cy).toBeCloseTo(expectedPoint.cy, 10);
+    },
+  );
+
   it('keeps a screen squircle in the full transform box while preserving its resized ratio', () => {
     const transform = { x: 0.2, y: 0.1, width: 0.6, height: 0.5 };
     const clip = { transform, cameraFramingPreset: 'squircle' } as VisualClip;
@@ -185,13 +331,13 @@ describe('camera layout geometry', () => {
       const crop: NormalizedCrop = { x: 0.25, y: 0.125, width: 0.5, height: 0.75 };
       const geometry = resolveScreenRenderGeometry(clip, 1920, 1080, 1920, 1080, false, transform, crop);
 
-      expect(geometry.source).toEqual({ x: 480, y: 270, width: 960, height: 540 });
+      expect(geometry.source).toEqual({ x: 480, y: 135, width: 960, height: 810 });
       expectRectToMatch(geometry.media, { x: 0, y: 0, width: 1920, height: 1080 });
       expectRectToMatch(geometry.positioned, {
-        x: transform.x * 1920,
-        y: transform.y * 1080,
-        width: transform.width * 1920,
-        height: transform.height * 1080,
+        x: transform.x * 1920 + crop.x * transform.width * 1920,
+        y: transform.y * 1080 + crop.y * transform.height * 1080,
+        width: transform.width * crop.width * 1920,
+        height: transform.height * crop.height * 1080,
       });
 
       const mappedCenter = mapSourcePointToScreen({ cx: 0.5, cy: 0.5 }, 1920, 1080, 1920, 1080, geometry);
@@ -207,6 +353,6 @@ describe('camera layout geometry', () => {
     const geometry = resolveScreenRenderGeometry(clip, 1920, 1080, 1920, 1080, false, transform, crop);
     const mapped = mapSourcePointToScreen({ cx: 0.25, cy: 0.5 }, 1920, 1080, 1920, 1080, geometry);
 
-    expect(mapped).toEqual({ cx: 0.5, cy: 0.5 });
+    expect(mapped).toEqual({ cx: 0.625, cy: 0.5 });
   });
 });

--- a/src/components/video-editor/composition/camera-layout.ts
+++ b/src/components/video-editor/composition/camera-layout.ts
@@ -1,6 +1,7 @@
 import type { CameraFramingPreset, CameraLayoutPreset } from '~/media/shared/camera-layout-types';
 import type { NormalizedCrop, NormalizedTransform, VisualClip } from '~/media/shared/composition-types';
 import { containedMediaRect, coverSourceRect, framedMediaRect, type CanvasRect } from '../canvas/output-canvas';
+import { isPhoneFrame } from './appearance/phone-frames';
 
 const FLOATING_MARGIN = 0.04;
 const FLOATING_SIZE = 0.28;
@@ -104,11 +105,21 @@ export function resolveCameraFraming(
   sourceWidth: number,
   sourceHeight: number,
   manualCrop?: NormalizedCrop,
+  mirrored = false,
+  mirroredY = false,
 ): CameraFramingGeometry {
   const safeWidth = Math.max(1, sourceWidth);
   const safeHeight = Math.max(1, sourceHeight);
   if (preset === 'custom') {
-    return { rect: bounds, sourceRect: cropRect(manualCrop, safeWidth, safeHeight), circular: false };
+    const rect = manualCrop
+      ? {
+          x: bounds.x + (mirrored ? 1 - manualCrop.x - manualCrop.width : manualCrop.x) * bounds.width,
+          y: bounds.y + (mirroredY ? 1 - manualCrop.y - manualCrop.height : manualCrop.y) * bounds.height,
+          width: bounds.width * manualCrop.width,
+          height: bounds.height * manualCrop.height,
+        }
+      : bounds;
+    return { rect, sourceRect: cropRect(manualCrop, safeWidth, safeHeight), circular: false };
   }
   if (preset === 'fit') {
     const fit = containedMediaRect(safeWidth, safeHeight, bounds.width, bounds.height);
@@ -152,6 +163,31 @@ export function resolveScreenRenderGeometry(
   crop = clip.crop,
   framingPreset = clip.cameraFramingPreset ?? 'custom',
 ): ScreenRenderGeometry {
+  const media = showBackground
+    ? framedMediaRect(sourceWidth, sourceHeight, canvasWidth, canvasHeight)
+    : { x: 0, y: 0, width: canvasWidth, height: canvasHeight };
+  const layout = {
+    x: media.x + transform.x * media.width,
+    y: media.y + transform.y * media.height,
+    width: media.width * transform.width,
+    height: media.height * transform.height,
+  };
+  if (framingPreset === 'custom') {
+    const framing = resolveCameraFraming(
+      'custom',
+      layout,
+      sourceWidth,
+      sourceHeight,
+      crop,
+      clip.isMirrored,
+      clip.isMirroredY,
+    );
+    return {
+      source: framing.sourceRect ?? { x: 0, y: 0, width: sourceWidth, height: sourceHeight },
+      media,
+      positioned: clip.appearance && isPhoneFrame(clip.appearance.frame) ? layout : framing.rect,
+    };
+  }
   const cropX = crop ? crop.x * sourceWidth : 0;
   const cropY = crop ? crop.y * sourceHeight : 0;
   const cropWidth = crop ? crop.width * sourceWidth : sourceWidth;
@@ -163,16 +199,6 @@ export function resolveScreenRenderGeometry(
     source.x += cropX;
     source.y += cropY;
   }
-  const media = showBackground
-    ? framedMediaRect(cropWidth, cropHeight, canvasWidth, canvasHeight)
-    : { x: 0, y: 0, width: canvasWidth, height: canvasHeight };
-  const layout = {
-    x: media.x + transform.x * media.width,
-    y: media.y + transform.y * media.height,
-    width: media.width * transform.width,
-    height: media.height * transform.height,
-  };
-  if (framingPreset === 'custom') return { source, media, positioned: layout };
   const flexibleSquircle = framingPreset === 'squircle' && clip.kind !== 'webcam';
   const framing = resolveCameraFraming(flexibleSquircle ? 'fill' : framingPreset, layout, source.width, source.height);
   const framedSource = framing.sourceRect

--- a/src/components/video-editor/composition/tests/webcam-zoom.test.ts
+++ b/src/components/video-editor/composition/tests/webcam-zoom.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   computeWebcamLayout,
   drawWebcamOverlay,
@@ -7,6 +7,10 @@ import {
   webcamSettingsForAppearance,
 } from '../webcam/webcam-zoom';
 import { resolveCameraFraming } from '../camera-layout';
+import { createDefaultClipAppearance } from '~/media/shared/composition-defaults';
+import * as renderDecoratedMedia from '../appearance/render-decorated-media';
+
+afterEach(() => vi.restoreAllMocks());
 
 const context = () =>
   ({
@@ -211,7 +215,40 @@ describe('webcam zoom layout', () => {
       { x: 0.1, y: 0.2, width: 0.4, height: 0.3 },
       { x: 0.1, y: 0.1, width: 0.8, height: 0.8 },
     );
-    expect(ctx.drawImage).toHaveBeenCalledWith(source, 32, 24, 256, 192, 100, 160, 400, 240);
+    expect(ctx.drawImage).toHaveBeenCalledWith(source, 32, 24, 256, 192, 140, 184, 320, 192);
     expect(ctx.scale).toHaveBeenCalledWith(-1, -1);
+  });
+
+  it('keeps a phone frame opening fixed while applying a custom source crop', () => {
+    const ctx = context();
+    const source = {} as CanvasImageSource;
+    const appearance = { ...createDefaultClipAppearance('webcam'), frame: 'iphone-16-max' as const };
+    const settings = webcamSettingsForAppearance(appearance, false, false);
+    const drawDecoratedMedia = vi.spyOn(renderDecoratedMedia, 'drawDecoratedMedia');
+
+    drawWebcamOverlay(
+      ctx,
+      source,
+      { width: 320, height: 240 },
+      1000,
+      800,
+      1,
+      settings,
+      { x: 0.1, y: 0.2, width: 0.4, height: 0.3 },
+      { x: 0.1, y: 0.1, width: 0.8, height: 0.8 },
+      appearance,
+      'Camera',
+      1,
+      'custom',
+    );
+
+    expect(drawDecoratedMedia).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({
+        source,
+        sourceRect: { x: 32, y: 24, width: 256, height: 192 },
+        rect: { x: 100, y: 160, width: 400, height: 240 },
+      }),
+    );
   });
 });

--- a/src/components/video-editor/composition/visual-framing.test.ts
+++ b/src/components/video-editor/composition/visual-framing.test.ts
@@ -95,6 +95,108 @@ describe('editable visual framing transforms', () => {
     expect(normalized).toBe(transform);
   });
 
+  it('keeps a custom crop inside the regular visual bounds while a phone keeps its screen opening', () => {
+    const crop = { x: 0.1, y: 0.2, width: 0.5, height: 0.4 };
+    const visualBounds = { x: bounds.dx, y: bounds.dy, width: bounds.dw, height: bounds.dh };
+    const regular = clipFor('video', 'custom');
+    regular.crop = crop;
+    const regularFraming = resolveVisualClipFraming(
+      regular,
+      visualBounds,
+      source.width!,
+      source.height!,
+      crop,
+      'custom',
+    );
+
+    expectRect(regularFraming.rect, { x: 180, y: 200, width: 400, height: 240 });
+    expectRect(regularFraming.sourceRect!, { x: 192, y: 216, width: 960, height: 432 });
+
+    const phone = clipFor('video', 'custom');
+    phone.crop = crop;
+    phone.appearance = { ...phone.appearance, frame: 'iphone-16-max' };
+    const phoneFraming = resolveVisualClipFraming(phone, visualBounds, source.width!, source.height!, crop, 'custom');
+
+    expectRect(phoneFraming.rect, visualBounds);
+    expectRect(phoneFraming.sourceRect!, regularFraming.sourceRect!);
+    expect(
+      visualClipDisplayLayout(
+        phone,
+        transform,
+        { x: 0, y: 0, width: 1_000, height: 800 },
+        source.width!,
+        source.height!,
+        'custom',
+        'none',
+      ),
+    ).toEqual({ left: 200, top: 80, width: 600, height: 400 });
+
+    const content = visualClipDisplayLayout(
+      phone,
+      transform,
+      { x: 0, y: 0, width: 1_000, height: 800 },
+      source.width!,
+      source.height!,
+      'custom',
+      'content',
+    );
+    expect(content.left).toBeGreaterThan(200);
+    expect(content.top).toBeGreaterThan(80);
+    expect(content.width).toBeLessThan(600);
+    expect(content.height).toBeLessThan(400);
+  });
+
+  it('uses custom framing when the clip framing preset is omitted', () => {
+    const clip = clipFor('video', undefined);
+    const composition = createComposition([source], [clip]);
+    const visualBounds = { x: bounds.dx, y: bounds.dy, width: bounds.dw, height: bounds.dh };
+
+    expectRect(resolveVisualClipFraming(clip, visualBounds, source.width!, source.height!).rect, visualBounds);
+    expect(editableVisualClipTransform(composition, clip, transform, bounds)).toBe(transform);
+
+    const phone = { ...clip, appearance: { ...clip.appearance, frame: 'iphone-16-max' as const } };
+    const resized = resizePhoneFrameTransform(composition, phone, transform, bounds, { x: 0, y: 0 });
+    expectRect(resized, transform);
+  });
+
+  it('keeps a phone transform unchanged while editing its framing', () => {
+    const clip = clipFor('video', 'fit');
+    clip.appearance = { ...clip.appearance, frame: 'iphone-16-max' };
+    const composition = createComposition([source], [clip]);
+
+    expect(editableVisualClipTransform(composition, clip, transform, bounds)).toBe(transform);
+  });
+
+  it('falls back to the viewport dimensions when an editable visual has no asset metadata', () => {
+    const clip = clipFor('video', 'fit');
+    const composition = createComposition([source], [clip]);
+    const missingAssetClip = { ...clip, assetId: 'missing-asset' };
+
+    const normalized = editableVisualClipTransform(composition, missingAssetClip, transform, bounds);
+
+    expectRect(normalized, { x: 0.25, y: 0.1, width: 0.5, height: 0.5 });
+  });
+
+  it('mirrors the in-place custom crop destination without moving its source crop', () => {
+    const clip = clipFor('video', 'custom');
+    const crop = { x: 0.1, y: 0.2, width: 0.5, height: 0.4 };
+    clip.crop = crop;
+    clip.isMirrored = true;
+    clip.isMirroredY = true;
+
+    const framing = resolveVisualClipFraming(
+      clip,
+      { x: bounds.dx, y: bounds.dy, width: bounds.dw, height: bounds.dh },
+      source.width!,
+      source.height!,
+      crop,
+      'custom',
+    );
+
+    expectRect(framing.rect, { x: 420, y: 320, width: 400, height: 240 });
+    expectRect(framing.sourceRect!, { x: 192, y: 216, width: 960, height: 432 });
+  });
+
   it.each(['screen', 'video', 'image'] as const)(
     'uses the complete transform box and a resized squircle mask for %s',
     (kind) => {
@@ -241,4 +343,103 @@ describe('editable visual framing transforms', () => {
       expect(resized.height).toBeGreaterThan(initial.height);
     },
   );
+
+  it('leaves a non-phone resize request unchanged', () => {
+    const clip = clipFor('video', 'custom');
+    const composition = createComposition([source], [clip]);
+
+    expect(
+      resizePhoneFrameTransform(
+        composition,
+        clip,
+        transform,
+        { dx: bounds.dx, dy: bounds.dy, dw: bounds.dw, dh: bounds.dh },
+        { x: 0.1, y: 0.1 },
+        'bottom-right',
+      ),
+    ).toBe(transform);
+  });
+
+  it.each([
+    ['top', { x: 0, y: -0.05 }],
+    ['left', { x: -0.05, y: 0 }],
+    [undefined, { x: 0, y: 0 }],
+  ] as const)('handles a custom phone resize from the %s edge', (edge, delta) => {
+    const clip = clipFor('video', 'custom');
+    clip.appearance = { ...clip.appearance, frame: 'iphone-16-max' };
+    const composition = createComposition([source], [clip]);
+
+    const resized = resizePhoneFrameTransform(composition, clip, transform, bounds, delta, edge);
+
+    const viewport = { x: bounds.dx, y: bounds.dy, width: bounds.dw, height: bounds.dh };
+    const before = visualClipDisplayLayout(clip, transform, viewport, source.width!, source.height!, 'custom');
+    const after = visualClipDisplayLayout(clip, resized, viewport, source.width!, source.height!, 'custom');
+    expect(after.width / after.height).toBeCloseTo(before.width / before.height, 10);
+    if (edge === 'top') expect(after.top + after.height).toBeCloseTo(before.top + before.height, 10);
+    else if (edge === 'left') expect(after.left + after.width).toBeCloseTo(before.left + before.width, 10);
+    else expectRect(resized, transform);
+  });
+
+  it('falls back to the viewport dimensions when resizing a phone without asset metadata', () => {
+    const clip = clipFor('video', 'fit');
+    clip.appearance = { ...clip.appearance, frame: 'iphone-16-max' };
+    const composition = createComposition([source], [clip]);
+    const missingAssetClip = { ...clip, assetId: 'missing-asset' };
+
+    const resized = resizePhoneFrameTransform(composition, missingAssetClip, transform, bounds, { x: 0, y: 0 });
+
+    const explicitMetadata = createComposition([{ ...source, width: bounds.dw, height: bounds.dh }], [clip]);
+    expectRect(resized, resizePhoneFrameTransform(explicitMetadata, clip, transform, bounds, { x: 0, y: 0 }));
+  });
+
+  it.each(['iphone-16-max', 'pixel-9-pro'] as const)(
+    'resizes a cropped custom %s phone through its transform branch',
+    (frame) => {
+      const clip = clipFor('video', 'custom');
+      clip.crop = { x: 0.1, y: 0.2, width: 0.5, height: 0.4 };
+      clip.appearance = { ...clip.appearance, frame };
+      const composition = createComposition([source], [clip]);
+      const viewport = { x: 0, y: 0, width: 800, height: 450 };
+      const initial = visualClipDisplayLayout(clip, transform, viewport, source.width!, source.height!, 'custom');
+      const resizedTransform = resizePhoneFrameTransform(
+        composition,
+        clip,
+        transform,
+        { dx: viewport.x, dy: viewport.y, dw: viewport.width, dh: viewport.height },
+        { x: 0.1, y: 0.01 },
+        'right',
+      );
+      const resized = visualClipDisplayLayout(
+        clip,
+        resizedTransform,
+        viewport,
+        source.width!,
+        source.height!,
+        'custom',
+      );
+
+      expect(resized.width).toBeGreaterThan(initial.width);
+      expect(resized.height).toBeGreaterThan(initial.height);
+    },
+  );
+
+  it('contains a very tall source in a fitted phone when the height branch wins', () => {
+    const tallSource = { ...source, width: 300, height: 1_920 };
+    const clip = clipFor('video', 'fit');
+    clip.appearance = { ...clip.appearance, frame: 'iphone-16-max' };
+    const composition = createComposition([tallSource], [clip]);
+    const viewport = { x: 0, y: 0, width: 800, height: 450 };
+    const resized = resizePhoneFrameTransform(
+      composition,
+      clip,
+      transform,
+      { dx: viewport.x, dy: viewport.y, dw: viewport.width, dh: viewport.height },
+      { x: 0.01, y: 0.1 },
+      'bottom-right',
+    );
+
+    expect(resized.width).toBeGreaterThan(0);
+    expect(resized.height).toBeGreaterThan(0);
+    expect(resized.width / resized.height).toBeCloseTo(tallSource.width / tallSource.height, 10);
+  });
 });

--- a/src/components/video-editor/composition/visual-framing.ts
+++ b/src/components/video-editor/composition/visual-framing.ts
@@ -19,7 +19,17 @@ export function resolveVisualClipFraming(
       mask: 'squircle' as const,
     };
   }
-  return resolveCameraFraming(preset, bounds, sourceWidth, sourceHeight, crop);
+  const framing = resolveCameraFraming(
+    preset,
+    bounds,
+    sourceWidth,
+    sourceHeight,
+    crop,
+    clip.isMirrored,
+    clip.isMirroredY,
+  );
+  // A device frame keeps its fixed screen opening; cropping fills that opening.
+  return preset === 'custom' && isPhoneFrame(clip.appearance.frame) ? { ...framing, rect: bounds } : framing;
 }
 
 export function visualClipDisplayLayout(

--- a/src/components/video-editor/composition/webcam/webcam-zoom.ts
+++ b/src/components/video-editor/composition/webcam/webcam-zoom.ts
@@ -10,6 +10,7 @@ import { DEFAULT_CLIP_APPEARANCE, drawDecoratedMedia } from '../appearance/rende
 import type { MediaRect } from '../appearance/appearance-types';
 import type { Canvas2DContext } from '~/types/canvas';
 import { resolveCameraFraming } from '../camera-layout';
+import { isPhoneFrame } from '../appearance/phone-frames';
 
 export interface WebcamOverlaySettings {
   widthPercent: number;
@@ -191,12 +192,20 @@ export function drawWebcamOverlay(
   const layout = computeWebcamLayout(canvasWidth, canvasHeight, appliedZoomScale, settings, transform);
   const sourceWidth = sourceDimensions.width;
   const sourceHeight = sourceDimensions.height;
-  const framing = resolveCameraFraming(framingPreset, layout, sourceWidth, sourceHeight, crop);
+  const framing = resolveCameraFraming(
+    framingPreset,
+    layout,
+    sourceWidth,
+    sourceHeight,
+    crop,
+    settings.mirror,
+    settings.mirrorY,
+  );
   const sourceRect: MediaRect | undefined = framing.sourceRect;
   drawDecoratedMedia(ctx, {
     source,
     sourceRect,
-    rect: framing.rect,
+    rect: framingPreset === 'custom' && appearance && isPhoneFrame(appearance.frame) ? layout : framing.rect,
     appearance: { ...DEFAULT_CLIP_APPEARANCE, ...appearance },
     shadowScale,
     title,


### PR DESCRIPTION
Applying a manual crop stretched the selected source region back into the full clip bounds, causing an unwanted zoom. Preserve the selected region’s scale and position in preview and export, keep crop editing on the full source, and align selection and resize geometry with the visible crop. Phone frames retain their fixed screen opening.

Validation: 251 targeted tests passed across 12 files. Scoped coverage: 97.05% statements, 92.17% branches, 100% functions, 99.74% lines. Vue typecheck, scoped lint, formatting, and diff checks passed. Visual verification in the Windows application remains outstanding.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved crop editing so resizing keeps the selected crop edge anchored correctly.
  * Preserved crop positioning and scale when reopening crop mode or exporting media.
  * Fixed mirrored and vertically mirrored crop behavior.
  * Improved webcam and phone-frame layouts, including custom crops and missing media dimensions.
* **Tests**
  * Added comprehensive coverage for crop rendering, resizing, camera framing, webcam transformations, and phone-frame behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->