### PR TITLE
fix(linux): negotiate PipeWire buffer counts compatible with KWin

### DIFF
--- a/packages/capture/src/screen/linux/pipewire/params.rs
+++ b/packages/capture/src/screen/linux/pipewire/params.rs
@@ -3,7 +3,8 @@ use std::{io::Cursor, mem::size_of};
 use pipewire::{self as pw, spa};
 use spa::{
     param::{ParamType, format::MediaSubtype, format::MediaType, video::VideoInfoRaw},
-    pod::{Pod, Value},
+    pod::{ChoiceValue, Pod, Value},
+    utils::{Choice, ChoiceEnum, ChoiceFlags},
 };
 
 use crate::CaptureError;
@@ -105,10 +106,7 @@ pub(super) fn format_parameter() -> Result<Vec<u8>, CaptureError> {
     serialize_object(object)
 }
 
-pub(super) fn update_buffer_params(
-    stream: &pw::stream::Stream,
-    format: NegotiatedFormat,
-) -> Result<(), CaptureError> {
+pub(super) fn buffer_parameter(format: NegotiatedFormat) -> Result<Vec<u8>, CaptureError> {
     let stride = i32::try_from(
         format
             .width
@@ -124,7 +122,19 @@ pub(super) fn update_buffer_params(
         type_: spa::utils::SpaTypes::ObjectParamBuffers.as_raw(),
         id: ParamType::Buffers.as_raw(),
         properties: vec![
-            spa::pod::Property::new(spa::sys::SPA_PARAM_BUFFERS_buffers, Value::Int(8)),
+            // KWin offers 2–4 buffers. Eight is a preference, not a requirement;
+            // keep the existing upper bound while allowing the producer's pool.
+            spa::pod::Property::new(
+                spa::sys::SPA_PARAM_BUFFERS_buffers,
+                Value::Choice(ChoiceValue::Int(Choice(
+                    ChoiceFlags::empty(),
+                    ChoiceEnum::Range {
+                        default: 8,
+                        min: 2,
+                        max: 8,
+                    },
+                ))),
+            ),
             spa::pod::Property::new(spa::sys::SPA_PARAM_BUFFERS_blocks, Value::Int(1)),
             spa::pod::Property::new(spa::sys::SPA_PARAM_BUFFERS_size, Value::Int(size)),
             spa::pod::Property::new(spa::sys::SPA_PARAM_BUFFERS_stride, Value::Int(stride)),
@@ -134,6 +144,14 @@ pub(super) fn update_buffer_params(
             ),
         ],
     };
+    serialize_object(buffer)
+}
+
+pub(super) fn update_buffer_params(
+    stream: &pw::stream::Stream,
+    format: NegotiatedFormat,
+) -> Result<(), CaptureError> {
+    let mut bytes = vec![buffer_parameter(format)?];
     let metas = [
         (
             spa::sys::SPA_META_Header,
@@ -149,7 +167,6 @@ pub(super) fn update_buffer_params(
             size_of::<spa::sys::spa_meta_videotransform>(),
         ),
     ];
-    let mut bytes = vec![serialize_object(buffer)?];
     for (meta_type, meta_size) in metas {
         let meta = spa::pod::Object {
             type_: spa::utils::SpaTypes::ObjectParamMeta.as_raw(),

--- a/packages/capture/src/screen/linux/pipewire/tests.rs
+++ b/packages/capture/src/screen/linux/pipewire/tests.rs
@@ -37,6 +37,7 @@ fn copy_pixel(format: NativePixelFormat, bytes: &[u8]) -> Vec<u8> {
         .to_vec()
 }
 
+mod buffer_params_tests;
 mod cursor_tests;
 mod format_tests;
 mod region_tests;

--- a/packages/capture/src/screen/linux/pipewire/tests/buffer_params_tests.rs
+++ b/packages/capture/src/screen/linux/pipewire/tests/buffer_params_tests.rs
@@ -1,0 +1,254 @@
+use std::{io::Cursor, mem::MaybeUninit, ptr};
+
+use super::*;
+use pipewire::spa;
+use spa::{
+    param::ParamType,
+    pod::{
+        ChoiceValue, Object, Pod, Property, Value, deserialize::PodDeserializer,
+        serialize::PodSerializer,
+    },
+    utils::{Choice, ChoiceEnum, ChoiceFlags, SpaTypes},
+};
+
+const POD_STORAGE_SIZE: usize = 1024;
+const FILTER_STORAGE_SIZE: usize = 4096;
+
+#[repr(align(8))]
+struct AlignedBytes<const N: usize>([u8; N]);
+
+impl<const N: usize> AlignedBytes<N> {
+    fn from_bytes(bytes: &[u8]) -> Self {
+        assert!(bytes.len() <= N, "test pod is larger than aligned storage");
+        let mut aligned = Self([0; N]);
+        aligned.0[..bytes.len()].copy_from_slice(bytes);
+        aligned
+    }
+
+    fn pod(&self) -> &Pod {
+        Pod::from_bytes(&self.0).expect("aligned bytes should contain a valid pod")
+    }
+}
+
+fn serialized(value: Value) -> Vec<u8> {
+    PodSerializer::serialize(Cursor::new(Vec::new()), &value)
+        .expect("test pod should serialize")
+        .0
+        .into_inner()
+}
+
+fn choice_range(default: i32, min: i32, max: i32) -> Value {
+    Value::Choice(ChoiceValue::Int(Choice(
+        ChoiceFlags::empty(),
+        ChoiceEnum::Range { default, min, max },
+    )))
+}
+
+fn choice_flags(default: i32) -> Value {
+    Value::Choice(ChoiceValue::Int(Choice(
+        ChoiceFlags::empty(),
+        ChoiceEnum::Flags {
+            default,
+            flags: Vec::new(),
+        },
+    )))
+}
+
+fn buffers_pod(buffers: Value, data_type: Value) -> Vec<u8> {
+    serialized(Value::Object(Object {
+        type_: SpaTypes::ObjectParamBuffers.as_raw(),
+        id: ParamType::Buffers.as_raw(),
+        properties: vec![
+            Property::new(spa::sys::SPA_PARAM_BUFFERS_buffers, buffers),
+            Property::new(spa::sys::SPA_PARAM_BUFFERS_blocks, Value::Int(1)),
+            Property::new(
+                spa::sys::SPA_PARAM_BUFFERS_size,
+                Value::Int(1920 * 1080 * 4),
+            ),
+            Property::new(spa::sys::SPA_PARAM_BUFFERS_stride, Value::Int(1920 * 4)),
+            Property::new(spa::sys::SPA_PARAM_BUFFERS_dataType, data_type),
+        ],
+    }))
+}
+
+fn kwin_buffers_pod() -> Vec<u8> {
+    buffers_pod(
+        choice_range(3, 2, 4),
+        choice_flags(1_i32 << spa::sys::SPA_DATA_MemFd),
+    )
+}
+
+fn fixed_buffers_pod(count: i32) -> Vec<u8> {
+    buffers_pod(
+        Value::Int(count),
+        choice_flags(1_i32 << spa::sys::SPA_DATA_MemFd),
+    )
+}
+
+fn dma_only_buffers_pod() -> Vec<u8> {
+    buffers_pod(
+        choice_range(3, 2, 4),
+        choice_flags(1_i32 << spa::sys::SPA_DATA_DmaBuf),
+    )
+}
+
+fn decoded_object(bytes: &[u8]) -> Object {
+    let (remaining, value) =
+        PodDeserializer::deserialize_any_from(bytes).expect("test pod should deserialize");
+    assert!(
+        remaining.is_empty(),
+        "test pod should have no trailing bytes"
+    );
+    let object = match value {
+        Value::Object(object) => Some(object),
+        _ => None,
+    };
+    object.expect("expected an object pod")
+}
+
+fn property(object: &Object, key: u32) -> &Value {
+    object
+        .properties
+        .iter()
+        .find(|property| property.key == key)
+        .map(|property| &property.value)
+        .expect("expected buffer property")
+}
+
+fn filter_pods(pod_bytes: &[u8], filter_bytes: &[u8]) -> Result<Vec<u8>, i32> {
+    let pod_storage = AlignedBytes::<POD_STORAGE_SIZE>::from_bytes(pod_bytes);
+    let filter_storage = AlignedBytes::<POD_STORAGE_SIZE>::from_bytes(filter_bytes);
+    let pod = pod_storage.pod();
+    let filter = filter_storage.pod();
+    let mut output = AlignedBytes::<FILTER_STORAGE_SIZE>([0; FILTER_STORAGE_SIZE]);
+    let mut builder = MaybeUninit::<spa::sys::spa_pod_builder>::uninit();
+    let mut result = ptr::null_mut();
+
+    // SAFETY: the builder and all pods point into live, 8-byte-aligned storage. The
+    // storage remains pinned for the entire call, and the output is large enough for
+    // the small object pods used by these tests.
+    let result_bytes = unsafe {
+        spa::sys::spa_pod_builder_init(
+            builder.as_mut_ptr(),
+            output.0.as_mut_ptr().cast(),
+            FILTER_STORAGE_SIZE as u32,
+        );
+        let status = spa::sys::spa_pod_filter(
+            builder.as_mut_ptr(),
+            &mut result,
+            pod.as_raw_ptr(),
+            filter.as_raw_ptr(),
+        );
+        if status < 0 {
+            return Err(status);
+        }
+        if result.is_null() {
+            return Err(-libc::EINVAL);
+        }
+        Pod::from_raw(result.cast_const()).as_bytes().to_vec()
+    };
+
+    Ok(result_bytes)
+}
+
+#[test]
+fn requests_a_pipewire_compatible_buffer_layout() {
+    let bytes = buffer_parameter(negotiated(NativePixelFormat::Bgra, 1920, 1080))
+        .expect("buffer parameter should serialize");
+    let object = decoded_object(&bytes);
+    let memory_mask = (1_i32 << spa::sys::SPA_DATA_MemPtr) | (1_i32 << spa::sys::SPA_DATA_MemFd);
+
+    assert_eq!(object.type_, SpaTypes::ObjectParamBuffers.as_raw());
+    assert_eq!(object.id, ParamType::Buffers.as_raw());
+    assert_eq!(
+        property(&object, spa::sys::SPA_PARAM_BUFFERS_buffers),
+        &choice_range(8, 2, 8)
+    );
+    assert_eq!(
+        property(&object, spa::sys::SPA_PARAM_BUFFERS_blocks),
+        &Value::Int(1)
+    );
+    assert_eq!(
+        property(&object, spa::sys::SPA_PARAM_BUFFERS_size),
+        &Value::Int(1920 * 1080 * 4)
+    );
+    assert_eq!(
+        property(&object, spa::sys::SPA_PARAM_BUFFERS_stride),
+        &Value::Int(1920 * 4)
+    );
+    assert_eq!(
+        property(&object, spa::sys::SPA_PARAM_BUFFERS_dataType),
+        &Value::Int(memory_mask)
+    );
+}
+
+#[test]
+fn intersects_kwin_buffer_range_and_memfd_choice() {
+    let beam = buffer_parameter(negotiated(NativePixelFormat::Bgra, 1920, 1080))
+        .expect("buffer parameter should serialize");
+    let result = filter_pods(&beam, &kwin_buffers_pod()).expect("KWin layout should intersect");
+    let object = decoded_object(&result);
+
+    assert_eq!(
+        property(&object, spa::sys::SPA_PARAM_BUFFERS_buffers),
+        &choice_range(3, 2, 4)
+    );
+    assert_eq!(
+        property(&object, spa::sys::SPA_PARAM_BUFFERS_dataType),
+        &choice_flags(1_i32 << spa::sys::SPA_DATA_MemFd)
+    );
+}
+
+#[test]
+fn rejects_the_old_fixed_count_but_accepts_a_fixed_eight_buffer_peer() {
+    let kwin = kwin_buffers_pod();
+    let old = buffers_pod(
+        Value::Int(8),
+        Value::Int((1_i32 << spa::sys::SPA_DATA_MemPtr) | (1_i32 << spa::sys::SPA_DATA_MemFd)),
+    );
+    assert_eq!(filter_pods(&old, &kwin), Err(-libc::EINVAL));
+
+    let beam = buffer_parameter(negotiated(NativePixelFormat::Bgra, 1920, 1080))
+        .expect("buffer parameter should serialize");
+    assert!(filter_pods(&beam, &fixed_buffers_pod(8)).is_ok());
+}
+
+#[test]
+fn rejects_buffer_counts_outside_the_supported_range_and_dma_only_memory() {
+    let beam = buffer_parameter(negotiated(NativePixelFormat::Bgra, 1920, 1080))
+        .expect("buffer parameter should serialize");
+    for count in [1, 9] {
+        assert!(
+            filter_pods(&beam, &fixed_buffers_pod(count)).is_err(),
+            "buffer count {count} must not intersect Beam's 2..=8 range"
+        );
+    }
+    assert!(filter_pods(&beam, &dma_only_buffers_pod()).is_err());
+}
+
+#[test]
+fn reports_stride_and_buffer_size_overflows() {
+    let stride_overflow = NegotiatedFormat {
+        width: u32::MAX,
+        height: 1,
+        pixel_format: NativePixelFormat::Bgra,
+    };
+    let size_overflow = NegotiatedFormat {
+        width: 1_000_000,
+        height: 1_000,
+        pixel_format: NativePixelFormat::Bgra,
+    };
+
+    assert!(
+        buffer_parameter(stride_overflow)
+            .expect_err("stride should overflow")
+            .to_string()
+            .contains("negotiated stride overflows")
+    );
+    assert!(
+        buffer_parameter(size_overflow)
+            .expect_err("buffer size should overflow")
+            .to_string()
+            .contains("negotiated buffer size overflows")
+    );
+}

--- a/packages/capture/src/screen/linux/pipewire/tests/buffer_params_tests.rs
+++ b/packages/capture/src/screen/linux/pipewire/tests/buffer_params_tests.rs
@@ -189,10 +189,18 @@ fn intersects_kwin_buffer_range_and_memfd_choice() {
     let result = filter_pods(&beam, &kwin_buffers_pod()).expect("KWin layout should intersect");
     let object = decoded_object(&result);
 
-    assert_eq!(
-        property(&object, spa::sys::SPA_PARAM_BUFFERS_buffers),
-        &choice_range(3, 2, 4)
-    );
+    let range = match property(&object, spa::sys::SPA_PARAM_BUFFERS_buffers) {
+        Value::Choice(ChoiceValue::Int(Choice(flags, ChoiceEnum::Range { default, min, max }))) => {
+            Some((flags, default, min, max))
+        }
+        _ => None,
+    };
+    let (flags, default, min, max) = range.expect("expected a negotiated buffer count range");
+    assert!(flags.is_empty());
+    assert_eq!((*min, *max), (2, 4));
+    // SPA versions may retain the producer's preference or clamp ours to the
+    // intersection. Both are valid as long as the default is inside that range.
+    assert!((*min..=*max).contains(default));
     assert_eq!(
         property(&object, spa::sys::SPA_PARAM_BUFFERS_dataType),
         &choice_flags(1_i32 << spa::sys::SPA_DATA_MemFd)


### PR DESCRIPTION
Beam requested exactly eight PipeWire buffers, while KWin offers a range of two to four. These constraints cannot intersect, reproducing the `Invalid argument (-22)` allocation failure reported in #73.

Negotiate a buffer-count range of 2–8, retaining eight as the preferred count and upper bound. Keep the existing MemPtr/MemFd memory types and buffer layout. Extract buffer parameter serialization so regression tests exercise the actual emitted parameters through SPA’s filter.

Validation:
- `cargo test -p capture --all-features --lib screen::linux::pipewire::` — 45 tests passed, including five new buffer negotiation regressions.
- The negotiated range must remain 2–4; its preferred count may vary within that range across SPA versions (including 3 locally and 4 in CI).
- `cargo clippy -p capture --all-features --lib --tests -- -D warnings` — passed.
- `cargo fmt -p capture -- --check` and `git diff --check` — passed.

The regression tests cover KWin’s range and MemFd mask, rejection of the previous fixed count, compatibility with an eight-buffer producer, incompatible counts and DMA-BUF-only memory, and size/stride overflow. End-to-end recording still needs validation on the reporter’s NVIDIA/KDE Wayland machine.

Fixes #73.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux screen-capture compatibility by allowing PipeWire to negotiate buffer counts between 2 and 8.
  * Improved compatibility with supported peer buffer ranges and memory types while rejecting unsupported configurations.
  * Added validation for invalid buffer counts and buffer-size or stride overflow conditions.

* **Tests**
  * Added coverage for PipeWire buffer negotiation, memory-type compatibility, filtering unsupported configurations, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->